### PR TITLE
Register container and operator configurations with the pool

### DIFF
--- a/test-network-function/container/suite.go
+++ b/test-network-function/container/suite.go
@@ -26,6 +26,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/redhat-nfvpe/test-network-function/internal/api"
+	configpool "github.com/redhat-nfvpe/test-network-function/pkg/config"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
 	containerTestConfig "github.com/redhat-nfvpe/test-network-function/pkg/tnf/config"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/handlers/container"
@@ -76,6 +77,9 @@ var _ = ginkgo.Describe(testSpecName, func() {
 		}
 		// Gather facts for containers
 		podFacts, err := testcases.LoadCnfTestCaseSpecs(testcases.GatherFacts)
+		//nolint:errcheck // Even if not run, each of the suites attempts to initialise the config. This results in
+		// RegisterConfigurations erroring due to duplicate keys.
+		(*configpool.GetInstance()).RegisterConfiguration(testSpecName, podFacts)
 		gomega.Expect(err).To(gomega.BeNil())
 		for _, factsTest := range podFacts.TestCase {
 			args := strings.Split(fmt.Sprintf(factsTest.Command, cnf.Name, cnf.Namespace), " ")

--- a/test-network-function/operator/suite.go
+++ b/test-network-function/operator/suite.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/redhat-nfvpe/test-network-function/internal/api"
+	configpool "github.com/redhat-nfvpe/test-network-function/pkg/config"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
 	operatorTestConfig "github.com/redhat-nfvpe/test-network-function/pkg/tnf/config"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/handlers/operator"
@@ -77,6 +78,9 @@ var _ = ginkgo.Describe(testSpecName, func() {
 		// TODO: Gather facts for operator
 		for _, testType := range operator.Tests {
 			testFile, err := testcases.LoadConfiguredTestFile(configuredTestFile)
+			//nolint:errcheck // Even if not run, each of the suites attempts to initialise the config. This results in
+			// RegisterConfigurations erroring due to duplicate keys.
+			(*configpool.GetInstance()).RegisterConfiguration(testSpecName, testFile)
 			gomega.Expect(testFile).ToNot(gomega.BeNil())
 			gomega.Expect(err).To(gomega.BeNil())
 			testConfigure := testcases.ContainsConfiguredTest(testFile.OperatorTest, testType)

--- a/test-network-function/suite_test.go
+++ b/test-network-function/suite_test.go
@@ -48,6 +48,8 @@ const (
 	junitFlagKey                  = "junit"
 	JunitXMLFileName              = "cnf-certification-tests_junit.xml"
 	reportFlagKey                 = "report"
+	// dateTimeFormatDirective is the directive used to format date/time according to ISO 8601.
+	dateTimeFormatDirective       = "2006-01-02T15:04:05+00:00"
 )
 
 var (
@@ -75,7 +77,7 @@ func createClaimRoot() *claim.Root {
 	startTime := time.Now()
 	c := &claim.Claim{
 		Metadata: &claim.Metadata{
-			StartTime: startTime.String(),
+			StartTime: startTime.UTC().Format(dateTimeFormatDirective),
 		},
 	}
 	return &claim.Root{
@@ -140,7 +142,7 @@ func TestTest(t *testing.T) {
 	if err != nil {
 		log.Fatalf("error unmarshalling configurations: %v", err)
 	}
-	claimData.Metadata.EndTime = endTime.String()
+	claimData.Metadata.EndTime = endTime.UTC().Format(dateTimeFormatDirective)
 
 	payload, err := j.MarshalIndent(claimRoot, "", "  ")
 	if err != nil {


### PR DESCRIPTION
The container/operator configurations were never registered after
collapsing into a single suite.  This change registers the configs
so they are output as a part of claim.json.

Additionally, it was noticed that the format directive of the
startTime and endTime was not compliant with ISO 8601.  This was
changed appropriately.

Lastly, the claim startTime and endTime are converted to UTC for
consistency.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>