### PR TITLE
Implement GoLang Linter to increase code quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 test-network-function_junit.xml
 cover.out
 test-network-function/cnf-certification-tests_junit.xml
+cnf-certification-tests_junit.xml

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 	cnf-tests \
 	deps-update \
 	generic-cnf-tests \
+	lint \
 	mocks \
 	run-cnf-tests \
 	run-generic-cnf-tests \
@@ -15,9 +16,10 @@ export GO111MODULE=on
 export COMMON_GINKGO_ARGS=-ginkgo.v -junit . -report .
 export COMMON_GO_ARGS=-race
 
-build:
+build: lint
 	go fmt ./...
 	go build ${COMMON_GO_ARGS} ./...
+	make unit-tests
 
 generic-cnf-tests: build build-cnf-tests run-generic-cnf-tests
 
@@ -43,6 +45,9 @@ mocks:
 
 unit-tests:
 	go test -coverprofile=cover.out `go list ./... | grep -v "github.com/redhat-nfvpe/test-network-function/test-network-function" | grep -v mock` && go tool cover -html=cover.out
+
+lint:
+	golint `go list ./... | grep -v vendor`
 
 .PHONY: clean
 clean:

--- a/cmd/oc/doc.go
+++ b/cmd/oc/doc.go
@@ -1,3 +1,2 @@
 // Package main provides an example of spawning an OpenShift client and using it to ping a target IP address.
-
 package main

--- a/cmd/oc/main.go
+++ b/cmd/oc/main.go
@@ -39,7 +39,7 @@ func parseArgs() (*interactive.Oc, <-chan error, string, time.Duration, error) {
 // Alternatively, read each input line as a JSON test configuration to execute.
 func main() {
 	result := tnf.ERROR
-	oc, ch, targetIpAddress, timeoutDuration, err := parseArgs()
+	oc, ch, targetIPAddress, timeoutDuration, err := parseArgs()
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -47,7 +47,7 @@ func main() {
 	}
 
 	printer := reel.NewPrinter(" \r\n")
-	request := ping.NewPing(timeoutDuration, targetIpAddress, 5)
+	request := ping.NewPing(timeoutDuration, targetIPAddress, 5)
 	chain := []reel.Handler{printer, request}
 	test, err := tnf.NewTest(oc.GetExpecter(), request, chain, ch)
 

--- a/cmd/ping/doc.go
+++ b/cmd/ping/doc.go
@@ -1,3 +1,2 @@
 // Package main provides an example of pinging a target IP address.
-
 package main

--- a/cmd/ssh/main.go
+++ b/cmd/ssh/main.go
@@ -28,7 +28,7 @@ func parseArgs() (*interactive.Context, string, time.Duration, error) {
 	timeoutDuration := time.Duration(*timeout) * time.Second
 	goExpectSpawner := interactive.NewGoExpectSpawner()
 	var spawner interactive.Spawner = goExpectSpawner
-	context, err := interactive.SpawnSsh(&spawner, args[0], args[1], time.Duration(10), expect.Verbose(true))
+	context, err := interactive.SpawnSSH(&spawner, args[0], args[1], time.Duration(10), expect.Verbose(true))
 	return context, args[2], timeoutDuration, err
 }
 
@@ -36,7 +36,7 @@ func parseArgs() (*interactive.Context, string, time.Duration, error) {
 // Execute a ping to the target IP address and print interaction with the controlled subprocess.
 func main() {
 	result := tnf.ERROR
-	context, targetIpAddress, timeoutDuration, err := parseArgs()
+	context, targetIPAddress, timeoutDuration, err := parseArgs()
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	printer := reel.NewPrinter(" \r\n")
-	request := ping.NewPing(timeoutDuration, targetIpAddress, 5)
+	request := ping.NewPing(timeoutDuration, targetIPAddress, 5)
 	chain := []reel.Handler{printer, request}
 	test, err := tnf.NewTest(context.GetExpecter(), request, chain, context.GetErrorChannel())
 

--- a/internal/itc/client.go
+++ b/internal/itc/client.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	// Return value when there is an error calculating the number of tunnels
-	DefaultNumTunnels = -1
-	// Return value when there is an error calculating the number of packets
-	DefaultPacketCount         = -1
+	// ErrorNumTunnels is the value returned when there is an error calculating the number of tunnels.
+	ErrorNumTunnels = -1
+	// ErrorPacketCount is the return value when there is an error calculating the number of desired packets.
+	ErrorPacketCount           = -1
 	itcCommand                 = "itc"
 	itcCreateCommand           = "create"
 	itcIcmpRepliesRecieved     = `ESPRawPacketsReceivedICMPReplyPayloadReceived`
@@ -25,7 +25,7 @@ const (
 	udpReceivedCount           = `ESPRawPacketsReceivedUDP`
 )
 
-// Creates IPSEC tunnels through wrapping "itc" (ike-testctl alias) on the remote container.
+// Create creates IPSEC tunnels through wrapping "itc" (ike-testctl alias) on the remote container.
 func Create(pod string, container string, namespace string, numTunnels, messagesPerSecond int) error {
 	remoteCommand := []string{itcCommand, itcCreateCommand, strconv.Itoa(numTunnels), strconv.Itoa(messagesPerSecond)}
 	// Ignore stdout, since "itc create" has no output.
@@ -54,20 +54,20 @@ func parseItcSummaryOutput(output string) (int, int, error) {
 		numCreatedTunnels := countTunnelMatches(output, itcIkeTunnelConnectedRegex)
 		return numInstantiatedTunnels, numCreatedTunnels, nil
 	}
-	return DefaultNumTunnels, DefaultNumTunnels, errors.New("itc ike command failed")
+	return ErrorNumTunnels, ErrorNumTunnels, errors.New("itc ike command failed")
 }
 
-// Extracts the number of instantiated tunnels and the number of successfully connected tunnels.
+// IkeSummary extracts the number of instantiated tunnels and the number of successfully connected tunnels.
 func IkeSummary(pod string, container string, namespace string) (int, int, error) {
 	remoteCommand := []string{itcCommand, itcIkeCommand}
 	stdout, err := oc.InvokeOCCommand(pod, container, namespace, remoteCommand)
 	if err != nil {
-		return DefaultNumTunnels, DefaultNumTunnels, err
+		return ErrorNumTunnels, ErrorNumTunnels, err
 	}
 	return parseItcSummaryOutput(stdout)
 }
 
-// Extracts the result of running "itc summary" on a remote container.
+// Summary extracts the result of running "itc summary" on a remote container.
 func Summary(pod string, container string, namespace string) (string, error) {
 	remoteCommand := []string{itcCommand, itcSummaryCommand}
 	return oc.InvokeOCCommand(pod, container, namespace, remoteCommand)
@@ -78,39 +78,39 @@ func getPacketTypeRegex(packetType string) string {
 	return `(?m)^\s+` + packetType + `\:\s+(\d+).*`
 }
 
-// Extracts packet count for a particular type from "itc summary".
+// GetPacketCount extracts packet count for a particular type from "itc summary".
 func GetPacketCount(pod string, container string, namespace string, packetType string) (int, error) {
 	packetTypeRegex := getPacketTypeRegex(packetType)
 	re := regexp.MustCompile(packetTypeRegex)
 	summary, err := Summary(pod, container, namespace)
 	if err != nil {
-		return DefaultPacketCount, err
+		return ErrorPacketCount, err
 	}
 	match := re.FindStringSubmatch(summary)
 	if match == nil || len(match) <= 1 {
-		return DefaultPacketCount, errors.New("couldn't find a match for " + packetType)
+		return ErrorPacketCount, errors.New("couldn't find a match for " + packetType)
 	}
 	return strconv.Atoi(match[1])
 }
 
-// Extracts ICMP Reply count.
+// GetItcIcmpReplyCount extracts ICMP Reply count.
 func GetItcIcmpReplyCount(pod string, container string, namespace string) (int, error) {
 	return GetPacketCount(pod, container, namespace, itcIcmpRepliesRecieved)
 }
 
-// Extracts the number of UDP replies received.
-func GetUdpReceivedCount(pod string, container string, namespace string) (int, error) {
+// GetUDPReceivedCount extracts the number of UDP replies received.
+func GetUDPReceivedCount(pod string, container string, namespace string) (int, error) {
 	return GetPacketCount(pod, container, namespace, udpReceivedCount)
 }
 
-// A wrapper for "itc ping".
+// Ping is a wrapper for "itc ping".
 func Ping(pod string, container string, namespace string, tunnelIndex int, targetAddress string, messagesPerSecond int, packetCount int, dataLength int) (string, error) {
 	remoteCommand := []string{itcCommand, itcPingCommand, strconv.Itoa(tunnelIndex), targetAddress,
 		strconv.Itoa(messagesPerSecond), strconv.Itoa(packetCount), strconv.Itoa(dataLength)}
 	return oc.InvokeOCCommand(pod, container, namespace, remoteCommand)
 }
 
-// A wrapper for "itc senddata".
+// SendData is a wrapper for "itc senddata".
 func SendData(pod string, container string, namespace string, tunnelIndex int, messagesPerSecond int, packetCount int, dataLength int) (string, error) {
 	remoteCommand := []string{itcCommand, itcSendDataCommand, strconv.Itoa(tunnelIndex),
 		strconv.Itoa(messagesPerSecond), strconv.Itoa(packetCount), strconv.Itoa(dataLength)}

--- a/internal/itc/doc.go
+++ b/internal/itc/doc.go
@@ -1,3 +1,2 @@
 // Package itc provides a GoLang wrapper over the ike-testctl command line tool.
-
 package itc

--- a/internal/oc/client.go
+++ b/internal/oc/client.go
@@ -10,7 +10,7 @@ const (
 	ocNamespaceArg            = "-n"
 )
 
-// Lightweight wrapper client around oc client.
+// InvokeOCCommand is a lightweight wrapper client around oc client.
 func InvokeOCCommand(pod string, container string, namespace string, command []string) (string, error) {
 	invokeCommandArgs := []string{ocExecCommand, pod, ocExecContainerArg, container}
 	if namespace != "" {

--- a/internal/oc/doc.go
+++ b/internal/oc/doc.go
@@ -1,3 +1,2 @@
 // Package oc provides a lightweight GoLang wrapper around the OpenShift "oc" command line interface.
-
 package oc

--- a/internal/reel/doc.go
+++ b/internal/reel/doc.go
@@ -1,0 +1,3 @@
+// Package reel runs a target subprocess with programmatic control over interaction with it.  Programmatic control uses
+// a Read-Execute-Expect-Loop ("REEL") pattern.
+package reel

--- a/internal/reel/mocks/mock_reel.go
+++ b/internal/reel/mocks/mock_reel.go
@@ -75,14 +75,14 @@ func (mr *MockHandlerMockRecorder) ReelTimeout() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReelTimeout", reflect.TypeOf((*MockHandler)(nil).ReelTimeout))
 }
 
-// ReelEof mocks base method
-func (m *MockHandler) ReelEof() {
+// ReelEOF mocks base method
+func (m *MockHandler) ReelEOF() {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReelEof")
+	m.ctrl.Call(m, "ReelEOF")
 }
 
 // ReelEof indicates an expected call of ReelEof
 func (mr *MockHandlerMockRecorder) ReelEof() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReelEof", reflect.TypeOf((*MockHandler)(nil).ReelEof))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReelEOF", reflect.TypeOf((*MockHandler)(nil).ReelEOF))
 }

--- a/internal/reel/printer.go
+++ b/internal/reel/printer.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// A handler printing event interaction.
+// Printer provides handler printing event interaction.
 // A printer is only used for the side effect of printing: it never feeds steps.
 // `trimr` specifies a string used in filtering out text appearing before a
 // match string. (When that text is empty after being right-trimmed using
@@ -14,14 +14,13 @@ type Printer struct {
 	trimr string
 }
 
-// Returns no step; a printer does not feed steps.
+// ReelFirst Returns no step; a printer does not feed steps.
 func (p *Printer) ReelFirst() *Step {
 	return nil
 }
 
-// On match, print `before` and `match` strings, unless `before` is empty when
-// right-trimmed using the printer's `trimr` string, in which case only print
-// `match`.
+// ReelMatch is called when a pattern matches, and prints `before` and `match` strings, unless `before` is empty when
+// right-trimmed using the printer's `trimr` string, in which case only print `match`.
 // Returns no step; a printer does not feed steps.
 func (p *Printer) ReelMatch(pattern string, before string, match string) *Step {
 	if strings.TrimRight(before, p.trimr) == "" {
@@ -32,19 +31,19 @@ func (p *Printer) ReelMatch(pattern string, before string, match string) *Step {
 	return nil
 }
 
-// On timeout, print timeout.
+// ReelTimeout prints timeout messaging to the log on timeout.
 // Returns no step; a printer does not feed steps.
 func (p *Printer) ReelTimeout() *Step {
 	fmt.Println("(timeout)")
 	return nil
 }
 
-// On eof, print eof.
-func (p *Printer) ReelEof() {
+// ReelEOF prints eof messaging to the log on eof.
+func (p *Printer) ReelEOF() {
 	fmt.Println("(eof)")
 }
 
-// Create a new `Printer` using `trimr` to filter output text before a match.
+// NewPrinter create a new Printer using `trimr` to filter output text before a match.
 func NewPrinter(trimr string) *Printer {
 	return &Printer{
 		trimr: trimr,

--- a/internal/reel/reel.go
+++ b/internal/reel/reel.go
@@ -1,5 +1,3 @@
-// Run a target subprocess with programmatic control over interaction with it.
-// Programmatic control uses a Read-Execute-Expect-Loop ("REEL") pattern.
 package reel
 
 import (
@@ -11,12 +9,11 @@ import (
 )
 
 const (
-	CtrlC   = "\003" // ^C
-	newLine = "\n"
-	sep     = " "
+	// CtrlC is the constant representing SIGINT.
+	CtrlC = "\003" // ^C
 )
 
-// A Step is an instruction for a single REEL pass.
+// Step is an instruction for a single REEL pass.
 // To process a step, first send the `Execute` string to the target subprocess (if supplied).  Block until the
 // subprocess output to stdout matches one of the regular expressions in `Expect` (if any supplied). A positive integer
 // `Timeout` (seconds) prevents blocking forever.
@@ -52,10 +49,11 @@ type Handler interface {
 	// ReelTimeout informs of a timeout event, returning the next step to perform.
 	ReelTimeout() *Step
 
-	// ReelEof informs of the eof event.
-	ReelEof()
+	// ReelEOF informs of the eof event.
+	ReelEOF()
 }
 
+// StepFunc provides a wrapper around a generic Handler.
 type StepFunc func(Handler) *Step
 
 // A Reel instance allows interaction with a target subprocess.
@@ -118,7 +116,7 @@ func isTimeout(err error) bool {
 	return ok
 }
 
-// Perform `step`, then, in response to events, consequent steps fed by `handler`.
+// Step performs `step`, then, in response to events, consequent steps fed by `handler`.
 // Return on first error, or when there is no next step to perform.
 func (reel *Reel) Step(step *Step, handler Handler) error {
 	for step != nil {
@@ -170,17 +168,17 @@ func (reel *Reel) Run(handler Handler) error {
 
 // Appends a new line to a command, if necessary.
 func createExecutableCommand(command string) string {
-	if !strings.HasSuffix(command, newLine) {
-		return command + newLine
+	if !strings.HasSuffix(command, "\n") {
+		return command + "\n"
 	}
 	return command
 }
 
-// Create a new `Reel` instance for interacting with a target subprocess.  The command line for the target is specified
-// by the args parameter.
+// NewReel create a new `Reel` instance for interacting with a target subprocess.  The command line for the target is
+// specified by the args parameter.
 func NewReel(expecter *expect.Expecter, args []string, errorChannel <-chan error) (*Reel, error) {
 	if len(args) > 0 {
-		command := createExecutableCommand(strings.Join(args, sep))
+		command := createExecutableCommand(strings.Join(args, " "))
 		err := (*expecter).Send(command)
 		if err != nil {
 			return nil, err

--- a/internal/subprocess/subprocess.go
+++ b/internal/subprocess/subprocess.go
@@ -4,7 +4,8 @@ import (
 	"os/exec"
 )
 
-// Lightweight wrapper around command subprocess which waits for the underlying process to complete prior to returning.
+// InvokeCommand is a lightweight wrapper around command subprocess which waits for the underlying process to complete
+// prior to returning.
 func InvokeCommand(executable string, args []string) (string, error) {
 	cmd := exec.Command(executable, args...)
 	stdout, err := cmd.Output()

--- a/pkg/tnf/handlers/base/redhat/version.go
+++ b/pkg/tnf/handlers/base/redhat/version.go
@@ -74,8 +74,8 @@ func (r *Release) ReelTimeout() *reel.Step {
 	return nil
 }
 
-// ReelEof does nothing;  no intervention is needed for EOF.
-func (r *Release) ReelEof() {
+// ReelEOF does nothing;  no intervention is needed for EOF.
+func (r *Release) ReelEOF() {
 }
 
 // NewRelease create a new Release tnf.Test.

--- a/pkg/tnf/handlers/base/redhat/version_test.go
+++ b/pkg/tnf/handlers/base/redhat/version_test.go
@@ -59,5 +59,5 @@ func TestRelease_ReelTimeout(t *testing.T) {
 func TestRelease_ReelEof(t *testing.T) {
 	// just ensures no panics
 	r := redhat.NewRelease(testTimeoutDuration)
-	r.ReelEof()
+	r.ReelEOF()
 }

--- a/pkg/tnf/handlers/doc.go
+++ b/pkg/tnf/handlers/doc.go
@@ -1,3 +1,2 @@
 // Package handlers provides a variety of Test Handler implementations.
-
 package handlers

--- a/pkg/tnf/handlers/hostname/doc.go
+++ b/pkg/tnf/handlers/hostname/doc.go
@@ -1,3 +1,2 @@
 // Package hostname provides a hostname discovery test utilizing the `hostname` Unix command.
-
 package hostname

--- a/pkg/tnf/handlers/hostname/hostname.go
+++ b/pkg/tnf/handlers/hostname/hostname.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// A hostname test implemented using command line tool "hostname".
+// Hostname provides a hostname test implemented using command line tool "hostname".
 type Hostname struct {
 	result  int
 	timeout time.Duration
@@ -16,27 +16,28 @@ type Hostname struct {
 }
 
 const (
+	// Command is the command name for the unix "hostname" command.
 	Command = "hostname"
-	// Anything other than the empty string is considered good output.
+	// SuccessfulOutputRegex is the regular expression match for hostname output.
 	SuccessfulOutputRegex = `.+`
 )
 
-// Return the command line args for the test.
+// Args returns the command line args for the test.
 func (h *Hostname) Args() []string {
 	return h.args
 }
 
-// Return the timeout in seconds for the test.
+// Timeout return the timeout for the test.
 func (h *Hostname) Timeout() time.Duration {
 	return h.timeout
 }
 
-// Return the test result.
+// Result returns the test result.
 func (h *Hostname) Result() int {
 	return h.result
 }
 
-// Return a step which expects an ip summary for the given device.
+// ReelFirst returns a step which expects an hostname summary for the given device.
 func (h *Hostname) ReelFirst() *reel.Step {
 	return &reel.Step{
 		Expect:  []string{SuccessfulOutputRegex},
@@ -44,7 +45,7 @@ func (h *Hostname) ReelFirst() *reel.Step {
 	}
 }
 
-// On match, parse the hostname output and set the test result.
+// ReelMatch parses the hostname output and set the test result on match.
 // Returns no step; the test is complete.
 func (h *Hostname) ReelMatch(_ string, _ string, match string) *reel.Step {
 	h.hostname = match
@@ -52,22 +53,21 @@ func (h *Hostname) ReelMatch(_ string, _ string, match string) *reel.Step {
 	return nil
 }
 
-// On timeout, return a step which kills the ping test by sending it ^C.
+// ReelTimeout does nothing;  hostname requires no explicit intervention for a timeout.
 func (h *Hostname) ReelTimeout() *reel.Step {
 	return nil
 }
 
-// On eof, take no action.
-func (h *Hostname) ReelEof() {
+// ReelEOF does nothing;  hostname requires no explicit intervention for EOF.
+func (h *Hostname) ReelEOF() {
 }
 
+// GetHostname returns the extracted hostname, if one is extracted.
 func (h *Hostname) GetHostname() string {
 	return h.hostname
 }
 
-// Create a new `Ping` test which pings `hosts` with `count` requests, or
-// indefinitely if `count` is not positive, and executes within `timeout`
-// seconds.
+// NewHostname creates a new `Hostname` test which runs the "hostname" command.
 func NewHostname(timeout time.Duration) *Hostname {
 	return &Hostname{
 		result:  tnf.ERROR,

--- a/pkg/tnf/handlers/hostname/hostname_test.go
+++ b/pkg/tnf/handlers/hostname/hostname_test.go
@@ -28,7 +28,7 @@ func TestHostname_ReelFirst(t *testing.T) {
 func TestHostname_ReelEof(t *testing.T) {
 	h := hostname.NewHostname(testTimeoutDuration)
 	// just ensures lack of panic
-	h.ReelEof()
+	h.ReelEOF()
 }
 
 func TestHostname_ReelTimeout(t *testing.T) {

--- a/pkg/tnf/handlers/ipaddr/doc.go
+++ b/pkg/tnf/handlers/ipaddr/doc.go
@@ -1,3 +1,2 @@
 // Package ipaddr provides an ip address polling test utilizing the `ip` Unix command.
-
 package ipaddr

--- a/pkg/tnf/handlers/ipaddr/ipaddr.go
+++ b/pkg/tnf/handlers/ipaddr/ipaddr.go
@@ -9,8 +9,8 @@ import (
 	"time"
 )
 
-// An ip addr test implemented using command line tool `ip`.
-type IpAddr struct {
+// IPAddr provides an ip addr test implemented using command line tool `ip addr`.
+type IPAddr struct {
 	result  int
 	timeout time.Duration
 	args    []string
@@ -19,37 +19,39 @@ type IpAddr struct {
 }
 
 const (
-	ipAddrCommand           = "ip addr show dev"
+	ipAddrCommand = "ip addr show dev"
+	// DeviceDoesNotExistRegex matches `ip addr` output when the given device does not exist.
 	DeviceDoesNotExistRegex = `(?m)Device \"(\w+)\" does not exist.$`
-	SuccessfulOutputRegex   = `(?m)^\s+inet ((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))`
+	// SuccessfulOutputRegex matches `ip addr` output for a given device, and provides grouping to extract the associated Ipv4 address.
+	SuccessfulOutputRegex = `(?m)^\s+inet ((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))`
 )
 
-// Return the command line args for the test.
-func (i *IpAddr) Args() []string {
+// Args returns the command line args for the test.
+func (i *IPAddr) Args() []string {
 	return i.args
 }
 
-// Return the timeout in seconds for the test.
-func (i *IpAddr) Timeout() time.Duration {
+// Timeout return the timeout for the test.
+func (i *IPAddr) Timeout() time.Duration {
 	return i.timeout
 }
 
-// Return the test result.
-func (i *IpAddr) Result() int {
+// Result returns the test result.
+func (i *IPAddr) Result() int {
 	return i.result
 }
 
-// Return a step which expects an ip summary for the given device.
-func (i *IpAddr) ReelFirst() *reel.Step {
+// ReelFirst returns a step which expects an ip summary for the given device.
+func (i *IPAddr) ReelFirst() *reel.Step {
 	return &reel.Step{
 		Expect:  []string{SuccessfulOutputRegex, DeviceDoesNotExistRegex},
 		Timeout: i.timeout,
 	}
 }
 
-// On match, parse the ip addr output and set the test result.
+// ReelMatch parses the ip addr output and set the test result on match.
 // Returns no step; the test is complete.
-func (i *IpAddr) ReelMatch(pattern string, _ string, match string) *reel.Step {
+func (i *IPAddr) ReelMatch(pattern string, _ string, match string) *reel.Step {
 	if pattern == DeviceDoesNotExistRegex {
 		i.result = tnf.ERROR
 		return nil
@@ -63,16 +65,17 @@ func (i *IpAddr) ReelMatch(pattern string, _ string, match string) *reel.Step {
 	return nil
 }
 
-// On timeout, return a step which kills the ping test by sending it ^C.
-func (i *IpAddr) ReelTimeout() *reel.Step {
+// ReelTimeout does nothing;  no intervention is needed for `ip addr` timeout.
+func (i *IPAddr) ReelTimeout() *reel.Step {
 	return nil
 }
 
-// On eof, take no action.
-func (i *IpAddr) ReelEof() {
+// ReelEOF does nothing;  no intervention is needed for `ip addr` EOF.
+func (i *IPAddr) ReelEOF() {
 }
 
-func (i *IpAddr) GetIpv4Address() string {
+// GetIPv4Address returns the extracted IPv4 address for the given device (interface).
+func (i *IPAddr) GetIPv4Address() string {
 	return i.ipv4Address
 }
 
@@ -80,9 +83,7 @@ func ipAddrCmd(dev string) []string {
 	return strings.Split(fmt.Sprintf("%s %s", ipAddrCommand, dev), " ")
 }
 
-// Create a new `Ping` test which pings `hosts` with `count` requests, or
-// indefinitely if `count` is not positive, and executes within `timeout`
-// seconds.
-func NewIpAddr(timeout time.Duration, dev string) *IpAddr {
-	return &IpAddr{result: tnf.ERROR, timeout: timeout, args: ipAddrCmd(dev)}
+// NewIPAddr creates a new `ip addr` test for the given device.
+func NewIPAddr(timeout time.Duration, device string) *IPAddr {
+	return &IPAddr{result: tnf.ERROR, timeout: timeout, args: ipAddrCmd(device)}
 }

--- a/pkg/tnf/handlers/ipaddr/ipaddr_test.go
+++ b/pkg/tnf/handlers/ipaddr/ipaddr_test.go
@@ -52,7 +52,7 @@ func getMockOutput(t *testing.T, testName string) string {
 
 func TestNewIpAddr(t *testing.T) {
 	for _, testCase := range testCases {
-		ipAddr := ipaddr.NewIpAddr(testTimeoutDuration, testCase.device)
+		ipAddr := ipaddr.NewIPAddr(testTimeoutDuration, testCase.device)
 		assert.NotNil(t, ipAddr)
 		assert.Equal(t, tnf.ERROR, ipAddr.Result())
 		assert.Equal(t, []string{"ip", "addr", "show", "dev", testCase.device}, ipAddr.Args())
@@ -61,21 +61,21 @@ func TestNewIpAddr(t *testing.T) {
 
 func TestIpAddr_Args(t *testing.T) {
 	for _, testCase := range testCases {
-		ipAddr := ipaddr.NewIpAddr(testTimeoutDuration, testCase.device)
+		ipAddr := ipaddr.NewIPAddr(testTimeoutDuration, testCase.device)
 		assert.Equal(t, []string{"ip", "addr", "show", "dev", testCase.device}, ipAddr.Args())
 	}
 }
 
 func TestIpAddr_Timeout(t *testing.T) {
 	for _, testCase := range testCases {
-		ipAddr := ipaddr.NewIpAddr(testTimeoutDuration, testCase.device)
+		ipAddr := ipaddr.NewIPAddr(testTimeoutDuration, testCase.device)
 		assert.Equal(t, testTimeoutDuration, ipAddr.Timeout())
 	}
 }
 
 func TestIpAddr_ReelFirst(t *testing.T) {
 	for _, testCase := range testCases {
-		ipAddr := ipaddr.NewIpAddr(testTimeoutDuration, testCase.device)
+		ipAddr := ipaddr.NewIPAddr(testTimeoutDuration, testCase.device)
 		step := ipAddr.ReelFirst()
 		assert.Equal(t, "", step.Execute)
 		assert.Contains(t, step.Expect, ipaddr.SuccessfulOutputRegex)
@@ -85,7 +85,7 @@ func TestIpAddr_ReelFirst(t *testing.T) {
 
 func TestIpAddr_Result(t *testing.T) {
 	for testName, testCase := range testCases {
-		ipAddr := ipaddr.NewIpAddr(testTimeoutDuration, testCase.device)
+		ipAddr := ipaddr.NewIPAddr(testTimeoutDuration, testCase.device)
 		assert.Equal(t, tnf.ERROR, ipAddr.Result())
 		step := ipAddr.ReelMatch(testCase.pattern, "", getMockOutput(t, testName))
 		assert.Nil(t, step)
@@ -95,16 +95,16 @@ func TestIpAddr_Result(t *testing.T) {
 
 func TestIpAddr_GetIpv4Address(t *testing.T) {
 	for testName, testCase := range testCases {
-		ipAddr := ipaddr.NewIpAddr(testTimeoutDuration, testCase.device)
+		ipAddr := ipaddr.NewIPAddr(testTimeoutDuration, testCase.device)
 		step := ipAddr.ReelMatch(testCase.pattern, "", getMockOutput(t, testName))
 		assert.Nil(t, step)
-		assert.Equal(t, testCase.expectedIpv4Address, ipAddr.GetIpv4Address())
+		assert.Equal(t, testCase.expectedIpv4Address, ipAddr.GetIPv4Address())
 	}
 }
 
 func TestIpAddr_ReelTimeout(t *testing.T) {
 	for _, testCase := range testCases {
-		ipAddr := ipaddr.NewIpAddr(testTimeoutDuration, testCase.device)
+		ipAddr := ipaddr.NewIPAddr(testTimeoutDuration, testCase.device)
 		assert.Nil(t, ipAddr.ReelTimeout())
 	}
 }
@@ -112,7 +112,7 @@ func TestIpAddr_ReelTimeout(t *testing.T) {
 // Ensure there are no panics.
 func TestIpAddr_ReelEof(t *testing.T) {
 	for _, testCase := range testCases {
-		ipAddr := ipaddr.NewIpAddr(testTimeoutDuration, testCase.device)
-		ipAddr.ReelEof()
+		ipAddr := ipaddr.NewIPAddr(testTimeoutDuration, testCase.device)
+		ipAddr.ReelEOF()
 	}
 }

--- a/pkg/tnf/handlers/ping/doc.go
+++ b/pkg/tnf/handlers/ping/doc.go
@@ -1,3 +1,2 @@
 // Package ping provides a test ICMPv4 implementation using the `ping` Unix command.
-
 package ping

--- a/pkg/tnf/handlers/ping/ping_test.go
+++ b/pkg/tnf/handlers/ping/ping_test.go
@@ -93,7 +93,7 @@ func TestNewPing(t *testing.T) {
 	for _, testCase := range testCases {
 		request := ping.NewPing(testTimeoutDuration, testCase.host, testCase.count)
 		assert.NotNil(t, request)
-		args := ping.PingCmd(testCase.host, testCase.count)
+		args := ping.Command(testCase.host, testCase.count)
 		assert.Equal(t, args, request.Args())
 		assert.Equal(t, tnf.ERROR, request.Result())
 	}
@@ -164,15 +164,15 @@ func TestPing_Timeout(t *testing.T) {
 func TestPing_ReelEof(t *testing.T) {
 	for _, testCase := range testCases {
 		request := ping.NewPing(testTimeoutDuration, testCase.host, testCase.count)
-		request.ReelEof()
+		request.ReelEOF()
 	}
 }
 
 func TestPingCmd(t *testing.T) {
-	cmd := ping.PingCmd("192.168.1.1", 0)
+	cmd := ping.Command("192.168.1.1", 0)
 	assert.Equal(t, []string{"ping", "192.168.1.1"}, cmd)
-	cmd = ping.PingCmd("192.168.1.1", -1)
+	cmd = ping.Command("192.168.1.1", -1)
 	assert.Equal(t, []string{"ping", "192.168.1.1"}, cmd)
-	cmd = ping.PingCmd("192.168.1.1", 1)
+	cmd = ping.Command("192.168.1.1", 1)
 	assert.Equal(t, []string{"ping", "-c", "1", "192.168.1.1"}, cmd)
 }

--- a/pkg/tnf/interactive/doc.go
+++ b/pkg/tnf/interactive/doc.go
@@ -1,3 +1,2 @@
 // Package interactive provides common implementations of the expect.Expecter interface including oc, shell, and ssh.
-
 package interactive

--- a/pkg/tnf/interactive/oc.go
+++ b/pkg/tnf/interactive/oc.go
@@ -15,7 +15,7 @@ const (
 	ocInteractiveArg         = "-it"
 )
 
-// An OpenShift Client designed to wrap the "oc" CLI.
+// Oc provides an OpenShift Client designed to wrap the "oc" CLI.
 type Oc struct {
 	// name of the pod
 	pod string
@@ -35,7 +35,7 @@ type Oc struct {
 	errorChannel <-chan error
 }
 
-// Creates an OpenShift Client subprocess, spawning the appropriate underlying PTY.
+// SpawnOc creates an OpenShift Client subprocess, spawning the appropriate underlying PTY.
 func SpawnOc(spawner *Spawner, pod, container, namespace string, timeout time.Duration, opts ...expect.Option) (*Oc, <-chan error, error) {
 	ocArgs := []string{ocExecCommand, ocNamespaceArg, namespace, ocInteractiveArg, pod, ocContainerArg, container, ocClientCommandSeparator, ocDefaultShell}
 	context, err := (*spawner).Spawn(ocCommand, ocArgs, timeout, opts...)
@@ -46,37 +46,37 @@ func SpawnOc(spawner *Spawner, pod, container, namespace string, timeout time.Du
 	return &Oc{pod: pod, container: container, namespace: namespace, timeout: timeout, opts: opts, expecter: context.GetExpecter(), spawnErr: err, errorChannel: errorChannel}, errorChannel, nil
 }
 
-// Extract the expect.Expecter reference used to control the OpenShift client.
+// GetExpecter returns a reference to the expect.Expecter reference used to control the OpenShift client.
 func (o *Oc) GetExpecter() *expect.Expecter {
 	return o.expecter
 }
 
-// Extract the name of the pod.
+// GetPodName returns the name of the pod.
 func (o *Oc) GetPodName() string {
 	return o.pod
 }
 
-// Extract the name of the container.
+// GetPodContainerName returns the name of the container.
 func (o *Oc) GetPodContainerName() string {
 	return o.container
 }
 
-// Extract the namespace of the pod.
+// GetPodNamespace extracts the namespace of the pod.
 func (o *Oc) GetPodNamespace() string {
 	return o.namespace
 }
 
-// Extract the timeout for the expect.Expecter.
+// GetTimeout returns the timeout for the expect.Expecter.
 func (o *Oc) GetTimeout() time.Duration {
 	return o.timeout
 }
 
-// Extract the options, such as verbosity.
+// GetOptions returns the options, such as verbosity.
 func (o *Oc) GetOptions() []expect.Option {
 	return o.opts
 }
 
-// Extract the error channel for interactive monitoring.
+// GetErrorChannel returns the error channel for interactive monitoring.
 func (o *Oc) GetErrorChannel() <-chan error {
 	return o.errorChannel
 }

--- a/pkg/tnf/interactive/shell.go
+++ b/pkg/tnf/interactive/shell.go
@@ -10,7 +10,8 @@ const (
 	shellEnvironmentVariableKey = "SHELL"
 )
 
-// Creates an interactive shell subprocess based on the value of $SHELL, spawning the appropriate underlying PTY.
+// SpawnShell creates an interactive shell subprocess based on the value of $SHELL, spawning the appropriate underlying
+// PTY.
 func SpawnShell(spawner *Spawner, timeout time.Duration, opts ...expect.Option) (*Context, error) {
 	shellEnv := os.Getenv(shellEnvironmentVariableKey)
 	var args []string

--- a/pkg/tnf/interactive/ssh.go
+++ b/pkg/tnf/interactive/ssh.go
@@ -11,14 +11,14 @@ const (
 	sshSeparator = "@"
 )
 
-// Spawn an SSH session to a generic linux host using ssh provided by openssh-clients.  Takes care of establishing the
-// pseudo-terminal (PTY) through expect.SpawnGeneric().
+// SpawnSSH spawns an SSH session to a generic linux host using ssh provided by openssh-clients.  Takes care of
+// establishing the pseudo-terminal (PTY) through expect.SpawnGeneric().
 // TODO: This method currently relies upon passwordless SSH setup beforehand.  Handle all types of auth.
-func SpawnSsh(spawner *Spawner, user, host string, timeout time.Duration, opts ...expect.Option) (*Context, error) {
-	sshArgs := getSshString(user, host)
+func SpawnSSH(spawner *Spawner, user, host string, timeout time.Duration, opts ...expect.Option) (*Context, error) {
+	sshArgs := getSSHString(user, host)
 	return (*spawner).Spawn(sshCommand, []string{sshArgs}, timeout, opts...)
 }
 
-func getSshString(user, host string) string {
+func getSSHString(user, host string) string {
 	return fmt.Sprintf("%s%s%s", user, sshSeparator, host)
 }

--- a/pkg/tnf/interactive/ssh_test.go
+++ b/pkg/tnf/interactive/ssh_test.go
@@ -46,7 +46,7 @@ func TestSpawnSsh(t *testing.T) {
 		mockSpawner.EXPECT().Spawn(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testCase.contextReturnValue, testCase.errReturnValue)
 
 		var spawner interactive.Spawner = mockSpawner
-		_, err := interactive.SpawnSsh(&spawner, testCase.user, testCase.host, ocTestTimeoutDuration, testCase.options...)
+		_, err := interactive.SpawnSSH(&spawner, testCase.user, testCase.host, ocTestTimeoutDuration, testCase.options...)
 		assert.Equal(t, testCase.expectedSpawnErr, err)
 	}
 }

--- a/pkg/tnf/test.go
+++ b/pkg/tnf/test.go
@@ -7,23 +7,29 @@ import (
 )
 
 const (
+	// SUCCESS represents a successful test.
 	SUCCESS = iota
+	// FAILURE represents a failed test.
 	FAILURE
+	// ERROR represents an errored test.
 	ERROR
 )
 
+// Tester provides the interface for a Test.
 type Tester interface {
 	Args() []string
 	Timeout() time.Duration
 	Result() int
 }
 
+// Test runs a chain of Handlers.
 type Test struct {
 	runner *reel.Reel
 	tester Tester
 	chain  []reel.Handler
 }
 
+// Run performs a test, returning the result and any encountered errors.
 func (t *Test) Run() (int, error) {
 	err := t.runner.Run(t)
 	return t.tester.Result(), err
@@ -39,30 +45,38 @@ func (t *Test) dispatch(fp reel.StepFunc) *reel.Step {
 	return nil
 }
 
+// ReelFirst calls the current Handler's ReelFirst function.
 func (t *Test) ReelFirst() *reel.Step {
 	fp := func(handler reel.Handler) *reel.Step {
 		return handler.ReelFirst()
 	}
 	return t.dispatch(fp)
 }
+
+// ReelMatch calls the current Handler's ReelMatch function.
 func (t *Test) ReelMatch(pattern string, before string, match string) *reel.Step {
 	fp := func(handler reel.Handler) *reel.Step {
 		return handler.ReelMatch(pattern, before, match)
 	}
 	return t.dispatch(fp)
 }
+
+// ReelTimeout calls the current Handler's ReelTimeout function.
 func (t *Test) ReelTimeout() *reel.Step {
 	fp := func(handler reel.Handler) *reel.Step {
 		return handler.ReelTimeout()
 	}
 	return t.dispatch(fp)
 }
-func (t *Test) ReelEof() {
+
+// ReelEOF calls the current Handler's ReelEOF function.
+func (t *Test) ReelEOF() {
 	for _, handler := range t.chain {
-		handler.ReelEof()
+		handler.ReelEOF()
 	}
 }
 
+// NewTest creates a new Test given a chain of Handlers.
 func NewTest(expecter *expect.Expecter, tester Tester, chain []reel.Handler, errorChannel <-chan error) (*Test, error) {
 	var args []string
 	args = tester.Args()

--- a/pkg/tnf/test_test.go
+++ b/pkg/tnf/test_test.go
@@ -211,5 +211,5 @@ func TestTest_ReelEof(t *testing.T) {
 
 	assert.Nil(t, err)
 	// just ensure there are no panics
-	test.ReelEof()
+	test.ReelEOF()
 }

--- a/test-network-function/cnf-specific/casa/cnf/nrf/nrfid_test.go
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/nrfid_test.go
@@ -137,5 +137,5 @@ func TestRegistration_ReelTimeout(t *testing.T) {
 func TestRegistration_ReelEof(t *testing.T) {
 	r := nrf.NewRegistration(defaultTestTimeout, defaultNamespace)
 	// Just ensure it doesn't panic.
-	r.ReelEof()
+	r.ReelEOF()
 }

--- a/test-network-function/cnf-specific/casa/cnf/nrf/registration.go
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/registration.go
@@ -20,7 +20,7 @@ const (
 // CheckRegistration checks whether a Casa CNF is registered.
 type CheckRegistration struct {
 	// nrf represents the underlying CNF information.
-	nrf *NRFID
+	nrf *ID
 	// command is the Unix command to run to check the registration
 	command []string
 	// result is the result of the test.
@@ -70,19 +70,19 @@ func (c *CheckRegistration) ReelTimeout() *reel.Step {
 	return nil
 }
 
-// ReelEof does nothing;  no further steps are required for EOF.
-func (c *CheckRegistration) ReelEof() {
+// ReelEOF does nothing;  no further steps are required for EOF.
+func (c *CheckRegistration) ReelEOF() {
 	// do nothing
 }
 
 // FormCheckRegistrationCmd forms the command to check that a CNF is registered.
-func FormCheckRegistrationCmd(namespace string, nrfID *NRFID) []string {
+func FormCheckRegistrationCmd(namespace string, nrfID *ID) []string {
 	command := fmt.Sprintf(GetRegistrationNFStatusCmd, namespace, nrfID.nrf, nrfID.instID)
 	return strings.Split(command, " ")
 }
 
 // NewCheckRegistration Creates a CheckRegistration tnf.Test.
-func NewCheckRegistration(namespace string, timeout time.Duration, nrf *NRFID) *CheckRegistration {
+func NewCheckRegistration(namespace string, timeout time.Duration, nrf *ID) *CheckRegistration {
 	command := FormCheckRegistrationCmd(namespace, nrf)
 	return &CheckRegistration{nrf: nrf, command: command, timeout: timeout, result: tnf.ERROR}
 }

--- a/test-network-function/cnf-specific/casa/cnf/nrf/registration_test.go
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/registration_test.go
@@ -15,7 +15,7 @@ const (
 
 // TestNewCheckRegistration also tests Timeout and Result.
 func TestNewCheckRegistration(t *testing.T) {
-	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, &nrf.NRFID{})
+	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, &nrf.ID{})
 	assert.NotNil(t, cr)
 	assert.Equal(t, testTimeout, cr.Timeout())
 	assert.Equal(t, tnf.ERROR, cr.Result())
@@ -77,5 +77,5 @@ func TestCheckRegistration_ReelEof(t *testing.T) {
 	assert.NotNil(t, cr)
 
 	// just ensures no panics.
-	cr.ReelEof()
+	cr.ReelEOF()
 }

--- a/test-network-function/cnf-specific/casa/cnf/suite.go
+++ b/test-network-function/cnf-specific/casa/cnf/suite.go
@@ -3,8 +3,8 @@ package cnf
 import (
 	"fmt"
 	expect "github.com/google/goexpect"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 	"github.com/redhat-nfvpe/test-network-function/internal/reel"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/interactive"
@@ -18,70 +18,70 @@ const (
 	testTimeout = time.Second * 10
 )
 
-var _ = Describe("casa-cnf", func() {
+var _ = ginkgo.Describe("casa-cnf", func() {
 
 	var config *configuration.CasaCNFConfiguration
 	var err error
 	config, err = configuration.GetCasaCNFTestConfiguration()
 	log.Info("Casa CNF Specific Configuration: %s", config)
-	Expect(err).To(BeNil())
-	Expect(config).ToNot(BeNil())
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(config).ToNot(gomega.BeNil())
 
 	cnfTypes := config.CNFTypes
 	nrfName := config.NRFName
 	namespace := config.Namespace
 
 	var context *interactive.Context
-	When("A local shell is spawned", func() {
+	ginkgo.When("A local shell is spawned", func() {
 		goExpectSpawner := interactive.NewGoExpectSpawner()
 		var spawner interactive.Spawner = goExpectSpawner
 		context, err = interactive.SpawnShell(&spawner, testTimeout, expect.Verbose(true))
-		Expect(err).To(BeNil())
-		Expect(context).ToNot(BeNil())
-		Expect(context.GetExpecter()).ToNot(BeNil())
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(context).ToNot(gomega.BeNil())
+		gomega.Expect(context.GetExpecter()).ToNot(gomega.BeNil())
 	})
 
-	var nrfs map[string]*nrf.NRFID
-	When("Registrations are polled from the \"nfregistrations.mgmt.casa.io\" Custom Resource", func() {
-		It("The appropriate registrations should be reported", func() {
+	var nrfs map[string]*nrf.ID
+	ginkgo.When("Registrations are polled from the \"nfregistrations.mgmt.casa.io\" Custom Resource", func() {
+		ginkgo.It("The appropriate registrations should be reported", func() {
 			registrationTest := nrf.NewRegistration(testTimeout, namespace)
-			Expect(registrationTest).ToNot(BeNil())
+			gomega.Expect(registrationTest).ToNot(gomega.BeNil())
 			test, err := tnf.NewTest(context.GetExpecter(), registrationTest, []reel.Handler{registrationTest}, context.GetErrorChannel())
-			Expect(err).To(BeNil())
-			Expect(test).ToNot(BeNil())
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(test).ToNot(gomega.BeNil())
 			testResult, err := test.Run()
-			Expect(err).To(BeNil())
-			Expect(testResult).To(Equal(tnf.SUCCESS))
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(testResult).To(gomega.Equal(tnf.SUCCESS))
 			nrfs = registrationTest.GetRegisteredNRFs()
 			log.Infof("nrfs=%s", nrfs)
 			for _, cnfType := range cnfTypes {
 				nrfInstalled := getNRF(nrfs, cnfType)
-				Expect(nrfInstalled).ToNot(BeNil())
+				gomega.Expect(nrfInstalled).ToNot(gomega.BeNil())
 			}
 		})
 	})
 
 	for _, cnfType := range cnfTypes {
-		When(fmt.Sprintf("%s(%s) is checked for registration", nrfName, cnfType), func() {
-			It("Should be registered", func() {
+		ginkgo.When(fmt.Sprintf("%s(%s) is checked for registration", nrfName, cnfType), func() {
+			ginkgo.It("Should be registered", func() {
 				for _, cnfType := range cnfTypes {
 					specificNrf := getNRF(nrfs, cnfType)
-					Expect(specificNrf).ToNot(BeNil())
+					gomega.Expect(specificNrf).ToNot(gomega.BeNil())
 					checkRegistrationTest := nrf.NewCheckRegistration(namespace, testTimeout, specificNrf)
 					test, err := tnf.NewTest(context.GetExpecter(), checkRegistrationTest, []reel.Handler{checkRegistrationTest}, context.GetErrorChannel())
-					Expect(err).To(BeNil())
-					Expect(test).ToNot(BeNil())
+					gomega.Expect(err).To(gomega.BeNil())
+					gomega.Expect(test).ToNot(gomega.BeNil())
 					result, err := test.Run()
-					Expect(err).To(BeNil())
-					Expect(result).To(Equal(tnf.SUCCESS))
+					gomega.Expect(err).To(gomega.BeNil())
+					gomega.Expect(result).To(gomega.Equal(tnf.SUCCESS))
 				}
 			})
 		})
 	}
 })
 
-// getNRF returns the first NRFID for a given CNF Type (i.e., AMF, SMF, etc).
-func getNRF(nrfs map[string]*nrf.NRFID, cnfType string) *nrf.NRFID {
+// getNRF returns the first ID for a given CNF Type (i.e., AMF, SMF, etc).
+func getNRF(nrfs map[string]*nrf.ID, cnfType string) *nrf.ID {
 	for _, nrf := range nrfs {
 		if nrf.GetType() == cnfType {
 			return nrf

--- a/test-network-function/cnf-specific/casa/configuration/configuration.go
+++ b/test-network-function/cnf-specific/casa/configuration/configuration.go
@@ -11,8 +11,9 @@ const (
 	casaCNFTestConfigurationFilePathEnvironmentVariableKey = "CASA_CNF_TEST_CONFIGURATION_PATH"
 )
 
-var defaultConfigurationFilePath = path.Join("cnf-specific", "casa", "cnf", "casa-cnf-test-configuration.yaml")
+var defaultConfigurationFilePath = path.Join("cnf-specific", "casa", "casa-cnf-test-configuration.yaml")
 
+// GetCasaCNFTestConfiguration returns the Casa CNF specific test configuration.
 func GetCasaCNFTestConfiguration() (*CasaCNFConfiguration, error) {
 	config := &CasaCNFConfiguration{}
 	yamlFile, err := ioutil.ReadFile(getCasaCNFConfigurationFilePathFromEnvironment())
@@ -34,6 +35,7 @@ func getCasaCNFConfigurationFilePathFromEnvironment() string {
 	return defaultConfigurationFilePath
 }
 
+// CasaCNFConfiguration stores the Casa CNF specific test configuration.
 type CasaCNFConfiguration struct {
 	NRFName   string   `json:"nrfName" yaml:"nrfName"`
 	CNFTypes  []string `json:"cnfTypes" yaml:"cnfTypes"`

--- a/test-network-function/cnf-specific/cisco/kiknos/cisco_kiknos_cnf_specific_tests.go
+++ b/test-network-function/cnf-specific/cisco/kiknos/cisco_kiknos_cnf_specific_tests.go
@@ -17,13 +17,13 @@ const (
 	// The number of ICMP Requests to perform across the IPSEC tunnel
 	numPings = 100
 	// The number of UDP packets to send.
-	numUdpPackets = 100
+	numUDPPackets = 100
 	// The number of new tunnels to create.
 	numTunnels = 1
 	// The size of the ICMP Requests that will traverse the IPSEC tunnel
 	pingSize = 100
 	// The target IP address, which is preconfigured in the setup.
-	targetTunnelIp = "40.0.0.1"
+	targetTunnelIP = "40.0.0.1"
 	// The size of the UDP Packets
 	udpSize = 100
 )
@@ -58,19 +58,19 @@ func testTunnel(partnerPodName string, partnerPodContainerName string, partnerPo
 // Verify UDP traffic
 func verifyUDPTraffic(partnerPodName string, partnerPodContainerName string, partnerPodNamespace string, newTunnelIndex int) {
 	// Take an initial snapshot of the ICMP received count.
-	intialUdpCount, err := itc.GetUdpReceivedCount(partnerPodName, partnerPodContainerName, partnerPodNamespace)
+	initialUDPCount, err := itc.GetUDPReceivedCount(partnerPodName, partnerPodContainerName, partnerPodNamespace)
 	expectNil(err)
-	_, err = itc.SendData(partnerPodName, partnerPodContainerName, partnerPodNamespace, newTunnelIndex, messagesPerSecond, numUdpPackets, udpSize)
+	_, err = itc.SendData(partnerPodName, partnerPodContainerName, partnerPodNamespace, newTunnelIndex, messagesPerSecond, numUDPPackets, udpSize)
 	expectNil(err)
 
 	// TODO:  Could this be done asynchronously through a channel?
 	time.Sleep(busyWaitSeconds * time.Second)
 
 	// Check that numPings were received.
-	updatedUdpCount, err := itc.GetUdpReceivedCount(partnerPodName, partnerPodContainerName, partnerPodNamespace)
+	updatedUDPCount, err := itc.GetUDPReceivedCount(partnerPodName, partnerPodContainerName, partnerPodNamespace)
 	expectNil(err)
-	udpCountDiff := updatedUdpCount - intialUdpCount
-	gomega.Expect(udpCountDiff).To(gomega.Equal(numUdpPackets))
+	udpCountDiff := updatedUDPCount - initialUDPCount
+	gomega.Expect(udpCountDiff).To(gomega.Equal(numUDPPackets))
 }
 
 // Verify ICMP traffic
@@ -78,7 +78,7 @@ func verifyICMPTraffic(partnerPodName string, partnerPodContainerName string, pa
 	// Take an initial snapshot of the ICMP received count.
 	initialIcmpCount, err := itc.GetItcIcmpReplyCount(partnerPodName, partnerPodContainerName, partnerPodNamespace)
 	expectNil(err)
-	_, err = itc.Ping(partnerPodName, partnerPodContainerName, partnerPodNamespace, newTunnelIndex, targetTunnelIp, messagesPerSecond, numPings, pingSize)
+	_, err = itc.Ping(partnerPodName, partnerPodContainerName, partnerPodNamespace, newTunnelIndex, targetTunnelIP, messagesPerSecond, numPings, pingSize)
 	expectNil(err)
 
 	// TODO:  Could this be done asynchronously through a channel?

--- a/test-network-function/configuration/configuration.go
+++ b/test-network-function/configuration/configuration.go
@@ -9,6 +9,7 @@ const (
 	defaultConfigurationFilePath                = "./test-configuration.yaml"
 )
 
+// GetConfigurationFilePathFromEnvironment returns the test configuration file.
 func GetConfigurationFilePathFromEnvironment() string {
 	environmentSourcedConfigurationFilePath := os.Getenv(configurationFilePathEnvironmentVariableKey)
 	if environmentSourcedConfigurationFilePath != "" {
@@ -17,20 +18,22 @@ func GetConfigurationFilePathFromEnvironment() string {
 	return defaultConfigurationFilePath
 }
 
+// ContainerIdentifier is a complex key representing a unique container.
 type ContainerIdentifier struct {
 	Namespace     string `yaml:"namespace" json:"namespace"`
 	PodName       string `yaml:"podName" json:"podName"`
 	ContainerName string `yaml:"containerName" json:"containerName"`
 }
 
+// Container contains the payload of container facets.
 type Container struct {
 	// OpenShift Default network interface name (i.e., eth0)
 	DefaultNetworkDevice string `yaml:"defaultNetworkDevice" json:"defaultNetworkDevice"`
-	// Container overlay IP
-	MultusIpAddresses []string `yaml:"multusIpAddresses,omitempty" json:"multusIpAddresses,omitempty"`
+	// MultusIPAddresses are the overlay IPs.
+	MultusIPAddresses []string `yaml:"multusIpAddresses,omitempty" json:"multusIpAddresses,omitempty"`
 }
 
-// Generic test related configuration
+// TestConfiguration provides generic test related configuration
 type TestConfiguration struct {
 	ContainersUnderTest map[ContainerIdentifier]Container `yaml:"containersUnderTest" json:"containersUnderTest"`
 	PartnerContainers   map[ContainerIdentifier]Container `yaml:"partnerContainers" json:"partnerContainers"`

--- a/test-network-function/test-configuration.yaml
+++ b/test-network-function/test-configuration.yaml
@@ -3,14 +3,14 @@ containersUnderTest:
     podName: test
     containerName: test
   : defaultNetworkDevice: eth0
-    multusIpAddresses:
+    multusIPAddresses:
       - 192.168.1.1
 partnerContainers:
   ? namespace: default
     podName: partner
     containerName: partner
   : defaultNetworkDevice: eth0
-    multusIpAddresses:
+    multusIPAddresses:
       - 192.168.1.3
 testOrchestrator:
   namespace: default

--- a/test-network-function/test_suite_test.go
+++ b/test-network-function/test_suite_test.go
@@ -1,4 +1,4 @@
-package test_network_function
+package suite
 
 import (
 	"flag"
@@ -17,7 +17,7 @@ const (
 	defaultCliArgValue            = ""
 	CnfCertificationTestSuiteName = "CNF Certification Test Suite"
 	junitFlagKey                  = "junit"
-	JunitXmlFileName              = "cnf-certification-tests_junit.xml"
+	JunitXMLFileName              = "cnf-certification-tests_junit.xml"
 	reportFlagKey                 = "report"
 )
 
@@ -42,7 +42,7 @@ func TestTest(t *testing.T) {
 	}
 
 	if *junitPath != "" {
-		junitFile := path.Join(*junitPath, JunitXmlFileName)
+		junitFile := path.Join(*junitPath, JunitXMLFileName)
 		ginkgoReporters = append(ginkgoReporters, reporters.NewJUnitReporter(junitFile))
 	}
 


### PR DESCRIPTION
The test-network-function code base is approaching the size that implementing
code quality controls should be mandatory (in hindsight, we ought to have done
this much from the start).  Thus, this patch implements go lint on non-vendor
files.

We have little control over what our dependencies provide in terms of linting;
it would be great to contribute and help them with achieving lint status, but
for now we will simply ignore lint errors caused by our dependencies.  This
patch considers only the code implemented directly in this repository.

As such, a Makefile target called "lint" was introduced, which invokes the
linter on non-vendor files.  Additionally, the default Makefile target (build)
is modified to invoke the "lint" target, so that lint errors are found earlier
on in the process.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>