### PR TITLE
Introduce multiple container logic to TestConfiguration

### DIFF
--- a/test-network-function/cnf-specific/cisco/kiknos/cisco_kiknos_cnf_specific_tests.go
+++ b/test-network-function/cnf-specific/cisco/kiknos/cisco_kiknos_cnf_specific_tests.go
@@ -31,9 +31,9 @@ const (
 var _ = ginkgo.Describe("cisco_kiknos", func() {
 	// Extract some basic configuration parameters from the generic configuration.
 	config := generic.GetTestConfiguration()
-	partnerPodName := config.PartnerPod.Name
-	partnerPodNamespace := config.PartnerPod.Namespace
-	partnerPodContainerName := config.PartnerPod.ContainerConfiguration.Name
+	partnerPodName := config.TestOrchestrator.PodName
+	partnerPodNamespace := config.TestOrchestrator.Namespace
+	partnerPodContainerName := config.TestOrchestrator.ContainerName
 
 	// Run the only CNF-Specific Test Spec., which has several sub-tests.
 	testTunnel(partnerPodName, partnerPodContainerName, partnerPodNamespace)

--- a/test-network-function/configuration/configuration.go
+++ b/test-network-function/configuration/configuration.go
@@ -17,37 +17,22 @@ func GetConfigurationFilePathFromEnvironment() string {
 	return defaultConfigurationFilePath
 }
 
+type ContainerIdentifier struct {
+	Namespace     string `yaml:"namespace" json:"namespace"`
+	PodName       string `yaml:"podName" json:"podName"`
+	ContainerName string `yaml:"containerName" json:"containerName"`
+}
+
+type Container struct {
+	// OpenShift Default network interface name (i.e., eth0)
+	DefaultNetworkDevice string `yaml:"defaultNetworkDevice" json:"defaultNetworkDevice"`
+	// Container overlay IP
+	MultusIpAddresses []string `yaml:"multusIpAddresses,omitempty" json:"multusIpAddresses,omitempty"`
+}
+
 // Generic test related configuration
 type TestConfiguration struct {
-	// The CNF pod brought by our partner
-	PodUnderTest struct {
-		// Pod name
-		Name string `yaml:"name"`
-		// Pod namespace
-		Namespace string `yaml:"namespace"`
-		// Container facets
-		ContainerConfiguration struct {
-			// Container name
-			Name string `yaml:"name"`
-			// OpenShift Default network interface name (i.e., eth0)
-			DefaultNetworkDevice string `yaml:"defaultNetworkDevice"`
-			// Container overlay IP
-			MultusIpAddresses []string `yaml:"multusIpAddresses"`
-		} `yaml:"containerConfiguration"`
-	} `yaml:"podUnderTest"`
-	PartnerPod struct {
-		// Partner Pod name
-		Name string `yaml:"name"`
-		// Partner Pod namespace
-		Namespace string `yaml:"namespace"`
-		// Container facets
-		ContainerConfiguration struct {
-			// Container name
-			Name string `yaml:"name"`
-			// OpenShift Default network interface name (i.e., eth0)
-			DefaultNetworkDevice string `yaml:"defaultNetworkDevice"`
-			// Container overlay IP
-			MultusIpAddresses []string `yaml:"multusIpAddresses"`
-		} `yaml:"containerConfiguration"`
-	} `yaml:"partnerPod"`
+	ContainersUnderTest map[ContainerIdentifier]Container `yaml:"containersUnderTest" json:"containersUnderTest"`
+	PartnerContainers   map[ContainerIdentifier]Container `yaml:"partnerContainers" json:"partnerContainers"`
+	TestOrchestrator    ContainerIdentifier               `yaml:"testOrchestrator" json:"testOrchestrator"`
 }

--- a/test-network-function/test-configuration.yaml
+++ b/test-network-function/test-configuration.yaml
@@ -1,16 +1,18 @@
-podUnderTest:
-  name: "test"
-  namespace: "default"
-  containerConfiguration:
-    name: "test"
-    defaultNetworkDevice: "eth0"
+containersUnderTest:
+  ? namespace: default
+    podName: test
+    containerName: test
+  : defaultNetworkDevice: eth0
     multusIpAddresses:
-      - "192.168.2.1"
-partnerPod:
-  name: "partner"
-  namespace: "default"
-  containerConfiguration:
-    name: "partner"
-    defaultNetworkDevice: "eth0"
+      - 192.168.1.1
+partnerContainers:
+  ? namespace: default
+    podName: partner
+    containerName: partner
+  : defaultNetworkDevice: eth0
     multusIpAddresses:
-      - "192.168.2.3"
+      - 192.168.1.3
+testOrchestrator:
+  namespace: default
+  podName: partner
+  containerName: partner


### PR DESCRIPTION
This commit contains logic to enable testing across a multitude of containers
from the containerUnderTest and partnerContainer perspective.  The former is
made necessary by the fact that most CNFs are composed of multiple containers.
The latter is future proofing for more complex test cases.

The default test orchestrator is also abstracted.  This is the orchestrator
which will be the "test partner".

All keys are complex ContainerIdentifiers.  This provided the most efficient
and human readable storage mechanism.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>