### PR TITLE
reel.exp changes to enable matching on EOF

### DIFF
--- a/bin/reel.exp
+++ b/bin/reel.exp
@@ -39,13 +39,18 @@ array set ctrl [parse_argv $argv]
 package require json
 
 proc step_decode { str } {
+    set CTRL_D [format %c 4]
     array set step {timeout -1}
     foreach {key val} [json::json2dict $str] {
         switch $key {
             expect {
                 for { set idx 0 } { $idx < [llength $val] } { incr idx } {
                     set exp [lindex $val $idx]
-                    lappend step(expect) -re "^.*($exp)" [list matched $idx $exp]
+                    if { $CTRL_D != $exp } {
+                        lappend step(expect) -re "^.*($exp)" [list matched $idx $exp]
+                    } elseif { ![info exists step(expect)] } {
+                        array set step {expect {}}
+                    }
                 }
             }
             execute -


### PR DESCRIPTION
David made these changes as a part of a separate branch.  Through
further development of Kiknos CNF Specific Testing using the tnf
library, it became apparent that I need these changes earlier in order
to support the commands I run as a part of that test suite.  For
example, "itc create", "itc ping" and "itc senddata" emit no output
to Stdout.

Since these changes are completely separte from my updates to the CNF
specific test cases, they should be done in a separate commit.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>