### PR TITLE
Append new line character for reel.Step.Execute when missing

### DIFF
--- a/internal/reel/reel.go
+++ b/internal/reel/reel.go
@@ -102,12 +102,21 @@ func generateCase(expectation string, firstMatch *string) *expect.Case {
 	}}
 }
 
+// appendNewLineIfNecessary appends a new line to the end of execute if it doesn't already end in a new line.
+func appendNewlineIfNecessary(execute string) string {
+	if strings.HasSuffix(execute, "\n") {
+		return execute
+	}
+	return execute + "\n"
+}
+
 // Each Step can have exactly one execution string (Step.Execute).  This method follows the Adapter design pattern;  a
 // single raw execution string is converted into a corresponding expect.Batcher.  The function returns an array of
 // expect.Batcher, as it is expected that there are likely expectations to follow.
 func generateBatcher(execute string) []expect.Batcher {
 	var batcher []expect.Batcher
 	if execute != "" {
+		execute = appendNewlineIfNecessary(execute)
 		batcher = append(batcher, &expect.BSnd{S: execute})
 	}
 	return batcher


### PR DESCRIPTION
If a reel.Step.Execute is missing a newline at the end, it is the same as
inputting a command to a terminal and never pressing return.  Thus, this
makes the state machine implementation more defensive by adding a newline
if one is missing.  There is no known use case at this time when this is
not desired.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>