### PR TITLE
CNF Certification GoLang code should be formatted appropriately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ export GO111MODULE=on
 export COMMON_GINKGO_ARGS="-ginkgo.v -junit . -report ."
 
 build:
+	go fmt ./...
 	go build ./...
 
 generic-cnf-tests: build build-cnf-tests run-generic-cnf-tests

--- a/test-network-function/cnf-specific/cisco/kiknos/cisco_kiknos_cnf_specific_tests.go
+++ b/test-network-function/cnf-specific/cisco/kiknos/cisco_kiknos_cnf_specific_tests.go
@@ -91,7 +91,6 @@ func verifyICMPTraffic(partnerPodName string, partnerPodContainerName string, pa
 	gomega.Expect(icmpCountDiff).To(gomega.Equal(numPings))
 }
 
-
 // Create an IPSEC tunnel and verify it was successfully established.
 func createAndVerifyTunnel(partnerPodName string, partnerPodContainerName string, partnerPodNamespace string) int {
 	var newTunnelIndex int

--- a/test-network-function/configuration/configuration.go
+++ b/test-network-function/configuration/configuration.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	configurationFilePathEnvironmentVariableKey = "TEST_CONFIGURATION_PATH"
-	defaultConfigurationFilePath = "./test-configuration.yaml"
+	defaultConfigurationFilePath                = "./test-configuration.yaml"
 )
 
 func GetConfigurationFilePathFromEnvironment() string {

--- a/test-network-function/generic/generic_cnf_tests.go
+++ b/test-network-function/generic/generic_cnf_tests.go
@@ -13,10 +13,10 @@ import (
 )
 
 const (
-	defaultNumPings = 10
-	defaultTnfTimeout = 20
-	GenericTestsKey = "generic"
-	MultusTestsKey = "multus"
+	defaultNumPings            = 10
+	defaultTnfTimeout          = 20
+	GenericTestsKey            = "generic"
+	MultusTestsKey             = "multus"
 	openshiftNamespaceArgument = "-n"
 )
 

--- a/test-network-function/test_suite_test.go
+++ b/test-network-function/test_suite_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 const (
-	defaultCliArgValue = ""
+	defaultCliArgValue            = ""
 	CnfCertificationTestSuiteName = "CNF Certification Test Suite"
-	junitFlagKey = "junit"
-	JunitXmlFileName = "cnf-certification-tests_junit.xml"
-	reportFlagKey = "report"
+	junitFlagKey                  = "junit"
+	JunitXmlFileName              = "cnf-certification-tests_junit.xml"
+	reportFlagKey                 = "report"
 )
 
 var junitPath *string


### PR DESCRIPTION
The GoLang specification is exacting in terms of its code formatting and
stylistic guidelines.  Whether one loves or hates this dictum, it should be
obeyed in order to promote hygienic GoLang code which adheres to the language
specification.

This change includes a change to the Makefile which automates GoLang code
formatting across the project at build time using the "gofmt" tool.
Additionally, this change includes an initial run of the "gofmt" tool, which
fixes existing formatting errors in the project.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>
Issue-Id: CTONET-508