### PR TITLE
mapping of formal test identifier to purpose, description, and result…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/basgys/goxml2json v1.1.0
 	github.com/bitly/go-simplejson v0.5.0 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
-	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/golang/mock v1.4.4
 	github.com/google/goexpect v0.0.0-20200816234442-b5b77125c2c5
 	github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f

--- a/go.sum
+++ b/go.sum
@@ -13,7 +13,6 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/pkg/tnf/dependencies/binaries.go
+++ b/pkg/tnf/dependencies/binaries.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2020 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package dependencies
+
+const (
+	// AwkBinaryName is the name of the Unix `awk` command.
+	AwkBinaryName = "awk"
+
+	// CatBinaryName is the name of the Unix `cat` command.
+	CatBinaryName = "cat"
+
+	// HostnameBinaryName is the name of the Unix `hostname` command.
+	HostnameBinaryName = "hostname"
+
+	// IPBinaryName is the name of the Unix `ip` command.
+	IPBinaryName = "ip"
+
+	// JqBinaryName is the name of the Unix `jq` command.
+	JqBinaryName = "jq"
+
+	// OcBinaryName is the name of the OpenShift CLI client command.
+	OcBinaryName = "oc"
+
+	// PingBinaryName is the name of the Unix `ping` command.
+	PingBinaryName = "ping"
+
+	// XargsBinaryName is the name of the Unix `xargs` command.
+	XargsBinaryName = "xargs"
+)

--- a/pkg/tnf/dependencies/doc.go
+++ b/pkg/tnf/dependencies/doc.go
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+// Package dependencies provides constants related to test runtime dependencies.
+package dependencies

--- a/pkg/tnf/handlers/base/redhat/version.go
+++ b/pkg/tnf/handlers/base/redhat/version.go
@@ -17,21 +17,26 @@
 package redhat
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/dependencies"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/identifier"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/reel"
 )
 
 const (
-	// ReleaseCommand is the Unix command used to check whether a container is based on Red Hat technologies.
-	ReleaseCommand = "if [ -e /etc/redhat-release ]; then cat /etc/redhat-release; else echo \"Unknown Base Image\"; fi"
 	// NotRedHatBasedRegex is the expected output for a container that is not based on Red Hat technologies.
 	NotRedHatBasedRegex = `(?m)Unknown Base Image`
 	// VersionRegex is regular expression expected for a container based on Red Hat technologies.
 	VersionRegex = `(?m)Red Hat Enterprise Linux Server release (\d+\.\d+) \(\w+\)`
+)
+
+var (
+	// ReleaseCommand is the Unix command used to check whether a container is based on Red Hat technologies.
+	ReleaseCommand = fmt.Sprintf("if [ -e /etc/redhat-release ]; then %s /etc/redhat-release; else echo \"Unknown Base Image\"; fi", dependencies.CatBinaryName)
 )
 
 // Release is an implementation of tnf.Test used to determine whether a container is based on Red Hat technologies.

--- a/pkg/tnf/handlers/hostname/hostname.go
+++ b/pkg/tnf/handlers/hostname/hostname.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/dependencies"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/identifier"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/reel"
 )
@@ -35,7 +36,7 @@ type Hostname struct {
 
 const (
 	// Command is the command name for the unix "hostname" command.
-	Command = "hostname"
+	Command = dependencies.HostnameBinaryName
 	// SuccessfulOutputRegex is the regular expression match for hostname output.
 	SuccessfulOutputRegex = `.+`
 )

--- a/pkg/tnf/handlers/ipaddr/ipaddr.go
+++ b/pkg/tnf/handlers/ipaddr/ipaddr.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/dependencies"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/identifier"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/reel"
 )
@@ -37,11 +38,15 @@ type IPAddr struct {
 }
 
 const (
-	ipAddrCommand = "ip addr show dev"
 	// DeviceDoesNotExistRegex matches `ip addr` output when the given device does not exist.
 	DeviceDoesNotExistRegex = `(?m)Device \"(\w+)\" does not exist.$`
 	// SuccessfulOutputRegex matches `ip addr` output for a given device, and provides grouping to extract the associated Ipv4 address.
 	SuccessfulOutputRegex = `(?m)^\s+inet ((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))`
+)
+
+var (
+	// ipAddrCommand is the skeleton command used to get ip address information for a device.
+	ipAddrCommand = fmt.Sprintf("%s addr show dev", dependencies.IPBinaryName)
 )
 
 // Args returns the command line args for the test.

--- a/pkg/tnf/handlers/ping/ping.go
+++ b/pkg/tnf/handlers/ping/ping.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/dependencies"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/identifier"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/reel"
 )
@@ -124,9 +125,9 @@ func (p *Ping) GetStats() (transmitted, received, errors int) {
 // positive.
 func Command(host string, count int) []string {
 	if count > 0 {
-		return []string{"ping", "-c", strconv.Itoa(count), host}
+		return []string{dependencies.PingBinaryName, "-c", strconv.Itoa(count), host}
 	}
-	return []string{"ping", host}
+	return []string{dependencies.PingBinaryName, host}
 }
 
 // NewPing creates a new `Ping` test which pings `hosts` with `count` requests, or indefinitely if `count` is not

--- a/pkg/tnf/identifier/identifiers.go
+++ b/pkg/tnf/identifier/identifiers.go
@@ -16,6 +16,8 @@
 
 package identifier
 
+import "github.com/redhat-nfvpe/test-network-function/pkg/tnf/dependencies"
+
 const (
 	casaNRFCheckRegistrationIdentifierURL = "http://test-network-function.com/tests/casa/nrf/checkregistration"
 	casaNRFIDIdentifierURL                = "http://test-network-function.com/tests/casa/nrf/id"
@@ -25,7 +27,8 @@ const (
 	pingIdentifierURL                     = "http://test-network-function.com/tests/ping"
 	podIdentifierURL                      = "http://test-network-function.com/tests/container/pod"
 	versionIdentifierURL                  = "http://test-network-function.com/tests/generic/version"
-	versionOne                            = "v1.0.0"
+
+	versionOne = "v1.0.0"
 )
 
 const (
@@ -38,13 +41,30 @@ const (
 type TestCatalogEntry struct {
 
 	// Identifier is the unique test identifier.
-	Identifier Identifier
+	Identifier Identifier `json:"identifier" yaml:"identifier"`
 
 	// Description is a helpful description of the purpose of the test.
-	Description string
+	Description string `json:"description" yaml:"description"`
 
 	// Type is the type of the test (i.e., normative).
-	Type string
+	Type string `json:"type" yaml:"type"`
+
+	// IntrusionSettings is used to specify test intrusion behavior into a target system.
+	IntrusionSettings IntrusionSettings `json:"intrusionSettings" yaml:"intrusionSettings"`
+
+	// BinaryDependencies tracks the needed binaries to complete tests, such as `ping`.
+	BinaryDependencies []string `json:"binaryDependencies" yaml:"binaryDependencies"`
+}
+
+// IntrusionSettings is used to specify test intrusion behavior into a target system.
+type IntrusionSettings struct {
+	// ModifiesSystem records whether the test makes changes to target systems.
+	ModifiesSystem bool `json:"modifiesSystem" yaml:"modifiesSystem"`
+
+	// ModificationIsPersistent records whether the test makes a modification to the system that persists after the test
+	// completes.  This is not always negative, and could involve something like setting up a tunnel that is used in
+	// future tests.
+	ModificationIsPersistent bool `json:"modificationIsPersistent" yaml:"modificationIsPersistent"`
 }
 
 // Catalog is the test catalog.
@@ -53,41 +73,102 @@ var Catalog = map[string]TestCatalogEntry{
 		Identifier:  CasaNRFIDIdentifier,
 		Description: "A Casa cnf-specific test which checks for the existence of the AMF and SMF CNFs.  The UUIDs are gathered and stored by introspecting the \"nfregistrations.mgmt.casa.io\" Custom Resource.",
 		Type:        Normative,
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.AwkBinaryName,
+			dependencies.OcBinaryName,
+			dependencies.XargsBinaryName,
+		},
 	},
 	casaNRFCheckRegistrationIdentifierURL: {
 		Identifier:  CasaNRFRegistrationIdentifier,
 		Description: "A Casa cnf-specific test which checks the Registration status of the AMF and SMF from the NRF.  This is done by making sure the \"nfStatus\" field in the \"nfregistrations.mgmt.casa.io\" Custom Resource reports as \"REGISTERED\"",
 		Type:        Normative,
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.JqBinaryName,
+			dependencies.OcBinaryName,
+		},
 	},
 	hostnameIdentifierURL: {
 		Identifier:  HostnameIdentifier,
 		Description: "A generic test used to check the hostname of a target machine/container.",
 		Type:        Normative,
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.HostnameBinaryName,
+		},
 	},
 	ipAddrIdentifierURL: {
 		Identifier:  IPAddrIdentifier,
 		Description: "A generic test used to derive the default network interface IP address of a target container.",
 		Type:        Normative,
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.IPBinaryName,
+		},
 	},
 	operatorIdentifierURL: {
 		Identifier:  OperatorIdentifier,
 		Description: "An operator-specific test used to exercise the behavior of a given operator.  Currently, this test just checks that the Custom Resource Definition (CRD) of a resource is properly installed.",
 		Type:        Normative,
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.JqBinaryName,
+			dependencies.OcBinaryName,
+		},
 	},
 	pingIdentifierURL: {
 		Identifier:  PingIdentifier,
 		Description: "A generic test used to test ICMP connectivity from a source machine/container to a target destination.",
 		Type:        Normative,
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.PingBinaryName,
+		},
 	},
 	podIdentifierURL: {
 		Identifier:  PodIdentifier,
 		Description: "A container-specific test suite used to verify various aspects of the underlying container.",
 		Type:        Normative,
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.JqBinaryName,
+			dependencies.OcBinaryName,
+		},
 	},
 	versionIdentifierURL: {
 		Identifier:  VersionIdentifier,
 		Description: "A generic test used to determine if a target container/machine is based on RHEL.",
 		Type:        Normative,
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.CatBinaryName,
+		},
 	},
 }
 

--- a/test-network-function/cnf_specific/casa/cnf/nrf/nrfid.go
+++ b/test-network-function/cnf_specific/casa/cnf/nrf/nrfid.go
@@ -22,15 +22,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/identifier"
-
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/dependencies"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/identifier"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/reel"
 )
 
 const (
 	// CheckRegistrationCommand is the Unix command for checking NRF registrations.
-	CheckRegistrationCommand = "oc -n %s get nfregistrations.mgmt.casa.io $(oc -n %s get nfregistrations.mgmt.casa.io | awk {\"print $2\"} | xargs -n 1)"
+	CheckRegistrationCommand = "%s -n %s get nfregistrations.mgmt.casa.io $(%s -n %s get nfregistrations.mgmt.casa.io | %s {\"print $2\"} | %s -n 1)"
 	// CommandCompleteRegexString is the regular expression indicating the command has completed.
 	CommandCompleteRegexString = `(?m)NRF\s+TYPE\s+INSTID\s+STATUS\s+`
 	// OutputRegexString is the regular expression capturing all CNFs in the NRF registration output.
@@ -39,11 +39,13 @@ const (
 	SingleEntryRegexString = `(\w+)\s+(\w+)\s+([0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12})\s+(\w+)`
 )
 
-// OutputRegex matches the output from inspecting ID registrations.
-var OutputRegex = regexp.MustCompile(OutputRegexString)
+var (
+	// OutputRegex matches the output from inspecting ID registrations.
+	OutputRegex = regexp.MustCompile(OutputRegexString)
 
-// SingleEntryRegex matches a single matching ID.
-var SingleEntryRegex = regexp.MustCompile(SingleEntryRegexString)
+	// SingleEntryRegex matches a single matching ID.
+	SingleEntryRegex = regexp.MustCompile(SingleEntryRegexString)
+)
 
 // ID follows the container design pattern, and stores Network Registration information.
 type ID struct {
@@ -161,7 +163,7 @@ func (r *Registration) GetRegisteredNRFs() map[string]*ID {
 
 // registrationCommand creates the Unix command to check for registration.
 func registrationCommand(namespace string) []string {
-	command := fmt.Sprintf(CheckRegistrationCommand, namespace, namespace)
+	command := fmt.Sprintf(CheckRegistrationCommand, dependencies.OcBinaryName, namespace, dependencies.OcBinaryName, namespace, dependencies.AwkBinaryName, dependencies.XargsBinaryName)
 	return strings.Split(command, " ")
 }
 

--- a/test-network-function/cnf_specific/casa/cnf/nrf/nrfid_test.go
+++ b/test-network-function/cnf_specific/casa/cnf/nrf/nrfid_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/dependencies"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/identifier"
 	"github.com/redhat-nfvpe/test-network-function/test-network-function/cnf_specific/casa/cnf/nrf"
 	"github.com/stretchr/testify/assert"
@@ -125,7 +126,7 @@ func TestNewRegistration(t *testing.T) {
 		r := nrf.NewRegistration(testCase.timeout, testCase.namespace)
 		assert.NotNil(t, r)
 		assert.Equal(t, testCase.timeout, r.Timeout())
-		assert.Equal(t, strings.Split(fmt.Sprintf(nrf.CheckRegistrationCommand, testCase.namespace, testCase.namespace), " "), r.Args())
+		assert.Equal(t, strings.Split(fmt.Sprintf(nrf.CheckRegistrationCommand, dependencies.OcBinaryName, testCase.namespace, dependencies.OcBinaryName, testCase.namespace, dependencies.AwkBinaryName, dependencies.XargsBinaryName), " "), r.Args())
 	}
 }
 

--- a/test-network-function/cnf_specific/casa/cnf/nrf/registration.go
+++ b/test-network-function/cnf_specific/casa/cnf/nrf/registration.go
@@ -21,15 +21,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/identifier"
-
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/dependencies"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/identifier"
 	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/reel"
 )
 
 const (
 	// GetRegistrationNFStatusCmd gets the "nfStatus" for a particular CNF.
-	GetRegistrationNFStatusCmd = "oc get -n %s nfregistrations.mgmt.casa.io %s %s -o jsonpath='{.items[*].spec.data}' | jq '.nfStatus'"
+	GetRegistrationNFStatusCmd = "%s get -n %s nfregistrations.mgmt.casa.io %s %s -o jsonpath='{.items[*].spec.data}' | %s '.nfStatus'"
 	// SuccessfulRegistrationOutputRegexString is the output regular expression expected when a CNF has successfully registered.
 	SuccessfulRegistrationOutputRegexString = "(?m)\"REGISTERED\""
 	// UnsuccessfulRegistrationOutputRegexString is the output regular expression expected when a CNF has not successfully registered.
@@ -101,7 +101,7 @@ func (c *CheckRegistration) ReelEOF() {
 
 // FormCheckRegistrationCmd forms the command to check that a CNF is registered.
 func FormCheckRegistrationCmd(namespace string, nrfID *ID) []string {
-	command := fmt.Sprintf(GetRegistrationNFStatusCmd, namespace, nrfID.nrf, nrfID.instID)
+	command := fmt.Sprintf(GetRegistrationNFStatusCmd, dependencies.OcBinaryName, namespace, nrfID.nrf, nrfID.instID, dependencies.JqBinaryName)
 	return strings.Split(command, " ")
 }
 

--- a/test-network-function/suite_test.go
+++ b/test-network-function/suite_test.go
@@ -49,7 +49,7 @@ const (
 	JunitXMLFileName              = "cnf-certification-tests_junit.xml"
 	reportFlagKey                 = "report"
 	// dateTimeFormatDirective is the directive used to format date/time according to ISO 8601.
-	dateTimeFormatDirective       = "2006-01-02T15:04:05+00:00"
+	dateTimeFormatDirective = "2006-01-02T15:04:05+00:00"
 )
 
 var (


### PR DESCRIPTION
… type

Added the extra facets described in CTONET-521 to the TestCatalogEntry
definition.  This includes:
* IntrusionSettings:   Includes whether the test modifies the target system
  and whether the modifications persist after the test.  This could be
  non-nefarious, such as setting up a tunnel in a Test that is in place for
  future tests to utilize.  Further work in 2.0 may lead to inter-test
  dependency specification, which will allow us to build a dependency tree
  to ensure ordering.
* BinaryDependencies:  The binary dependencies required on the target context,
  whether that is a container, physical, or virtual machine.  Right now, this
  is purely informative.  Future work in 2.0 may lead to allowing pre-flight
  installation of missing dependencies, etc.  For now, we just track binary
  name as there is no consistent means of tracking minimum binary version
  across various Unix distributions.  Command implementations of "--version"
  also tend to vary widely.  We may be able to shim a per-command strategy in
  the future, but that is not work for today.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>