### PR TITLE
Add golangci-lint to "lint" Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ unit-tests:
 
 lint:
 	golint `go list ./... | grep -v vendor`
+	golangci-lint run
 
 .PHONY: clean
 clean:

--- a/cmd/ping/main.go
+++ b/cmd/ping/main.go
@@ -37,7 +37,9 @@ func main() {
 	ping, timeoutDuration := parseArgs()
 	goExpectSpawner := interactive.NewGoExpectSpawner()
 	var spawner interactive.Spawner = goExpectSpawner
-	context, err := interactive.SpawnShell(&spawner, timeoutDuration, expect.Verbose(true))
+	var err error
+	var context *interactive.Context
+	context, err = interactive.SpawnShell(&spawner, timeoutDuration, expect.Verbose(true))
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -48,6 +50,9 @@ func main() {
 
 	if err == nil {
 		result, err = tester.Run()
+		if err != nil {
+			fmt.Fprintf(os.Stderr,"Fatal Error Running Test: %v\n", err)
+		}
 	} else {
 		fmt.Fprintln(os.Stderr, err)
 	}

--- a/internal/reel/reel.go
+++ b/internal/reel/reel.go
@@ -141,7 +141,7 @@ func (reel *Reel) Step(step *Step, handler Handler) error {
 				return err
 			}
 		} else {
-			if results != nil && len(results) > 0 {
+			if len(results) > 0 {
 				result := results[0]
 				output := result.Output
 				match := result.Match[0]

--- a/pkg/config/pool_test.go
+++ b/pkg/config/pool_test.go
@@ -14,8 +14,6 @@ func TestGetInstance(t *testing.T) {
 // Also tests GetConfigurations
 func TestPool_RegisterConfiguration(t *testing.T) {
 	type arbitraryConfig struct {
-		name string
-		id   int
 	}
 	assert.Nil(t, config.GetInstance().RegisterConfiguration("someKey", &arbitraryConfig{}))
 	assert.Contains(t, config.GetInstance().GetConfigurations(), "someKey")

--- a/pkg/tnf/handlers/base/redhat/version.go
+++ b/pkg/tnf/handlers/base/redhat/version.go
@@ -24,8 +24,6 @@ type Release struct {
 	timeout time.Duration
 	// args stores the command and arguments.
 	args []string
-	// release contains the contents of /etc/redhat-release if it exists, or "NOT Red Hat Based" if it does not exist.
-	release string
 	// isRedHatBased contains whether the container is based on Red Hat technologies.
 	isRedHatBased bool
 }

--- a/pkg/tnf/handlers/container/pod.go
+++ b/pkg/tnf/handlers/container/pod.go
@@ -15,7 +15,6 @@ type Pod struct {
 	result       int
 	timeout      time.Duration
 	args         []string
-	status       string
 	Command      string
 	Name         string
 	Namespace    string

--- a/pkg/tnf/handlers/container/testcases/base.go
+++ b/pkg/tnf/handlers/container/testcases/base.go
@@ -27,13 +27,6 @@ var OutRegExp = map[string]string{
 	"ERROR":         "Unknown out expression set",
 }
 
-func getOutRegExp(key string) string {
-	if val, ok := OutRegExp[key]; ok {
-		return val
-	}
-	return OutRegExp["ERROR"]
-}
-
 //BaseTestCaseConfigSpec slcie of test configurations template
 type BaseTestCaseConfigSpec struct {
 	TestCase []BaseTestCase `yaml:"testcase" json:"testcase"`

--- a/pkg/tnf/test.go
+++ b/pkg/tnf/test.go
@@ -78,8 +78,7 @@ func (t *Test) ReelEOF() {
 
 // NewTest creates a new Test given a chain of Handlers.
 func NewTest(expecter *expect.Expecter, tester Tester, chain []reel.Handler, errorChannel <-chan error) (*Test, error) {
-	var args []string
-	args = tester.Args()
+	args := tester.Args()
 	runner, err := reel.NewReel(expecter, args, errorChannel)
 	if err != nil {
 		return nil, err

--- a/pkg/tnf/test_test.go
+++ b/pkg/tnf/test_test.go
@@ -22,7 +22,6 @@ const (
 var (
 	defaultTestCommand = []string{"ls"}
 	sendError          = errors.New("generic send error")
-	runnerError        = errors.New("runner run error")
 )
 
 type newTestTestCase struct {

--- a/test-network-function/cnf-specific/casa/cnf/nrf/nrfid_test.go
+++ b/test-network-function/cnf-specific/casa/cnf/nrf/nrfid_test.go
@@ -23,7 +23,6 @@ var defaultTestTimeout = time.Second * 10
 type genericRegistrationTestCase struct {
 	timeout          time.Duration
 	namespace        string
-	expectedArgs     []string
 	reelMatchPattern string
 	expectedResult   int
 	expectedNRFUuids []string
@@ -33,7 +32,6 @@ var genericRegistrationTestCases = map[string]*genericRegistrationTestCase{
 	"real_test_data": {
 		timeout:          defaultTestTimeout,
 		namespace:        defaultNamespace,
-		expectedArgs:     []string{"oc", "-n", "default", "get", "nfregistrations.mgmt.casa.io", "$(oc", "-n", "default", "get", "nfregistrations.mgmt.casa.io", "|", "awk", "{\"print", "$2\"}", "|", "xargs", "-n", "1)"},
 		reelMatchPattern: nrf.OutputRegexString,
 		expectedResult:   tnf.SUCCESS,
 		expectedNRFUuids: []string{
@@ -44,7 +42,6 @@ var genericRegistrationTestCases = map[string]*genericRegistrationTestCase{
 	"default_test_case": {
 		timeout:          defaultTestTimeout,
 		namespace:        defaultNamespace,
-		expectedArgs:     []string{"oc", "-n", "default", "get", "nfregistrations.mgmt.casa.io", "$(oc", "-n", "default", "get", "nfregistrations.mgmt.casa.io", "|", "awk", "{\"print", "$2\"}", "|", "xargs", "-n", "1)"},
 		reelMatchPattern: nrf.OutputRegexString,
 		expectedResult:   tnf.SUCCESS,
 		expectedNRFUuids: []string{
@@ -58,7 +55,6 @@ var genericRegistrationTestCases = map[string]*genericRegistrationTestCase{
 	"no_nrfs_registered": {
 		timeout:          time.Hour * 24,
 		namespace:        "someOtherNamespace",
-		expectedArgs:     []string{"oc", "-n", "someOtherNamespace", "get", "nfregistrations.mgmt.casa.io", "$(oc", "-n", "someOtherNamespace", "get", "nfregistrations.mgmt.casa.io", "|", "awk", "{\"print", "$2\"}", "|", "xargs", "-n", "1)"},
 		reelMatchPattern: nrf.CommandCompleteRegexString,
 		expectedResult:   tnf.FAILURE,
 		expectedNRFUuids: []string{},
@@ -66,7 +62,6 @@ var genericRegistrationTestCases = map[string]*genericRegistrationTestCase{
 	"incorrect_match": {
 		timeout:          defaultTestTimeout,
 		namespace:        defaultNamespace,
-		expectedArgs:     []string{"oc", "-n", "default", "get", "nfregistrations.mgmt.casa.io", "$(oc", "-n", "default", "get", "nfregistrations.mgmt.casa.io", "|", "awk", "{\"print", "$2\"}", "|", "xargs", "-n", "1)"},
 		reelMatchPattern: "some_random_match_pattern",
 		expectedResult:   tnf.ERROR,
 		expectedNRFUuids: []string{},

--- a/test-network-function/cnf-specific/casa/cnf/suite.go
+++ b/test-network-function/cnf-specific/casa/cnf/suite.go
@@ -23,7 +23,7 @@ var _ = ginkgo.Describe("casa-cnf", func() {
 	var config *configuration.CasaCNFConfiguration
 	var err error
 	config, err = configuration.GetCasaCNFTestConfiguration()
-	log.Info("Casa CNF Specific Configuration: %s", config)
+	log.Infof("Casa CNF Specific Configuration: %s", config)
 	gomega.Expect(err).To(gomega.BeNil())
 	gomega.Expect(config).ToNot(gomega.BeNil())
 
@@ -53,7 +53,6 @@ var _ = ginkgo.Describe("casa-cnf", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(testResult).To(gomega.Equal(tnf.SUCCESS))
 			nrfs = registrationTest.GetRegisteredNRFs()
-			log.Infof("nrfs=%s", nrfs)
 			for _, cnfType := range cnfTypes {
 				nrfInstalled := getNRF(nrfs, cnfType)
 				gomega.Expect(nrfInstalled).ToNot(gomega.BeNil())

--- a/test-network-function/generic/configuration.go
+++ b/test-network-function/generic/configuration.go
@@ -59,7 +59,11 @@ func GetConfiguration(filepath string) (*TestConfiguration, error) {
 		err = json.Unmarshal(contents, config)
 	}
 
-	(*configpool.GetInstance()).RegisterConfiguration(configurationKey, config)
+	if err != nil {
+		return nil, err
+	}
+
+	err = (*configpool.GetInstance()).RegisterConfiguration(configurationKey, config)
 
 	return config, err
 }

--- a/test-network-function/generic/suite.go
+++ b/test-network-function/generic/suite.go
@@ -41,8 +41,8 @@ func getOcSession(pod, container, namespace string, timeout time.Duration, optio
 	var spawner interactive.Spawner = goExpectSpawner
 
 	go func(chOut <-chan error) {
-		oc, chOut, err := interactive.SpawnOc(&spawner, pod, container, namespace, timeout, options...)
-		gomega.Expect(chOut).ToNot(gomega.BeNil())
+		oc, spawnChan, err := interactive.SpawnOc(&spawner, pod, container, namespace, timeout, options...)
+		gomega.Expect(spawnChan).ToNot(gomega.BeNil())
 		gomega.Expect(err).To(gomega.BeNil())
 		ocChan <- oc
 	}(chOut)
@@ -75,7 +75,7 @@ type container struct {
 func createContainersUnderTest(config *TestConfiguration) map[ContainerIdentifier]*container {
 	containersUnderTest := map[ContainerIdentifier]*container{}
 	for containerID, containerConfig := range config.ContainersUnderTest {
-		oc := getOcSession(containerID.PodName, containerID.ContainerName, containerID.Namespace, defaultTimeout, expect.Verbose(true))
+		oc := getOcSession(containerID.PodName, containerID.ContainerName, containerID.Namespace, defaultTimeout, defaultExpectArgs)
 		defaultIPAddress := getContainerDefaultNetworkIPAddress(oc, containerConfig.DefaultNetworkDevice)
 		containersUnderTest[containerID] = &container{containerConfiguration: containerConfig, oc: oc, defaultNetworkIPAddress: defaultIPAddress}
 	}
@@ -87,7 +87,7 @@ func createContainersUnderTest(config *TestConfiguration) map[ContainerIdentifie
 func createPartnerContainers(config *TestConfiguration) map[ContainerIdentifier]*container {
 	partnerContainers := map[ContainerIdentifier]*container{}
 	for containerID, containerConfig := range config.PartnerContainers {
-		oc := getOcSession(containerID.PodName, containerID.ContainerName, containerID.Namespace, defaultTimeout, expect.Verbose(true))
+		oc := getOcSession(containerID.PodName, containerID.ContainerName, containerID.Namespace, defaultTimeout, defaultExpectArgs)
 		defaultIPAddress := getContainerDefaultNetworkIPAddress(oc, containerConfig.DefaultNetworkDevice)
 		partnerContainers[containerID] = &container{containerConfiguration: containerConfig, oc: oc, defaultNetworkIPAddress: defaultIPAddress}
 	}


### PR DESCRIPTION
Adds golangci-lint to "lint" Makefile target and fixes any existing
issues in the codebase.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>