### PR TITLE
Casa 5GCore CNF Specific Test

### DIFF
--- a/test-network-function/cnf-specific/casa/casa-cnf-test-configuration.yaml
+++ b/test-network-function/cnf-specific/casa/casa-cnf-test-configuration.yaml
@@ -1,0 +1,5 @@
+namespace: default
+nrfName: nrf1
+cnfTypes:
+  - AMF
+  - SMF

--- a/test-network-function/cnf-specific/casa/cnf/nrf/doc.go
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/doc.go
@@ -1,0 +1,4 @@
+// Package nrf provides the necessary tnf.Test implementations to perform the Casa CNF Specific test suite.
+// Specifically, this test suite checks that the appropriate CNF(s) report as "REGISTERED" in the
+// nfregistrations.mgmt.casa.io custom resource.
+package nrf

--- a/test-network-function/cnf-specific/casa/cnf/nrf/nrfid.go
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/nrfid.go
@@ -1,0 +1,149 @@
+package nrf
+
+import (
+	"errors"
+	"fmt"
+	"github.com/redhat-nfvpe/test-network-function/internal/reel"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	// CheckRegistrationCommand is the Unix command for checking NRF registrations.
+	CheckRegistrationCommand = "oc -n %s get nfregistrations.mgmt.casa.io $(oc -n %s get nfregistrations.mgmt.casa.io | awk {\"print $2\"} | xargs -n 1)"
+	// CommandCompleteRegexString is the regular expression indicating the command has completed.
+	CommandCompleteRegexString = `(?m)NRF\s+TYPE\s+INSTID\s+STATUS\s+`
+	// OutputRegexString is the regular expression capturing all CNFs in the NRF registration output.
+	OutputRegexString = `(?m)((\w+)\s+(\w+)\s+([0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12})\s+(\w+)\n)+`
+	// SingleEntryRegexString is the regular expression capturing one CNF in the NRF registration output.
+	SingleEntryRegexString = `(\w+)\s+(\w+)\s+([0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12})\s+(\w+)`
+)
+
+// OutputRegex matches the output from inspecting NRFID registrations.
+var OutputRegex = regexp.MustCompile(OutputRegexString)
+
+// SingleEntryRegex matches a single matching NRFID.
+var SingleEntryRegex = regexp.MustCompile(SingleEntryRegexString)
+
+// NRFID follows the container design pattern, and stores Network Registration information.
+type NRFID struct {
+	nrf    string
+	typ    string
+	instID string
+	status string
+}
+
+// GetType extracts the type of CNF.
+func (n *NRFID) GetType() string {
+	return n.typ
+}
+
+// NewNRFID creates a new NRFID.
+func NewNRFID(nrf, typ, instID, status string) *NRFID {
+	return &NRFID{nrf: nrf, typ: typ, instID: instID, status: status}
+}
+
+// fromString creates an NRFID from a string.
+func fromString(nrf string) (*NRFID, error) {
+	match := SingleEntryRegex.FindStringSubmatch(nrf)
+	if match != nil {
+		nrf := match[1]
+		typ := match[2]
+		instID := match[3]
+		status := match[4]
+		return NewNRFID(nrf, typ, instID, status), nil
+	}
+	// Untestable code below.  No current clients will ever call the code below.
+	return nil, errors.New(fmt.Sprintf("nrf string is not parsable: %s", nrf))
+}
+
+// Registration is a tnf.Test that dumps the output of all CNF registrations in the CR.
+type Registration struct {
+	// args represents the Unix command.
+	args []string
+	// namespace represents the namespace the CNF operators are deployed within.
+	namespace string
+	// result is the result of the tnf.Test.
+	result int
+	// timeout is the tnf.Test timeout.
+	timeout time.Duration
+	// registeredNRFs is a mapping of uuid to other NRF facets (NRFID).
+	registeredNRFs map[string]*NRFID
+}
+
+// Return the command line args for the test.
+func (r *Registration) Args() []string {
+	return r.args
+}
+
+// Return the timeout in seconds for the test.
+func (r *Registration) Timeout() time.Duration {
+	return r.timeout
+}
+
+// Return the test result.
+func (r *Registration) Result() int {
+	return r.result
+}
+
+// Return a step which expects an ip summary for the given device.
+func (r *Registration) ReelFirst() *reel.Step {
+	return &reel.Step{
+		Expect:  []string{OutputRegexString, CommandCompleteRegexString},
+		Timeout: r.timeout,
+	}
+}
+
+// On match, parse the ip addr output and set the test result.
+// Returns no step; the test is complete.
+func (r *Registration) ReelMatch(pattern string, _ string, match string) *reel.Step {
+	if pattern == CommandCompleteRegexString {
+		// Indicates that the command was successfully run, but there were no registered NRFs.
+		r.result = tnf.FAILURE
+		return nil
+	} else if pattern == OutputRegexString {
+		matches := SingleEntryRegex.FindAllString(match, -1)
+		r.result = tnf.SUCCESS
+		for _, m := range matches {
+			nrf, err := fromString(m)
+			// defensive;  should have already matched. Untestable, as we ensure a match prior to calling fromString()
+			// fromString() is also defensive in case there is a future client that doesn't perform such a check.
+			if err != nil {
+				r.result = tnf.ERROR
+				return nil
+			}
+			nrfInstID := nrf.instID
+			r.registeredNRFs[nrfInstID] = nrf
+		}
+		return nil
+	}
+	r.result = tnf.ERROR
+	return nil
+}
+
+// On timeout, do nothing;  no intervention is needed.
+func (r *Registration) ReelTimeout() *reel.Step {
+	return nil
+}
+
+// On eof, take no action.
+func (r *Registration) ReelEof() {
+}
+
+// GetRegisteredNRFs returns the map of registered NRFID instances.
+func (r *Registration) GetRegisteredNRFs() map[string]*NRFID {
+	return r.registeredNRFs
+}
+
+// registrationCommand creates the Unix command to check for registration.
+func registrationCommand(namespace string) []string {
+	command := fmt.Sprintf(CheckRegistrationCommand, namespace, namespace)
+	return strings.Split(command, " ")
+}
+
+// NewRegistration creates a Registration instance.
+func NewRegistration(timeout time.Duration, namespace string) *Registration {
+	return &Registration{result: tnf.ERROR, timeout: timeout, args: registrationCommand(namespace), namespace: namespace, registeredNRFs: map[string]*NRFID{}}
+}

--- a/test-network-function/cnf-specific/casa/cnf/nrf/nrfid_test.go
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/nrfid_test.go
@@ -1,0 +1,141 @@
+package nrf_test
+
+import (
+	"fmt"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/test-network-function/cnf-specific/casa/cnf/nrf"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"path"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	defaultNamespace  = "default"
+	testDataDirectory = "testdata"
+	testDataSuffix    = ".txt"
+)
+
+var defaultTestTimeout = time.Second * 10
+
+type genericRegistrationTestCase struct {
+	timeout          time.Duration
+	namespace        string
+	expectedArgs     []string
+	reelMatchPattern string
+	expectedResult   int
+	expectedNRFUuids []string
+}
+
+var genericRegistrationTestCases = map[string]*genericRegistrationTestCase{
+	"real_test_data": {
+		timeout:          defaultTestTimeout,
+		namespace:        defaultNamespace,
+		expectedArgs:     []string{"oc", "-n", "default", "get", "nfregistrations.mgmt.casa.io", "$(oc", "-n", "default", "get", "nfregistrations.mgmt.casa.io", "|", "awk", "{\"print", "$2\"}", "|", "xargs", "-n", "1)"},
+		reelMatchPattern: nrf.OutputRegexString,
+		expectedResult:   tnf.SUCCESS,
+		expectedNRFUuids: []string{
+			"9b971c6d-12ed-48ee-9ed7-bb99ee4d0b99",
+			"a9bb40c7-bddf-443b-bf64-89ae54812ef9",
+		},
+	},
+	"default_test_case": {
+		timeout:          defaultTestTimeout,
+		namespace:        defaultNamespace,
+		expectedArgs:     []string{"oc", "-n", "default", "get", "nfregistrations.mgmt.casa.io", "$(oc", "-n", "default", "get", "nfregistrations.mgmt.casa.io", "|", "awk", "{\"print", "$2\"}", "|", "xargs", "-n", "1)"},
+		reelMatchPattern: nrf.OutputRegexString,
+		expectedResult:   tnf.SUCCESS,
+		expectedNRFUuids: []string{
+			"77647705-bf24-4b0d-a754-4cb7df86d169",
+			"315889b0-4640-4de3-b41f-4b77643d1a9d",
+			"549328de-4ead-4dac-90ca-4d8d09af3938",
+			"f3d51461-83f4-4bfc-b20e-43297dd4404d",
+			"0a0a2ede-be2e-40f0-8145-5ea6c565296e",
+		},
+	},
+	"no_nrfs_registered": {
+		timeout:          time.Hour * 24,
+		namespace:        "someOtherNamespace",
+		expectedArgs:     []string{"oc", "-n", "someOtherNamespace", "get", "nfregistrations.mgmt.casa.io", "$(oc", "-n", "someOtherNamespace", "get", "nfregistrations.mgmt.casa.io", "|", "awk", "{\"print", "$2\"}", "|", "xargs", "-n", "1)"},
+		reelMatchPattern: nrf.CommandCompleteRegexString,
+		expectedResult:   tnf.FAILURE,
+		expectedNRFUuids: []string{},
+	},
+	"incorrect_match": {
+		timeout:          defaultTestTimeout,
+		namespace:        defaultNamespace,
+		expectedArgs:     []string{"oc", "-n", "default", "get", "nfregistrations.mgmt.casa.io", "$(oc", "-n", "default", "get", "nfregistrations.mgmt.casa.io", "|", "awk", "{\"print", "$2\"}", "|", "xargs", "-n", "1)"},
+		reelMatchPattern: "some_random_match_pattern",
+		expectedResult:   tnf.ERROR,
+		expectedNRFUuids: []string{},
+	},
+}
+
+func getTestOutputFileName(name string) string {
+	return fmt.Sprintf("%s%s", name, testDataSuffix)
+}
+
+func getTestOutputFile(name string) string {
+	return path.Join(testDataDirectory, getTestOutputFileName(name))
+}
+
+func getTestOutputContents(name string) (string, error) {
+	b, err := ioutil.ReadFile(getTestOutputFile(name))
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// TestNewRegistration also tests Registration.Timeout and Registration.Args
+func TestNewRegistration(t *testing.T) {
+	for _, testCase := range genericRegistrationTestCases {
+		r := nrf.NewRegistration(testCase.timeout, testCase.namespace)
+		assert.NotNil(t, r)
+		assert.Equal(t, testCase.timeout, r.Timeout())
+		assert.Equal(t, strings.Split(fmt.Sprintf(nrf.CheckRegistrationCommand, testCase.namespace, testCase.namespace), " "), r.Args())
+	}
+}
+
+func TestRegistration_ReelFirst(t *testing.T) {
+	for _, testCase := range genericRegistrationTestCases {
+		r := nrf.NewRegistration(testCase.timeout, testCase.namespace)
+		assert.NotNil(t, r)
+		step := r.ReelFirst()
+		assert.NotNil(t, step)
+		assert.Equal(t, 2, len(step.Expect))
+		assert.Equal(t, step.Expect[0], nrf.OutputRegexString)
+		assert.Equal(t, step.Expect[1], nrf.CommandCompleteRegexString)
+		assert.Equal(t, testCase.timeout, step.Timeout)
+		assert.Equal(t, "", step.Execute)
+	}
+}
+
+func TestRegistration_ReelMatch(t *testing.T) {
+	for testCaseName, testCase := range genericRegistrationTestCases {
+		r := nrf.NewRegistration(testCase.timeout, testCase.namespace)
+		testCaseOutput, err := getTestOutputContents(testCaseName)
+		assert.Nil(t, err)
+		assert.NotNil(t, testCaseOutput)
+		step := r.ReelMatch(testCase.reelMatchPattern, "", testCaseOutput)
+		assert.Nil(t, step)
+		assert.Equal(t, testCase.expectedResult, r.Result())
+		for _, expectedUuid := range testCase.expectedNRFUuids {
+			assert.NotNil(t, r.GetRegisteredNRFs()[expectedUuid])
+		}
+	}
+}
+
+func TestRegistration_ReelTimeout(t *testing.T) {
+	r := nrf.NewRegistration(defaultTestTimeout, defaultNamespace)
+	s := r.ReelTimeout()
+	assert.Nil(t, s)
+}
+
+func TestRegistration_ReelEof(t *testing.T) {
+	r := nrf.NewRegistration(defaultTestTimeout, defaultNamespace)
+	// Just ensure it doesn't panic.
+	r.ReelEof()
+}

--- a/test-network-function/cnf-specific/casa/cnf/nrf/registration.go
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/registration.go
@@ -1,0 +1,88 @@
+package nrf
+
+import (
+	"fmt"
+	"github.com/redhat-nfvpe/test-network-function/internal/reel"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"strings"
+	"time"
+)
+
+const (
+	// GetRegistrationNFStatusCmd gets the "nfStatus" for a particular CNF.
+	GetRegistrationNFStatusCmd = "oc get -n %s nfregistrations.mgmt.casa.io %s %s -o jsonpath='{.items[*].spec.data}' | jq '.nfStatus'"
+	// SuccessfulRegistrationOutputRegexString is the output regular expression expected when a CNF has successfully registered.
+	SuccessfulRegistrationOutputRegexString = "(?m)\"REGISTERED\""
+	// UnsuccessfulRegistrationOutputRegexString is the output regular expression expected when a CNF has not successfully registered.
+	UnsuccessfulRegistrationOutputRegexString = "(?m)\"\""
+)
+
+// CheckRegistration checks whether a Casa CNF is registered.
+type CheckRegistration struct {
+	// nrf represents the underlying CNF information.
+	nrf *NRFID
+	// command is the Unix command to run to check the registration
+	command []string
+	// result is the result of the test.
+	result int
+	// timeout is the timeout of the test.
+	timeout time.Duration
+}
+
+// Args returns the command to test that a CNF is registered.
+func (c *CheckRegistration) Args() []string {
+	return c.command
+}
+
+// Timeout returns the timeout of the test.
+func (c *CheckRegistration) Timeout() time.Duration {
+	return c.timeout
+}
+
+// Result returns the result of the test.
+func (c *CheckRegistration) Result() int {
+	return c.result
+}
+
+// ReelFirst returns the step that looks for whether a CNF is registered.
+func (c *CheckRegistration) ReelFirst() *reel.Step {
+	return &reel.Step{
+		Expect:  []string{SuccessfulRegistrationOutputRegexString, UnsuccessfulRegistrationOutputRegexString},
+		Timeout: c.timeout,
+	}
+}
+
+// ReelMatch determines whether a CNF was successfully registered.  The returned result is nil since no further action
+// is needed.
+func (c *CheckRegistration) ReelMatch(pattern string, _ string, _ string) *reel.Step {
+	if pattern == UnsuccessfulRegistrationOutputRegexString {
+		c.result = tnf.FAILURE
+	} else if pattern == SuccessfulRegistrationOutputRegexString {
+		c.result = tnf.SUCCESS
+	} else {
+		c.result = tnf.ERROR
+	}
+	return nil
+}
+
+// ReelTimeout returns nil;  no further steps are required for a timeout.
+func (c *CheckRegistration) ReelTimeout() *reel.Step {
+	return nil
+}
+
+// ReelEof does nothing;  no further steps are required for EOF.
+func (c *CheckRegistration) ReelEof() {
+	// do nothing
+}
+
+// FormCheckRegistrationCmd forms the command to check that a CNF is registered.
+func FormCheckRegistrationCmd(namespace string, nrfID *NRFID) []string {
+	command := fmt.Sprintf(GetRegistrationNFStatusCmd, namespace, nrfID.nrf, nrfID.instID)
+	return strings.Split(command, " ")
+}
+
+// NewCheckRegistration Creates a CheckRegistration tnf.Test.
+func NewCheckRegistration(namespace string, timeout time.Duration, nrf *NRFID) *CheckRegistration {
+	command := FormCheckRegistrationCmd(namespace, nrf)
+	return &CheckRegistration{nrf: nrf, command: command, timeout: timeout, result: tnf.ERROR}
+}

--- a/test-network-function/cnf-specific/casa/cnf/nrf/registration_test.go
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/registration_test.go
@@ -1,0 +1,81 @@
+package nrf_test
+
+import (
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/test-network-function/cnf-specific/casa/cnf/nrf"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+const (
+	testNamespace = "default"
+	testTimeout   = time.Second * 2
+)
+
+// TestNewCheckRegistration also tests Timeout and Result.
+func TestNewCheckRegistration(t *testing.T) {
+	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, &nrf.NRFID{})
+	assert.NotNil(t, cr)
+	assert.Equal(t, testTimeout, cr.Timeout())
+	assert.Equal(t, tnf.ERROR, cr.Result())
+}
+
+func TestCheckRegistration_Args(t *testing.T) {
+	nrfID := nrf.NewNRFID("nrf123", "AMF", "0a0a2ede-be2e-40f0-8145-5ea6c565296e", "REGISTERED")
+	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	assert.NotNil(t, cr)
+
+	expected := []string{"oc", "get", "-n", "default", "nfregistrations.mgmt.casa.io", "nrf123", "0a0a2ede-be2e-40f0-8145-5ea6c565296e", "-o", "jsonpath='{.items[*].spec.data}'", "|", "jq", "'.nfStatus'"}
+	assert.Equal(t, expected, nrf.FormCheckRegistrationCmd(testNamespace, nrfID))
+	assert.Equal(t, expected, cr.Args())
+}
+
+func TestCheckRegistration_ReelFirst(t *testing.T) {
+	nrfID := nrf.NewNRFID("nrf123", "AMF", "0a0a2ede-be2e-40f0-8145-5ea6c565296e", "REGISTERED")
+	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	assert.NotNil(t, cr)
+
+	step := cr.ReelFirst()
+	assert.NotNil(t, step)
+	assert.Equal(t, testTimeout, step.Timeout)
+	assert.Equal(t, "", step.Execute)
+	assert.Contains(t, step.Expect, nrf.SuccessfulRegistrationOutputRegexString)
+	assert.Contains(t, step.Expect, nrf.UnsuccessfulRegistrationOutputRegexString)
+}
+
+func TestCheckRegistration_ReelMatch(t *testing.T) {
+	nrfID := nrf.NewNRFID("nrf123", "AMF", "0a0a2ede-be2e-40f0-8145-5ea6c565296e", "REGISTERED")
+	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	assert.NotNil(t, cr)
+
+	step := cr.ReelMatch(nrf.SuccessfulRegistrationOutputRegexString, "", "")
+	assert.Nil(t, step)
+	assert.Equal(t, tnf.SUCCESS, cr.Result())
+
+	step = cr.ReelMatch(nrf.UnsuccessfulRegistrationOutputRegexString, "", "")
+	assert.Nil(t, step)
+	assert.Equal(t, tnf.FAILURE, cr.Result())
+
+	step = cr.ReelMatch("", "", "")
+	assert.Nil(t, step)
+	assert.Equal(t, tnf.ERROR, cr.Result())
+}
+
+func TestCheckRegistration_ReelTimeout(t *testing.T) {
+	nrfID := nrf.NewNRFID("nrf123", "AMF", "0a0a2ede-be2e-40f0-8145-5ea6c565296e", "REGISTERED")
+	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	assert.NotNil(t, cr)
+
+	step := cr.ReelTimeout()
+	assert.Nil(t, step)
+}
+
+func TestCheckRegistration_ReelEof(t *testing.T) {
+	nrfID := nrf.NewNRFID("nrf123", "AMF", "0a0a2ede-be2e-40f0-8145-5ea6c565296e", "REGISTERED")
+	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	assert.NotNil(t, cr)
+
+	// just ensures no panics.
+	cr.ReelEof()
+}

--- a/test-network-function/cnf-specific/casa/cnf/nrf/testdata/default_test_case.txt
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/testdata/default_test_case.txt
@@ -1,0 +1,6 @@
+NRF    TYPE   INSTID                                 STATUS
+nrf1   SMF    77647705-bf24-4b0d-a754-4cb7df86d169   REGISTERED
+nrf1   SMF    315889b0-4640-4de3-b41f-4b77643d1a9d   SUSPENDED
+nrf1   AMF    549328de-4ead-4dac-90ca-4d8d09af3938   REGISTERED
+nrf1   NSSF   f3d51461-83f4-4bfc-b20e-43297dd4404d   REGISTERED
+nrf1   SMF    0a0a2ede-be2e-40f0-8145-5ea6c565296e   REGISTERED

--- a/test-network-function/cnf-specific/casa/cnf/nrf/testdata/incorrect_match.txt
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/testdata/incorrect_match.txt
@@ -1,0 +1,1 @@
+some_random_match_pattern

--- a/test-network-function/cnf-specific/casa/cnf/nrf/testdata/no_nrfs_registered.txt
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/testdata/no_nrfs_registered.txt
@@ -1,0 +1,1 @@
+NRF    TYPE   INSTID                                 STATUS

--- a/test-network-function/cnf-specific/casa/cnf/nrf/testdata/real_test_data.txt
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/testdata/real_test_data.txt
@@ -1,0 +1,2 @@
+nrf1   SMF    9b971c6d-12ed-48ee-9ed7-bb99ee4d0b99   REGISTERED
+nrf1   AMF    a9bb40c7-bddf-443b-bf64-89ae54812ef9   REGISTERED

--- a/test-network-function/cnf-specific/casa/cnf/suite.go
+++ b/test-network-function/cnf-specific/casa/cnf/suite.go
@@ -1,0 +1,91 @@
+package cnf
+
+import (
+	"fmt"
+	expect "github.com/google/goexpect"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-nfvpe/test-network-function/internal/reel"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/interactive"
+	"github.com/redhat-nfvpe/test-network-function/test-network-function/cnf-specific/casa/cnf/nrf"
+	"github.com/redhat-nfvpe/test-network-function/test-network-function/cnf-specific/casa/configuration"
+	log "github.com/sirupsen/logrus"
+	"time"
+)
+
+const (
+	testTimeout = time.Second * 10
+)
+
+var _ = Describe("casa-cnf", func() {
+
+	var config *configuration.CasaCNFConfiguration
+	var err error
+	config, err = configuration.GetCasaCNFTestConfiguration()
+	log.Info("Casa CNF Specific Configuration: %s", config)
+	Expect(err).To(BeNil())
+	Expect(config).ToNot(BeNil())
+
+	cnfTypes := config.CNFTypes
+	nrfName := config.NRFName
+	namespace := config.Namespace
+
+	var context *interactive.Context
+	When("A local shell is spawned", func() {
+		goExpectSpawner := interactive.NewGoExpectSpawner()
+		var spawner interactive.Spawner = goExpectSpawner
+		context, err = interactive.SpawnShell(&spawner, testTimeout, expect.Verbose(true))
+		Expect(err).To(BeNil())
+		Expect(context).ToNot(BeNil())
+		Expect(context.GetExpecter()).ToNot(BeNil())
+	})
+
+	var nrfs map[string]*nrf.NRFID
+	When("Registrations are polled from the \"nfregistrations.mgmt.casa.io\" Custom Resource", func() {
+		It("The appropriate registrations should be reported", func() {
+			registrationTest := nrf.NewRegistration(testTimeout, namespace)
+			Expect(registrationTest).ToNot(BeNil())
+			test, err := tnf.NewTest(context.GetExpecter(), registrationTest, []reel.Handler{registrationTest}, context.GetErrorChannel())
+			Expect(err).To(BeNil())
+			Expect(test).ToNot(BeNil())
+			testResult, err := test.Run()
+			Expect(err).To(BeNil())
+			Expect(testResult).To(Equal(tnf.SUCCESS))
+			nrfs = registrationTest.GetRegisteredNRFs()
+			log.Infof("nrfs=%s", nrfs)
+			for _, cnfType := range cnfTypes {
+				nrfInstalled := getNRF(nrfs, cnfType)
+				Expect(nrfInstalled).ToNot(BeNil())
+			}
+		})
+	})
+
+	for _, cnfType := range cnfTypes {
+		When(fmt.Sprintf("%s(%s) is checked for registration", nrfName, cnfType), func() {
+			It("Should be registered", func() {
+				for _, cnfType := range cnfTypes {
+					specificNrf := getNRF(nrfs, cnfType)
+					Expect(specificNrf).ToNot(BeNil())
+					checkRegistrationTest := nrf.NewCheckRegistration(namespace, testTimeout, specificNrf)
+					test, err := tnf.NewTest(context.GetExpecter(), checkRegistrationTest, []reel.Handler{checkRegistrationTest}, context.GetErrorChannel())
+					Expect(err).To(BeNil())
+					Expect(test).ToNot(BeNil())
+					result, err := test.Run()
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(tnf.SUCCESS))
+				}
+			})
+		})
+	}
+})
+
+// getNRF returns the first NRFID for a given CNF Type (i.e., AMF, SMF, etc).
+func getNRF(nrfs map[string]*nrf.NRFID, cnfType string) *nrf.NRFID {
+	for _, nrf := range nrfs {
+		if nrf.GetType() == cnfType {
+			return nrf
+		}
+	}
+	return nil
+}

--- a/test-network-function/cnf-specific/casa/configuration/configuration.go
+++ b/test-network-function/cnf-specific/casa/configuration/configuration.go
@@ -1,0 +1,41 @@
+package configuration
+
+import (
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+	"path"
+)
+
+const (
+	casaCNFTestConfigurationFilePathEnvironmentVariableKey = "CASA_CNF_TEST_CONFIGURATION_PATH"
+)
+
+var defaultConfigurationFilePath = path.Join("cnf-specific", "casa", "cnf", "casa-cnf-test-configuration.yaml")
+
+func GetCasaCNFTestConfiguration() (*CasaCNFConfiguration, error) {
+	config := &CasaCNFConfiguration{}
+	yamlFile, err := ioutil.ReadFile(getCasaCNFConfigurationFilePathFromEnvironment())
+	if err != nil {
+		return nil, err
+	}
+	err = yaml.Unmarshal(yamlFile, config)
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+func getCasaCNFConfigurationFilePathFromEnvironment() string {
+	environmentSourcedConfigurationFilePath := os.Getenv(casaCNFTestConfigurationFilePathEnvironmentVariableKey)
+	if environmentSourcedConfigurationFilePath != "" {
+		return environmentSourcedConfigurationFilePath
+	}
+	return defaultConfigurationFilePath
+}
+
+type CasaCNFConfiguration struct {
+	NRFName   string   `json:"nrfName" yaml:"nrfName"`
+	CNFTypes  []string `json:"cnfTypes" yaml:"cnfTypes"`
+	Namespace string   `json:"namespace" yaml:"namespace"`
+}

--- a/test-network-function/generic/generic_cnf_tests.go
+++ b/test-network-function/generic/generic_cnf_tests.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	defaultNumPings       = 1
+	defaultNumPings       = 5
 	defaultTimeoutSeconds = 10
 	multusTestsKey        = "multus"
 	testsKey              = "generic"

--- a/test-network-function/test_suite_test.go
+++ b/test-network-function/test_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
+	_ "github.com/redhat-nfvpe/test-network-function/test-network-function/cnf-specific/casa/cnf"
 	_ "github.com/redhat-nfvpe/test-network-function/test-network-function/cnf-specific/cisco/kiknos"
 	_ "github.com/redhat-nfvpe/test-network-function/test-network-function/generic"
 	ginkgoreporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"


### PR DESCRIPTION
Adds a test suite called "casa-cnf" which tests nfregistrations.mgmt.casa.io
reports that a CNF is "REGISTERED".  The tnf.Test implementations used to
perform this test have 100% unit test line coverage.

To run these tests, issue the following command:
> ./test-network-function.test -ginkgo.v -ginkgo.focus="casa-cnf" -junit . -report .

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>