### PR TITLE
Fix Casa CNF specific configuration path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 	build-generic-cnf-tests \
 	clean \
 	cnf-tests \
+	dependencies \
 	deps-update \
 	generic-cnf-tests \
 	mocks \
@@ -11,6 +12,12 @@
 
 # Export GO111MODULE=on to enable project to be built from within GOPATH/src
 export GO111MODULE=on
+
+ifeq (,$(shell go env GOBIN))
+  GOBIN=$(shell go env GOPATH)/bin
+else
+  GOBIN=$(shell go env GOBIN)
+endif
 
 export COMMON_GINKGO_ARGS=-ginkgo.v -junit . -report .
 export COMMON_GO_ARGS=-race
@@ -24,7 +31,7 @@ generic-cnf-tests: build build-cnf-tests run-generic-cnf-tests
 cnf-tests: build build-cnf-tests run-cnf-tests
 
 build-cnf-tests:
-	ginkgo build ./test-network-function
+	PATH=${PATH}:${GOBIN} ginkgo build ./test-network-function
 
 run-generic-cnf-tests:
 	cd ./test-network-function && ./test-network-function.test -ginkgo.focus="generic" ${COMMON_GINKGO_ARGS}
@@ -49,3 +56,7 @@ clean:
 	go clean
 	rm -f ./test-network-function/test-network-function.test
 	rm -f ./test-network-function/cnf-certification-tests_junit.xml
+
+dependencies:
+	go get github.com/onsi/ginkgo/ginkgo
+	go get github.com/onsi/gomega/...

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/golang/mock v1.4.3
 	github.com/google/goexpect v0.0.0-20200816234442-b5b77125c2c5
 	github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f // indirect
-	github.com/onsi/ginkgo v1.14.0
-	github.com/onsi/gomega v1.10.1
+	github.com/onsi/ginkgo v1.14.1
+	github.com/onsi/gomega v1.10.2
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.2.2
 	google.golang.org/grpc v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -48,9 +48,13 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.14.1 h1:jMU0WaQrP0a/YAEq8eJmJKjBoMs+pClEr1vDMlM/Do4=
+github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
+github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/test-network-function/cnf-specific/casa/configuration/configuration.go
+++ b/test-network-function/cnf-specific/casa/configuration/configuration.go
@@ -11,11 +11,12 @@ const (
 	casaCNFTestConfigurationFilePathEnvironmentVariableKey = "CASA_CNF_TEST_CONFIGURATION_PATH"
 )
 
-var defaultConfigurationFilePath = path.Join("cnf-specific", "casa", "cnf", "casa-cnf-test-configuration.yaml")
+var defaultConfigurationFilePath = path.Join("cnf-specific", "casa", "casa-cnf-test-configuration.yaml")
 
 func GetCasaCNFTestConfiguration() (*CasaCNFConfiguration, error) {
 	config := &CasaCNFConfiguration{}
-	yamlFile, err := ioutil.ReadFile(getCasaCNFConfigurationFilePathFromEnvironment())
+	configFilePath := getCasaCNFConfigurationFilePathFromEnvironment()
+	yamlFile, err := ioutil.ReadFile(configFilePath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When tested in NM, the environment variable was sourced rather than using
the default.  This fixes the default.  Additionally, sets up a Makefile
target to install dependencies.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>