### PR TITLE
Add a test to determine if the container is based on Red Hat base image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 *.test
 test-network-function_junit.xml
 cover.out
+test-network-function/cnf-certification-tests_junit.xml

--- a/pkg/tnf/handlers/base/redhat/doc.go
+++ b/pkg/tnf/handlers/base/redhat/doc.go
@@ -1,0 +1,2 @@
+// Package redhat provides a tnf.Test implementation which tests whether a container is based on Red Hat technologies.
+package redhat

--- a/pkg/tnf/handlers/base/redhat/version.go
+++ b/pkg/tnf/handlers/base/redhat/version.go
@@ -1,0 +1,84 @@
+package redhat
+
+import (
+	"github.com/redhat-nfvpe/test-network-function/internal/reel"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"strings"
+	"time"
+)
+
+const (
+	// ReleaseCommand is the Unix command used to check whether a container is based on Red Hat technologies.
+	ReleaseCommand = "if [ -e /etc/redhat-release ]; then cat /etc/redhat-release; else echo \"Unknown Base Image\"; fi"
+	// NotRedHatBasedRegex is the expected output for a container that is not based on Red Hat technologies.
+	NotRedHatBasedRegex = `(?m)Unknown Base Image`
+	// VersionRegex is regular expression expected for a container based on Red Hat technologies.
+	VersionRegex = `(?m)Red Hat Enterprise Linux Server release (\d+\.\d+) \(\w+\)`
+)
+
+// Release is an implementation of tnf.Test used to determine whether a container is based on Red Hat technologies.
+type Release struct {
+	// result is the result of the test.
+	result int
+	// timeout is the timeout duration for the test.
+	timeout time.Duration
+	// args stores the command and arguments.
+	args []string
+	// release contains the contents of /etc/redhat-release if it exists, or "NOT Red Hat Based" if it does not exist.
+	release string
+	// isRedHatBased contains whether the container is based on Red Hat technologies.
+	isRedHatBased bool
+}
+
+// Args returns the command line arguments for the test.
+func (r *Release) Args() []string {
+	return r.args
+}
+
+// Timeout returns the timeout for the test.
+func (r *Release) Timeout() time.Duration {
+	return r.timeout
+}
+
+// Result returns the test result.
+func (r *Release) Result() int {
+	return r.result
+}
+
+// ReelFirst returns a reel.Step which expects output from running the Args command.
+func (r *Release) ReelFirst() *reel.Step {
+	return &reel.Step{
+		Expect:  []string{VersionRegex, NotRedHatBasedRegex},
+		Timeout: r.timeout,
+	}
+}
+
+// ReelMatch determines whether the container is based on Red Hat technologies through pattern matching logic.
+func (r *Release) ReelMatch(pattern string, _ string, _ string) *reel.Step {
+	if pattern == NotRedHatBasedRegex {
+		r.result = tnf.FAILURE
+		r.isRedHatBased = false
+	} else if pattern == VersionRegex {
+		// If the above conditional is not triggered, it can be deduced that we have matched the VersionRegex.
+		r.result = tnf.SUCCESS
+		r.isRedHatBased = true
+	} else {
+		r.result = tnf.ERROR
+		r.isRedHatBased = false
+	}
+	return nil
+}
+
+// ReelTimeout does nothing;  no intervention is needed for a timeout.
+func (r *Release) ReelTimeout() *reel.Step {
+	return nil
+}
+
+// ReelEof does nothing;  no intervention is needed for EOF.
+func (r *Release) ReelEof() {
+}
+
+// NewRelease create a new Release tnf.Test.
+func NewRelease(timeout time.Duration) *Release {
+	return &Release{result: tnf.ERROR, timeout: timeout, args: strings.Split(ReleaseCommand, " ")}
+}

--- a/pkg/tnf/handlers/base/redhat/version_test.go
+++ b/pkg/tnf/handlers/base/redhat/version_test.go
@@ -1,0 +1,63 @@
+package redhat_test
+
+import (
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/handlers/base/redhat"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+	"time"
+)
+
+var testTimeoutDuration = time.Second * 2
+
+// TestNewRelease also tests Args, Timeout and Result
+func TestNewRelease(t *testing.T) {
+	r := redhat.NewRelease(testTimeoutDuration)
+	assert.NotNil(t, r)
+	assert.Equal(t, strings.Split(redhat.ReleaseCommand, " "), r.Args())
+	assert.Equal(t, testTimeoutDuration, r.Timeout())
+	assert.Equal(t, tnf.ERROR, r.Result())
+}
+
+func TestRelease_ReelFirst(t *testing.T) {
+	r := redhat.NewRelease(testTimeoutDuration)
+	step := r.ReelFirst()
+	assert.Equal(t, "", step.Execute)
+	assert.Contains(t, step.Expect, redhat.VersionRegex)
+	assert.Contains(t, step.Expect, redhat.NotRedHatBasedRegex)
+	assert.Equal(t, testTimeoutDuration, step.Timeout)
+}
+
+func TestRelease_ReelMatch(t *testing.T) {
+	r := redhat.NewRelease(testTimeoutDuration)
+
+	// Positive test.
+	step := r.ReelMatch(redhat.VersionRegex, "", "")
+	assert.Nil(t, step)
+	assert.Equal(t, tnf.SUCCESS, r.Result())
+
+	r = redhat.NewRelease(testTimeoutDuration)
+
+	// Negative test.
+	step = r.ReelMatch(redhat.NotRedHatBasedRegex, "", "")
+	assert.Nil(t, step)
+	assert.Equal(t, tnf.FAILURE, r.Result())
+
+	// Error case.  Note, this shouldn't ever happen based on the FSM, but it is better to be defensive.
+	step = r.ReelMatch("unknown regex", "", "")
+	assert.Nil(t, step)
+	assert.Equal(t, tnf.ERROR, r.Result())
+}
+
+func TestRelease_ReelTimeout(t *testing.T) {
+	r := redhat.NewRelease(testTimeoutDuration)
+	step := r.ReelTimeout()
+	assert.Nil(t, step)
+}
+
+func TestRelease_ReelEof(t *testing.T) {
+	// just ensures no panics
+	r := redhat.NewRelease(testTimeoutDuration)
+	r.ReelEof()
+}


### PR DESCRIPTION
This test allows us to quickly and effectively determine whether or not a given
container is based on Red Hat technologies.  The test has 100% unit test
coverage.  Additionally, a manual test was run locally to ensure that an Ubuntu
based container fails the test.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>