### PR TITLE
Utilize race condition static analysis tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,11 @@
 export GO111MODULE=on
 
 export COMMON_GINKGO_ARGS="-ginkgo.v -junit . -report ."
+export COMMON_GO_ARGS="-race"
 
 build:
 	go fmt ./...
-	go build ./...
+	go build ${COMMON_GO_ARGS} ./...
 
 generic-cnf-tests: build build-cnf-tests run-generic-cnf-tests
 


### PR DESCRIPTION
Utilize race condition static analysis tools at compile time.  The overhead
cost to running such tools is minimal (seconds), and allows us to be more
confident as we introduce goroutines.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>
Issue-Id: CTONET-509