### PR TITLE
Adding operator testing for check for CSV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,14 +32,22 @@ generic-cnf-tests: build build-cnf-tests run-generic-cnf-tests
 
 cnf-tests: build build-cnf-tests run-cnf-tests
 
+operator-cnf-tests: build build-cnf-operator-tests run-operator-tests
+
 build-cnf-tests:
 	PATH=${PATH}:${GOBIN} ginkgo build ./test-network-function
+
+build-cnf-operator-tests:
+	PATH=${PATH}:${GOBIN} ginkgo build ./test-network-function/operator-test --tags operator_suite
 
 run-generic-cnf-tests:
 	cd ./test-network-function && ./test-network-function.test -ginkgo.focus="generic" ${COMMON_GINKGO_ARGS}
 
 run-cnf-tests:
 	cd ./test-network-function && ./test-network-function.test $COMMON_GINKGO_ARGS
+
+run-operator-tests:
+	cd ./test-network-function/operator-test && ./operator-test.test  $COMMON_GINKGO_ARGS
 
 deps-update:
 	go mod tidy && \
@@ -61,6 +69,8 @@ clean:
 	go clean
 	rm -f ./test-network-function/test-network-function.test
 	rm -f ./test-network-function/cnf-certification-tests_junit.xml
+	rm -f ./test-network-function/operator-test/operator-test.test
+	rm -f ./test-network-function/operator-test/cnf-operator-certification-tests_junit.xml
 
 dependencies:
 	go get github.com/onsi/ginkgo/ginkgo

--- a/README.md
+++ b/README.md
@@ -274,3 +274,33 @@ cd ./test-network-function && ./test-network-function.test -ginkgo.v -ginkgo.foc
 ```
 
 A JUnit report containing results is created at `test-network-function/cnf-certification-tests_junit.xml`.
+
+### Run an Operator Test Suite
+
+In order to run an operator test suite, `operator-test` for example, issue the following command:
+
+```shell script
+make build build-cnf-operator-tests
+cd ./test-network-function/operator-test && ./operator-test.test -ginkgo.v -ginkgo.focus="operatr_test" -junit . -report .
+```
+
+Test Configuration
+ 
+You can either edit the provided config at `test-network-function/operator-test/config/config.yml`
+or you can pass config with `-config` flag to the test suite
+
+Sample config.yml
+
+    ---
+    csv:
+      name: "etcdoperator.v0.9.4"
+      namespace: "my-etcd"
+      status: "Succeeded"
+      
+```
+cd ./test-network-function/operator-test && ./operator-test.test -config=config.yml  -ginkgo.v -ginkgo.focus="operatr_test" -junit . -report .
+```
+
+
+A JUnit report containing results is created at `test-network-function/operator-test/cnf-operator-certification-tests_junit.xml`.
+

--- a/pkg/tnf/handlers/operator/config/config.go
+++ b/pkg/tnf/handlers/operator/config/config.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"flag"
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"os"
+)
+
+//String that contains the configured configuration path
+var configPath = flag.String("config", "./config/config.yml", "path to config file")
+
+//Config struct for configuring operator test
+type Config struct {
+	//Csv is a clusterServiceVersion which contains the packaging details of the operator
+	Csv struct {
+		//Name of csv  operator package with version name
+		Name string `yaml:"name" json:"name"`
+		//Namespace where the operator will be running
+		Namespace string `yaml:"namespace" json:"namespace"`
+		//Expected status of the Csv
+		Status string `yaml:"status" json:"status"`
+	} `yaml:"csv" json:"csv"`
+}
+
+//NewConfig  returns a new decoded Config struct
+func NewConfig(configPath string) (*Config, error) {
+	var file *os.File
+	var err error
+	// Create config structure
+	config := &Config{}
+	// Open config file
+	if file, err = os.Open(configPath); err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	// Init new YAML decode
+	d := yaml.NewDecoder(file)
+	// Start YAML decoding from file
+	if err := d.Decode(&config); err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+// ValidateConfigPath just makes sure, that the path provided is a file,
+// that can be read
+func validateConfigPath(path string) error {
+	s, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if s.IsDir() {
+		return fmt.Errorf("'%s' is a directory, not a normal file", path)
+	}
+	return nil
+}
+
+// parseFlags will create and parse the CLI flags
+// and return the path to be used elsewhere
+func parseFlags() (string, error) {
+	var err error
+	flag.Parse()
+	// Validate the path first
+	if err = validateConfigPath(*configPath); err != nil {
+		return "", err
+	}
+	// Return the configuration path
+	return *configPath, nil
+}
+
+// GetConfig returns the Operator TestConfig configuration.
+func GetConfig() (*Config, error) {
+	// Generate our config based on the config supplied
+	// by the user in the flags
+	cfgPath, err := parseFlags()
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := NewConfig(cfgPath)
+	return cfg, err
+}

--- a/pkg/tnf/handlers/operator/config/config.yml
+++ b/pkg/tnf/handlers/operator/config/config.yml
@@ -1,0 +1,7 @@
+---
+csv:
+  name: "etcdoperator.v0.9.4"
+  namespace: "my-etcd"
+  status: "Succeeded"
+
+

--- a/pkg/tnf/handlers/operator/config/config_test.go
+++ b/pkg/tnf/handlers/operator/config/config_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNewConfig(t *testing.T) {
+	file, err := ioutil.TempFile("", "testconfig.yml")
+	defer os.Remove(file.Name())
+	if err != nil {
+		fmt.Println(err)
+		assert.Fail(t, "failed to parse valid test file")
+	}
+	cfg, err := NewConfig(file.Name())
+	assert.Nil(t, cfg)
+	assert.NotNil(t, err)
+	cfg, err = NewConfig(file.Name() + "bad_file")
+	assert.Nil(t, cfg)
+	assert.NotNil(t, err)
+
+	cfg, err = NewConfig("config.yml")
+	assert.NotNil(t, cfg)
+	assert.Nil(t, err)
+}
+
+func TestValidateConfigPath(t *testing.T) {
+	var tests = []struct {
+		path  string
+		error error
+	}{
+		{".", fmt.Errorf("'.' is a directory, not a normal file")},
+		{"./config", fmt.Errorf("./config is a directory, not a normal file")},
+		{"./config.yml", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			err := validateConfigPath(tt.path)
+			if err == nil && tt.error != nil {
+				assert.Fail(t, err.Error())
+			}
+
+		})
+	}
+}
+
+//TestConfigLoadFunction ... Test if config is read correctly
+func TestConfigLoadFunction(t *testing.T) {
+	var test Config
+	test.Csv.Name = "etcdoperator.v0.9.4"
+	test.Csv.Namespace = "my-etcd"
+	test.Csv.Status = "Succeeded"
+	path, _ := os.Getwd()
+
+	var tests = []struct {
+		args  []string
+		conf  Config
+		error string
+	}{
+		{[]string{"./operator-test"}, test, "no such file or directory"},
+		{[]string{"./operator-test", "-config", "config_not_exists"}, test, "no such file or directory"},
+		{[]string{"./operator-test", "-config", path}, test, "is a directory, not a normal file"},
+		{[]string{"./operator-test", "-config", "config.yml"}, test, ""},
+		{[]string{"./operator-test", "-config", path + "/config.yml"}, test, ""},
+	}
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.args, " "), func(t *testing.T) {
+			os.Args = tt.args
+			if len(tt.args) > 2 {
+				configPath = &tt.args[2]
+			}
+			testConfig, err := GetConfig()
+			if err == nil {
+				assert.Nil(t, err)
+				assert.NotNil(t, testConfig)
+				assert.Equal(t, *testConfig, tt.conf)
+			} else {
+				assert.NotNil(t, err)
+				assert.Contains(t, err.Error(), tt.error)
+			}
+		})
+	}
+}

--- a/pkg/tnf/handlers/operator/config/doc.go
+++ b/pkg/tnf/handlers/operator/config/doc.go
@@ -1,0 +1,1 @@
+package config

--- a/pkg/tnf/handlers/operator/csv.go
+++ b/pkg/tnf/handlers/operator/csv.go
@@ -1,0 +1,82 @@
+package operator
+
+import (
+	"fmt"
+	"github.com/redhat-nfvpe/test-network-function/internal/reel"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	// CheckCSVCommand is the OC command for checking for CSV.
+	CheckCSVCommand = "oc get csv %s -n %s -o json | jq -r '.status.phase'"
+)
+
+//Csv Cluster service version , manifests of the operator.
+type Csv struct {
+	result       int
+	timeout      time.Duration
+	args         []string
+	Name         string
+	Status       string
+	Namespace    string
+	ExpectStatus string
+}
+
+// Args returns the command line args for the test.
+func (c *Csv) Args() []string {
+	return c.args
+}
+
+// Timeout return the timeout for the test.
+func (c *Csv) Timeout() time.Duration {
+	return c.timeout
+}
+
+// Result returns the test result.
+func (c *Csv) Result() int {
+	return c.result
+}
+
+// ReelFirst returns a step which expects an csv status for the given csv.
+func (c *Csv) ReelFirst() *reel.Step {
+	return &reel.Step{
+		Expect:  []string{c.ExpectStatus},
+		Timeout: c.timeout,
+	}
+}
+
+// ReelMatch parses the csv status output and set the test result on match.
+// Returns no step; the test is complete.
+func (c *Csv) ReelMatch(_ string, _ string, match string) *reel.Step {
+	re := regexp.MustCompile(c.ExpectStatus)
+	matched := re.MatchString(match)
+	if matched {
+		c.result = tnf.SUCCESS
+	}
+	return nil
+}
+
+// ReelTimeout does nothing;
+func (c *Csv) ReelTimeout() *reel.Step {
+	return nil
+}
+
+// ReelEOF does nothing.
+func (c *Csv) ReelEOF() {
+}
+
+// NewCsv creates a `Operator Csv` test which determines the "csv" status.
+func NewCsv(name, namespace string, expectedStatus string, timeout time.Duration) *Csv {
+	args := strings.Split(fmt.Sprintf(CheckCSVCommand, name, namespace), " ")
+	return &Csv{
+		Name:         name,
+		Namespace:    namespace,
+		ExpectStatus: expectedStatus,
+		result:       tnf.ERROR,
+		timeout:      timeout,
+		args:         args,
+	}
+}

--- a/pkg/tnf/handlers/operator/csv_test.go
+++ b/pkg/tnf/handlers/operator/csv_test.go
@@ -1,0 +1,56 @@
+package operator_test
+
+import (
+	"fmt"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/handlers/operator"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testTimeoutDuration = time.Second * 2
+	csvName             = "csv-test-v1.0"
+	namespace           = "test"
+	expectedStatus      = "Succeeded"
+)
+
+func TestCsv_Args(t *testing.T) {
+	c := operator.NewCsv(csvName, namespace, expectedStatus, testTimeoutDuration)
+	args := strings.Split(fmt.Sprintf(operator.CheckCSVCommand, c.Name, c.Namespace), " ")
+	fmt.Println(args)
+	assert.Equal(t, args, c.Args())
+}
+func TestCsv_ReelFirst(t *testing.T) {
+	c := operator.NewCsv(csvName, namespace, expectedStatus, testTimeoutDuration)
+	step := c.ReelFirst()
+	assert.Equal(t, "", step.Execute)
+	fmt.Println(c.ExpectStatus)
+	assert.Equal(t, []string{c.ExpectStatus}, step.Expect)
+	assert.Equal(t, testTimeoutDuration, step.Timeout)
+}
+
+func TestCsv_ReelEof(t *testing.T) {
+	c := operator.NewCsv(csvName, namespace, expectedStatus, testTimeoutDuration)
+	// just ensures lack of panic
+	c.ReelEOF()
+}
+
+func TestCsv_ReelTimeout(t *testing.T) {
+	c := operator.NewCsv(csvName, namespace, expectedStatus, testTimeoutDuration)
+	step := c.ReelTimeout()
+	assert.Nil(t, step)
+}
+func TestCsv_ReelMatch(t *testing.T) {
+	c := operator.NewCsv(csvName, namespace, expectedStatus, testTimeoutDuration)
+	step := c.ReelMatch("", "", "Succeeded")
+	assert.Nil(t, step)
+	assert.Equal(t, tnf.SUCCESS, c.Result())
+}
+func TestNewCsv(t *testing.T) {
+	c := operator.NewCsv(csvName, namespace, expectedStatus, testTimeoutDuration)
+	assert.Equal(t, tnf.ERROR, c.Result())
+	assert.Equal(t, testTimeoutDuration, c.Timeout())
+}

--- a/pkg/tnf/handlers/operator/doc.go
+++ b/pkg/tnf/handlers/operator/doc.go
@@ -1,0 +1,1 @@
+package operator

--- a/test-network-function/operator-test/config/config.yml
+++ b/test-network-function/operator-test/config/config.yml
@@ -1,0 +1,5 @@
+---
+csv:
+  name: "etcdoperator.v0.9.4"
+  namespace: "my-etcd"
+  status: "Succeeded"

--- a/test-network-function/operator-test/operator_cnf_test.go
+++ b/test-network-function/operator-test/operator_cnf_test.go
@@ -1,0 +1,57 @@
+package operator
+
+import (
+	expect "github.com/google/goexpect"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"github.com/redhat-nfvpe/test-network-function/internal/reel"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	. "github.com/redhat-nfvpe/test-network-function/pkg/tnf/handlers/operator"
+	. "github.com/redhat-nfvpe/test-network-function/pkg/tnf/handlers/operator/config"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/interactive"
+	"time"
+)
+
+const (
+	// The default test timeout.
+	defaultTimeoutSeconds = 10
+)
+
+var (
+	defaultTimeout     = time.Duration(defaultTimeoutSeconds) * time.Second
+	context            *interactive.Context
+	err                error
+	OperatorTestConfig *Config
+)
+
+var _ = ginkgo.BeforeSuite(func() {
+	OperatorTestConfig, _ = GetConfig()
+	gomega.Expect(OperatorTestConfig).ToNot(gomega.BeNil())
+})
+
+var _ = ginkgo.Describe("operator_test", func() {
+
+	ginkgo.When("A local shell is spawned", func() {
+		goExpectSpawner := interactive.NewGoExpectSpawner()
+		var spawner interactive.Spawner = goExpectSpawner
+		context, err = interactive.SpawnShell(&spawner, defaultTimeout, expect.Verbose(true))
+		gomega.Expect(err).To(gomega.BeNil())
+		gomega.Expect(context).ToNot(gomega.BeNil())
+		gomega.Expect(context.GetExpecter()).ToNot(gomega.BeNil())
+	})
+
+	ginkgo.When("Operator is already installed", func() {
+		ginkgo.It("Checks if the CSV is installed successfully", func() {
+			csv := NewCsv(OperatorTestConfig.Csv.Name, OperatorTestConfig.Csv.Namespace, OperatorTestConfig.Csv.Status, defaultTimeout)
+			csv.ExpectStatus = OperatorTestConfig.Csv.Status
+			gomega.Expect(csv).ToNot(gomega.BeNil())
+			test, err := tnf.NewTest(context.GetExpecter(), csv, []reel.Handler{csv}, context.GetErrorChannel())
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(test).ToNot(gomega.BeNil())
+			testResult, err := test.Run()
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(testResult).To(gomega.Equal(tnf.SUCCESS))
+		})
+	})
+
+})

--- a/test-network-function/operator-test/operator_test_suite_test.go
+++ b/test-network-function/operator-test/operator_test_suite_test.go
@@ -1,0 +1,44 @@
+package operator
+
+import (
+	"flag"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+	ginkgoreporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
+	"path"
+	"testing"
+)
+
+const (
+	defaultCliArgValue            = ""
+	CnfCertificationTestSuiteName = "CNF Certification Operator Test Suite"
+	junitFlagKey                  = "junit"
+	JunitXMLFileName              = "cnf-operator-certification-tests_junit.xml"
+	reportFlagKey                 = "report"
+)
+
+var junitPath *string
+var reportPath *string
+
+func init() {
+	junitPath = flag.String(junitFlagKey, defaultCliArgValue,
+		"the path for the junit format report")
+	reportPath = flag.String(reportFlagKey, defaultCliArgValue,
+		"the path of the report file containing details for failed tests")
+}
+
+//TestOperatorTest Entry function to run k8s operator test  cases
+func TestOperatorTest(t *testing.T) {
+	flag.Parse()
+	RegisterFailHandler(Fail)
+	var ginkgoReporters []Reporter
+	if ginkgoreporters.Polarion.Run {
+		ginkgoReporters = append(ginkgoReporters, &ginkgoreporters.Polarion)
+	}
+	if *junitPath != "" {
+		junitFile := path.Join(*junitPath, JunitXMLFileName)
+		ginkgoReporters = append(ginkgoReporters, reporters.NewJUnitReporter(junitFile))
+	}
+	RunSpecsWithDefaultAndCustomReporters(t, CnfCertificationTestSuiteName, ginkgoReporters)
+}


### PR DESCRIPTION
Addressing : https://issues.redhat.com/browse/CTONET-546
Add operator test, to check if CSV is installed successfully.
This test asserting information including the expected status is configured via Yaml along with other parameters.
The status is what we are asserting on, making sure the CSV  with the specified name under the specified namespace  exists and has status =" Succeeded" 
This way we can assert different status by changing it via the config file.

Sample config. 
`
---
csv:
  name: "etcdoperator.v0.9.4"
  namespace: "my-etcd"
  status: "Succeeded"

`