### PR TITLE
Sanitize CLI Input

### DIFF
--- a/test-network-function/cnf-specific/casa/cnf/nrf/nrfid.go
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/nrfid.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/redhat-nfvpe/test-network-function/internal/reel"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/test-network-function/utils"
 	"regexp"
 	"strings"
 	"time"
@@ -138,12 +139,19 @@ func (r *Registration) GetRegisteredNRFs() map[string]*NRFID {
 }
 
 // registrationCommand creates the Unix command to check for registration.
-func registrationCommand(namespace string) []string {
-	command := fmt.Sprintf(CheckRegistrationCommand, namespace, namespace)
-	return strings.Split(command, " ")
+func registrationCommand(namespace string) ([]string, error) {
+	command, err := utils.PrepareString(CheckRegistrationCommand, namespace, namespace)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(command, " "), nil
 }
 
 // NewRegistration creates a Registration instance.
-func NewRegistration(timeout time.Duration, namespace string) *Registration {
-	return &Registration{result: tnf.ERROR, timeout: timeout, args: registrationCommand(namespace), namespace: namespace, registeredNRFs: map[string]*NRFID{}}
+func NewRegistration(timeout time.Duration, namespace string) (*Registration, error) {
+	preparedCommand, err := registrationCommand(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return &Registration{result: tnf.ERROR, timeout: timeout, args: preparedCommand, namespace: namespace, registeredNRFs: map[string]*NRFID{}}, nil
 }

--- a/test-network-function/cnf-specific/casa/cnf/nrf/nrfid_test.go
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/nrfid_test.go
@@ -92,7 +92,8 @@ func getTestOutputContents(name string) (string, error) {
 // TestNewRegistration also tests Registration.Timeout and Registration.Args
 func TestNewRegistration(t *testing.T) {
 	for _, testCase := range genericRegistrationTestCases {
-		r := nrf.NewRegistration(testCase.timeout, testCase.namespace)
+		r, err := nrf.NewRegistration(testCase.timeout, testCase.namespace)
+		assert.Nil(t, err)
 		assert.NotNil(t, r)
 		assert.Equal(t, testCase.timeout, r.Timeout())
 		assert.Equal(t, strings.Split(fmt.Sprintf(nrf.CheckRegistrationCommand, testCase.namespace, testCase.namespace), " "), r.Args())
@@ -101,7 +102,8 @@ func TestNewRegistration(t *testing.T) {
 
 func TestRegistration_ReelFirst(t *testing.T) {
 	for _, testCase := range genericRegistrationTestCases {
-		r := nrf.NewRegistration(testCase.timeout, testCase.namespace)
+		r, err := nrf.NewRegistration(testCase.timeout, testCase.namespace)
+		assert.Nil(t, err)
 		assert.NotNil(t, r)
 		step := r.ReelFirst()
 		assert.NotNil(t, step)
@@ -115,7 +117,8 @@ func TestRegistration_ReelFirst(t *testing.T) {
 
 func TestRegistration_ReelMatch(t *testing.T) {
 	for testCaseName, testCase := range genericRegistrationTestCases {
-		r := nrf.NewRegistration(testCase.timeout, testCase.namespace)
+		r, err := nrf.NewRegistration(testCase.timeout, testCase.namespace)
+		assert.Nil(t, err)
 		testCaseOutput, err := getTestOutputContents(testCaseName)
 		assert.Nil(t, err)
 		assert.NotNil(t, testCaseOutput)
@@ -129,13 +132,15 @@ func TestRegistration_ReelMatch(t *testing.T) {
 }
 
 func TestRegistration_ReelTimeout(t *testing.T) {
-	r := nrf.NewRegistration(defaultTestTimeout, defaultNamespace)
+	r, err := nrf.NewRegistration(defaultTestTimeout, defaultNamespace)
+	assert.Nil(t, err)
 	s := r.ReelTimeout()
 	assert.Nil(t, s)
 }
 
 func TestRegistration_ReelEof(t *testing.T) {
-	r := nrf.NewRegistration(defaultTestTimeout, defaultNamespace)
+	r, err := nrf.NewRegistration(defaultTestTimeout, defaultNamespace)
+	assert.Nil(t, err)
 	// Just ensure it doesn't panic.
 	r.ReelEof()
 }

--- a/test-network-function/cnf-specific/casa/cnf/nrf/registration.go
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/registration.go
@@ -1,9 +1,9 @@
 package nrf
 
 import (
-	"fmt"
 	"github.com/redhat-nfvpe/test-network-function/internal/reel"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/test-network-function/utils"
 	"strings"
 	"time"
 )
@@ -76,13 +76,19 @@ func (c *CheckRegistration) ReelEof() {
 }
 
 // FormCheckRegistrationCmd forms the command to check that a CNF is registered.
-func FormCheckRegistrationCmd(namespace string, nrfID *NRFID) []string {
-	command := fmt.Sprintf(GetRegistrationNFStatusCmd, namespace, nrfID.nrf, nrfID.instID)
-	return strings.Split(command, " ")
+func FormCheckRegistrationCmd(namespace string, nrfID *NRFID) ([]string, error) {
+	command, err := utils.PrepareString(GetRegistrationNFStatusCmd, namespace, nrfID.nrf, nrfID.instID)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(command, " "), nil
 }
 
 // NewCheckRegistration Creates a CheckRegistration tnf.Test.
-func NewCheckRegistration(namespace string, timeout time.Duration, nrf *NRFID) *CheckRegistration {
-	command := FormCheckRegistrationCmd(namespace, nrf)
-	return &CheckRegistration{nrf: nrf, command: command, timeout: timeout, result: tnf.ERROR}
+func NewCheckRegistration(namespace string, timeout time.Duration, nrf *NRFID) (*CheckRegistration, error) {
+	command, err := FormCheckRegistrationCmd(namespace, nrf)
+	if err != nil {
+		return nil, err
+	}
+	return &CheckRegistration{nrf: nrf, command: command, timeout: timeout, result: tnf.ERROR}, nil
 }

--- a/test-network-function/cnf-specific/casa/cnf/nrf/registration_test.go
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/registration_test.go
@@ -15,7 +15,8 @@ const (
 
 // TestNewCheckRegistration also tests Timeout and Result.
 func TestNewCheckRegistration(t *testing.T) {
-	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, &nrf.NRFID{})
+	cr, err := nrf.NewCheckRegistration(testNamespace, testTimeout, &nrf.NRFID{})
+	assert.Nil(t, err)
 	assert.NotNil(t, cr)
 	assert.Equal(t, testTimeout, cr.Timeout())
 	assert.Equal(t, tnf.ERROR, cr.Result())
@@ -23,17 +24,21 @@ func TestNewCheckRegistration(t *testing.T) {
 
 func TestCheckRegistration_Args(t *testing.T) {
 	nrfID := nrf.NewNRFID("nrf123", "AMF", "0a0a2ede-be2e-40f0-8145-5ea6c565296e", "REGISTERED")
-	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	cr, err := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	assert.Nil(t, err)
 	assert.NotNil(t, cr)
 
 	expected := []string{"oc", "get", "-n", "default", "nfregistrations.mgmt.casa.io", "nrf123", "0a0a2ede-be2e-40f0-8145-5ea6c565296e", "-o", "jsonpath='{.items[*].spec.data}'", "|", "jq", "'.nfStatus'"}
-	assert.Equal(t, expected, nrf.FormCheckRegistrationCmd(testNamespace, nrfID))
+	actualCommand, err := nrf.FormCheckRegistrationCmd(testNamespace, nrfID)
+	assert.Nil(t, actualCommand)
+	assert.Equal(t, expected, actualCommand)
 	assert.Equal(t, expected, cr.Args())
 }
 
 func TestCheckRegistration_ReelFirst(t *testing.T) {
 	nrfID := nrf.NewNRFID("nrf123", "AMF", "0a0a2ede-be2e-40f0-8145-5ea6c565296e", "REGISTERED")
-	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	cr, err := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	assert.Nil(t, err)
 	assert.NotNil(t, cr)
 
 	step := cr.ReelFirst()
@@ -46,7 +51,8 @@ func TestCheckRegistration_ReelFirst(t *testing.T) {
 
 func TestCheckRegistration_ReelMatch(t *testing.T) {
 	nrfID := nrf.NewNRFID("nrf123", "AMF", "0a0a2ede-be2e-40f0-8145-5ea6c565296e", "REGISTERED")
-	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	cr, err := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	assert.Nil(t, err)
 	assert.NotNil(t, cr)
 
 	step := cr.ReelMatch(nrf.SuccessfulRegistrationOutputRegexString, "", "")
@@ -64,7 +70,8 @@ func TestCheckRegistration_ReelMatch(t *testing.T) {
 
 func TestCheckRegistration_ReelTimeout(t *testing.T) {
 	nrfID := nrf.NewNRFID("nrf123", "AMF", "0a0a2ede-be2e-40f0-8145-5ea6c565296e", "REGISTERED")
-	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	cr, err := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	assert.Nil(t, err)
 	assert.NotNil(t, cr)
 
 	step := cr.ReelTimeout()
@@ -73,7 +80,8 @@ func TestCheckRegistration_ReelTimeout(t *testing.T) {
 
 func TestCheckRegistration_ReelEof(t *testing.T) {
 	nrfID := nrf.NewNRFID("nrf123", "AMF", "0a0a2ede-be2e-40f0-8145-5ea6c565296e", "REGISTERED")
-	cr := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	cr, err := nrf.NewCheckRegistration(testNamespace, testTimeout, nrfID)
+	assert.Nil(t, err)
 	assert.NotNil(t, cr)
 
 	// just ensures no panics.

--- a/test-network-function/cnf-specific/casa/cnf/suite.go
+++ b/test-network-function/cnf-specific/casa/cnf/suite.go
@@ -44,7 +44,8 @@ var _ = Describe("casa-cnf", func() {
 	var nrfs map[string]*nrf.NRFID
 	When("Registrations are polled from the \"nfregistrations.mgmt.casa.io\" Custom Resource", func() {
 		It("The appropriate registrations should be reported", func() {
-			registrationTest := nrf.NewRegistration(testTimeout, namespace)
+			registrationTest, err := nrf.NewRegistration(testTimeout, namespace)
+			Expect(err).To(BeNil())
 			Expect(registrationTest).ToNot(BeNil())
 			test, err := tnf.NewTest(context.GetExpecter(), registrationTest, []reel.Handler{registrationTest}, context.GetErrorChannel())
 			Expect(err).To(BeNil())
@@ -67,7 +68,8 @@ var _ = Describe("casa-cnf", func() {
 				for _, cnfType := range cnfTypes {
 					specificNrf := getNRF(nrfs, cnfType)
 					Expect(specificNrf).ToNot(BeNil())
-					checkRegistrationTest := nrf.NewCheckRegistration(namespace, testTimeout, specificNrf)
+					checkRegistrationTest, err := nrf.NewCheckRegistration(namespace, testTimeout, specificNrf)
+					Expect(err).To(BeNil())
 					test, err := tnf.NewTest(context.GetExpecter(), checkRegistrationTest, []reel.Handler{checkRegistrationTest}, context.GetErrorChannel())
 					Expect(err).To(BeNil())
 					Expect(test).ToNot(BeNil())

--- a/test-network-function/utils/doc.go
+++ b/test-network-function/utils/doc.go
@@ -1,0 +1,2 @@
+// Package utils provides utilities common to generic and cnf-specific tests.
+package utils

--- a/test-network-function/utils/strings.go
+++ b/test-network-function/utils/strings.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// whitespaceRegex is a regular expression which matches any whitespace.
+var whitespaceRegex = regexp.MustCompile(`(?m)\s`)
+
+var isQuotedRegex = regexp.MustCompile(`(?m)[\"\'].*[\"\']`)
+
+// PrepareString is a utility function used to sanitize a CLI command input.  First, the command arguments are trimmed.
+// Next, each trimmed argument is inspected to see if it utilizes white space.  If the argument contains white space, it
+// is further checked to ensure that it is contained by single or double quotes.  If it fails this test, then an
+// appropriate error is returned.  If all tests pass, the prepared string is created and returned.
+func PrepareString(format string, args ...interface{}) (string, error) {
+	var preparedStringArgs []interface{}
+	for _, arg := range args {
+		// only inspect string arguments
+		if sArg, ok := arg.(string); ok {
+			preparedArg := strings.TrimSpace(sArg)
+			whitespaceMatch := whitespaceRegex.FindString(preparedArg)
+			if whitespaceMatch != "" {
+				quotedMatch := isQuotedRegex.FindString(preparedArg)
+				if quotedMatch == "" {
+					return "", errors.New(fmt.Sprintf("argument contains non-trimmable whitespace outside of quotes \"%s\"", arg))
+				}
+			}
+			preparedStringArgs = append(preparedStringArgs, preparedArg)
+		} else {
+			preparedStringArgs = append(preparedStringArgs, arg)
+		}
+	}
+	return fmt.Sprintf(format, preparedStringArgs...), nil
+}

--- a/test-network-function/utils/strings_test.go
+++ b/test-network-function/utils/strings_test.go
@@ -1,0 +1,123 @@
+package utils_test
+
+import (
+	"errors"
+	"github.com/redhat-nfvpe/test-network-function/test-network-function/utils"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type prepareStringTest struct {
+	format         string
+	args           []interface{}
+	expectedError  error
+	expectedOutput string
+}
+
+var prepareStringTestCases = map[string]prepareStringTest{
+	"no_arguments": {
+		format:         "ls",
+		args:           iface([]string{}),
+		expectedError:  nil,
+		expectedOutput: "ls",
+	},
+	"acceptable_arguments": {
+		format:         "ls %s",
+		args:           iface([]string{"/"}),
+		expectedError:  nil,
+		expectedOutput: "ls /",
+	},
+	"acceptable_multiple_arguments": {
+		format:         "ssh %s@%s",
+		args:           iface([]string{"user", "host"}),
+		expectedError:  nil,
+		expectedOutput: "ssh user@host",
+	},
+	"leading_and_trailing_whitespace_should_be_fine": {
+		format:         "ssh %s@%s",
+		args:           iface([]string{"    user", "host     "}),
+		expectedError:  nil,
+		expectedOutput: "ssh user@host",
+	},
+	"mixed_argument_types": {
+		format:         "ping -c %d %s",
+		args:           nil,
+		expectedError:  nil,
+		expectedOutput: "ping -c 1 host",
+	},
+	"empty_string": {
+		format: "%s",
+		args: iface([]string{" "}),
+		expectedError: nil,
+		expectedOutput: "",
+	},
+	"double_quoted_argument": {
+		format: "echo %s",
+		args: iface([]string{"\"   I can do this fine   \""}),
+		expectedError: nil,
+		expectedOutput: "echo \"   I can do this fine   \"",
+	},
+	"single_quoted_argument_unescaped": {
+		format: "echo %s",
+		args: iface([]string{"'   I can do this fine   '"}),
+		expectedError: nil,
+		expectedOutput: "echo '   I can do this fine   '",
+	},
+	// Negative Tests.
+	"negative_test_whitespace_arg": {
+		format:         "ssh %s@%s",
+		args:           iface([]string{"user 1", "host"}),
+		expectedError:  errors.New("argument contains non-trimmable whitespace outside of quotes \"user 1\""),
+		expectedOutput: "",
+	},
+	"negative_test_non_terminated_double_quote": {
+		format: "echo %s",
+		args: iface([]string{"\"   hi "}),
+		expectedError: errors.New("argument contains non-trimmable whitespace outside of quotes \"\"   hi \""),
+		expectedOutput: "",
+	},
+	"negative_test_non_started_double_quote": {
+		format: "echo %s",
+		args: iface([]string{"   hi \""}),
+		expectedError: errors.New("argument contains non-trimmable whitespace outside of quotes \"   hi \"\""),
+		expectedOutput: "",
+	},
+	"negative_test_non_terminated_single_quote": {
+		format: "echo %s",
+		args: iface([]string{"'   hi "}),
+		expectedError: errors.New("argument contains non-trimmable whitespace outside of quotes \"'   hi \""),
+		expectedOutput: "",
+	},
+	"negative_test_non_started_single_quote": {
+		format: "echo %s",
+		args: iface([]string{"   hi '"}),
+		expectedError: errors.New("argument contains non-trimmable whitespace outside of quotes \"   hi '\""),
+		expectedOutput: "",
+	},
+}
+
+func TestPrepareString(t *testing.T) {
+	var mixedArguments []interface{}
+	mixedArguments = append(mixedArguments, 1)
+	mixedArguments = append(mixedArguments, "host")
+
+	for testName, testCase := range prepareStringTestCases {
+		var inputArgs []interface{}
+		inputArgs = testCase.args
+		if testName == "mixed_argument_types" {
+			inputArgs = mixedArguments
+		}
+		actualOutput, actualErr := utils.PrepareString(testCase.format, inputArgs...)
+		assert.Equal(t, testCase.expectedError, actualErr)
+		assert.Equal(t, testCase.expectedOutput, actualOutput)
+	}
+}
+
+// iface is a utility function to convert a string array into an interface array for compatibility with fmt APIs.
+func iface(list []string) []interface{} {
+	vals := make([]interface{}, len(list))
+	for i, v := range list {
+		vals[i] = v
+	}
+	return vals
+}


### PR DESCRIPTION
There are several clients that form CLI command strings using fmt.Sprintf(...).
Although this utility is great, it lacks in sanitization and input checking.
The raw input is trusted and spewed to the output string.

This change introduces a "utils" package which contains common utilities for
consumption from both generic and cnf-specific test cases.  The first utility
method provided is "PrepareString".  PrepareString is a lightweight wrapper
around fmt.Sprintf(...) which checks that input arguments post-trim do not
contain whitespace.  The API signature fmt.Sprintf(string, ...interface{})
were not appropriate here, since we are just substituting strings;  thus
PrepareString(string, ...string) is used instead.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>