### PR TITLE
Fixed go imports formatting on mockgen

### DIFF
--- a/pkg/tnf/interactive/mocks/mock_spawner.go
+++ b/pkg/tnf/interactive/mocks/mock_spawner.go
@@ -5,38 +5,39 @@
 package mock_interactive
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	expect "github.com/google/goexpect"
-	interactive "github.com/redhat-nfvpe/test-network-function/pkg/tnf/interactive"
 	io "io"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	expect "github.com/google/goexpect"
+	interactive "github.com/redhat-nfvpe/test-network-function/pkg/tnf/interactive"
 )
 
-// MockSpawnFunc is a mock of SpawnFunc interface
+// MockSpawnFunc is a mock of SpawnFunc interface.
 type MockSpawnFunc struct {
 	ctrl     *gomock.Controller
 	recorder *MockSpawnFuncMockRecorder
 }
 
-// MockSpawnFuncMockRecorder is the mock recorder for MockSpawnFunc
+// MockSpawnFuncMockRecorder is the mock recorder for MockSpawnFunc.
 type MockSpawnFuncMockRecorder struct {
 	mock *MockSpawnFunc
 }
 
-// NewMockSpawnFunc creates a new mock instance
+// NewMockSpawnFunc creates a new mock instance.
 func NewMockSpawnFunc(ctrl *gomock.Controller) *MockSpawnFunc {
 	mock := &MockSpawnFunc{ctrl: ctrl}
 	mock.recorder = &MockSpawnFuncMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSpawnFunc) EXPECT() *MockSpawnFuncMockRecorder {
 	return m.recorder
 }
 
-// Command mocks base method
+// Command mocks base method.
 func (m *MockSpawnFunc) Command(name string, arg ...string) *interactive.SpawnFunc {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{name}
@@ -48,14 +49,14 @@ func (m *MockSpawnFunc) Command(name string, arg ...string) *interactive.SpawnFu
 	return ret0
 }
 
-// Command indicates an expected call of Command
+// Command indicates an expected call of Command.
 func (mr *MockSpawnFuncMockRecorder) Command(name interface{}, arg ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{name}, arg...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Command", reflect.TypeOf((*MockSpawnFunc)(nil).Command), varargs...)
 }
 
-// Start mocks base method
+// Start mocks base method.
 func (m *MockSpawnFunc) Start() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start")
@@ -63,13 +64,13 @@ func (m *MockSpawnFunc) Start() error {
 	return ret0
 }
 
-// Start indicates an expected call of Start
+// Start indicates an expected call of Start.
 func (mr *MockSpawnFuncMockRecorder) Start() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockSpawnFunc)(nil).Start))
 }
 
-// StdinPipe mocks base method
+// StdinPipe mocks base method.
 func (m *MockSpawnFunc) StdinPipe() (io.WriteCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StdinPipe")
@@ -78,13 +79,13 @@ func (m *MockSpawnFunc) StdinPipe() (io.WriteCloser, error) {
 	return ret0, ret1
 }
 
-// StdinPipe indicates an expected call of StdinPipe
+// StdinPipe indicates an expected call of StdinPipe.
 func (mr *MockSpawnFuncMockRecorder) StdinPipe() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StdinPipe", reflect.TypeOf((*MockSpawnFunc)(nil).StdinPipe))
 }
 
-// StdoutPipe mocks base method
+// StdoutPipe mocks base method.
 func (m *MockSpawnFunc) StdoutPipe() (io.Reader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StdoutPipe")
@@ -93,13 +94,13 @@ func (m *MockSpawnFunc) StdoutPipe() (io.Reader, error) {
 	return ret0, ret1
 }
 
-// StdoutPipe indicates an expected call of StdoutPipe
+// StdoutPipe indicates an expected call of StdoutPipe.
 func (mr *MockSpawnFuncMockRecorder) StdoutPipe() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StdoutPipe", reflect.TypeOf((*MockSpawnFunc)(nil).StdoutPipe))
 }
 
-// Wait mocks base method
+// Wait mocks base method.
 func (m *MockSpawnFunc) Wait() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Wait")
@@ -107,36 +108,36 @@ func (m *MockSpawnFunc) Wait() error {
 	return ret0
 }
 
-// Wait indicates an expected call of Wait
+// Wait indicates an expected call of Wait.
 func (mr *MockSpawnFuncMockRecorder) Wait() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wait", reflect.TypeOf((*MockSpawnFunc)(nil).Wait))
 }
 
-// MockSpawner is a mock of Spawner interface
+// MockSpawner is a mock of Spawner interface.
 type MockSpawner struct {
 	ctrl     *gomock.Controller
 	recorder *MockSpawnerMockRecorder
 }
 
-// MockSpawnerMockRecorder is the mock recorder for MockSpawner
+// MockSpawnerMockRecorder is the mock recorder for MockSpawner.
 type MockSpawnerMockRecorder struct {
 	mock *MockSpawner
 }
 
-// NewMockSpawner creates a new mock instance
+// NewMockSpawner creates a new mock instance.
 func NewMockSpawner(ctrl *gomock.Controller) *MockSpawner {
 	mock := &MockSpawner{ctrl: ctrl}
 	mock.recorder = &MockSpawnerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSpawner) EXPECT() *MockSpawnerMockRecorder {
 	return m.recorder
 }
 
-// Spawn mocks base method
+// Spawn mocks base method.
 func (m *MockSpawner) Spawn(command string, args []string, timeout time.Duration, opts ...expect.Option) (*interactive.Context, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{command, args, timeout}
@@ -149,7 +150,7 @@ func (m *MockSpawner) Spawn(command string, args []string, timeout time.Duration
 	return ret0, ret1
 }
 
-// Spawn indicates an expected call of Spawn
+// Spawn indicates an expected call of Spawn.
 func (mr *MockSpawnerMockRecorder) Spawn(command, args, timeout interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{command, args, timeout}, opts...)

--- a/pkg/tnf/mocks/mock_tester.go
+++ b/pkg/tnf/mocks/mock_tester.go
@@ -5,36 +5,37 @@
 package mock_tnf
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	identifier "github.com/redhat-nfvpe/test-network-function/pkg/tnf/identifier"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	identifier "github.com/redhat-nfvpe/test-network-function/pkg/tnf/identifier"
 )
 
-// MockTester is a mock of Tester interface
+// MockTester is a mock of Tester interface.
 type MockTester struct {
 	ctrl     *gomock.Controller
 	recorder *MockTesterMockRecorder
 }
 
-// MockTesterMockRecorder is the mock recorder for MockTester
+// MockTesterMockRecorder is the mock recorder for MockTester.
 type MockTesterMockRecorder struct {
 	mock *MockTester
 }
 
-// NewMockTester creates a new mock instance
+// NewMockTester creates a new mock instance.
 func NewMockTester(ctrl *gomock.Controller) *MockTester {
 	mock := &MockTester{ctrl: ctrl}
 	mock.recorder = &MockTesterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTester) EXPECT() *MockTesterMockRecorder {
 	return m.recorder
 }
 
-// Args mocks base method
+// Args mocks base method.
 func (m *MockTester) Args() []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Args")
@@ -42,13 +43,13 @@ func (m *MockTester) Args() []string {
 	return ret0
 }
 
-// Args indicates an expected call of Args
+// Args indicates an expected call of Args.
 func (mr *MockTesterMockRecorder) Args() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Args", reflect.TypeOf((*MockTester)(nil).Args))
 }
 
-// GetIdentifier mocks base method
+// GetIdentifier mocks base method.
 func (m *MockTester) GetIdentifier() identifier.Identifier {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIdentifier")
@@ -56,13 +57,13 @@ func (m *MockTester) GetIdentifier() identifier.Identifier {
 	return ret0
 }
 
-// GetIdentifier indicates an expected call of GetIdentifier
+// GetIdentifier indicates an expected call of GetIdentifier.
 func (mr *MockTesterMockRecorder) GetIdentifier() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIdentifier", reflect.TypeOf((*MockTester)(nil).GetIdentifier))
 }
 
-// Result mocks base method
+// Result mocks base method.
 func (m *MockTester) Result() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Result")
@@ -70,13 +71,13 @@ func (m *MockTester) Result() int {
 	return ret0
 }
 
-// Result indicates an expected call of Result
+// Result indicates an expected call of Result.
 func (mr *MockTesterMockRecorder) Result() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Result", reflect.TypeOf((*MockTester)(nil).Result))
 }
 
-// Timeout mocks base method
+// Timeout mocks base method.
 func (m *MockTester) Timeout() time.Duration {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Timeout")
@@ -84,7 +85,7 @@ func (m *MockTester) Timeout() time.Duration {
 	return ret0
 }
 
-// Timeout indicates an expected call of Timeout
+// Timeout indicates an expected call of Timeout.
 func (mr *MockTesterMockRecorder) Timeout() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Timeout", reflect.TypeOf((*MockTester)(nil).Timeout))

--- a/pkg/tnf/reel/mocks/mock_reel.go
+++ b/pkg/tnf/reel/mocks/mock_reel.go
@@ -5,35 +5,36 @@
 package mock_reel
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	reel "github.com/redhat-nfvpe/test-network-function/pkg/tnf/reel"
-	reflect "reflect"
 )
 
-// MockHandler is a mock of Handler interface
+// MockHandler is a mock of Handler interface.
 type MockHandler struct {
 	ctrl     *gomock.Controller
 	recorder *MockHandlerMockRecorder
 }
 
-// MockHandlerMockRecorder is the mock recorder for MockHandler
+// MockHandlerMockRecorder is the mock recorder for MockHandler.
 type MockHandlerMockRecorder struct {
 	mock *MockHandler
 }
 
-// NewMockHandler creates a new mock instance
+// NewMockHandler creates a new mock instance.
 func NewMockHandler(ctrl *gomock.Controller) *MockHandler {
 	mock := &MockHandler{ctrl: ctrl}
 	mock.recorder = &MockHandlerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
 }
 
-// ReelFirst mocks base method
+// ReelFirst mocks base method.
 func (m *MockHandler) ReelFirst() *reel.Step {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReelFirst")
@@ -41,13 +42,13 @@ func (m *MockHandler) ReelFirst() *reel.Step {
 	return ret0
 }
 
-// ReelFirst indicates an expected call of ReelFirst
+// ReelFirst indicates an expected call of ReelFirst.
 func (mr *MockHandlerMockRecorder) ReelFirst() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReelFirst", reflect.TypeOf((*MockHandler)(nil).ReelFirst))
 }
 
-// ReelMatch mocks base method
+// ReelMatch mocks base method.
 func (m *MockHandler) ReelMatch(pattern, before, match string) *reel.Step {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReelMatch", pattern, before, match)
@@ -55,13 +56,13 @@ func (m *MockHandler) ReelMatch(pattern, before, match string) *reel.Step {
 	return ret0
 }
 
-// ReelMatch indicates an expected call of ReelMatch
+// ReelMatch indicates an expected call of ReelMatch.
 func (mr *MockHandlerMockRecorder) ReelMatch(pattern, before, match interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReelMatch", reflect.TypeOf((*MockHandler)(nil).ReelMatch), pattern, before, match)
 }
 
-// ReelTimeout mocks base method
+// ReelTimeout mocks base method.
 func (m *MockHandler) ReelTimeout() *reel.Step {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReelTimeout")
@@ -69,19 +70,19 @@ func (m *MockHandler) ReelTimeout() *reel.Step {
 	return ret0
 }
 
-// ReelTimeout indicates an expected call of ReelTimeout
+// ReelTimeout indicates an expected call of ReelTimeout.
 func (mr *MockHandlerMockRecorder) ReelTimeout() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReelTimeout", reflect.TypeOf((*MockHandler)(nil).ReelTimeout))
 }
 
-// ReelEOF mocks base method
+// ReelEOF mocks base method.
 func (m *MockHandler) ReelEOF() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReelEOF")
 }
 
-// ReelEOF indicates an expected call of ReelEOF
+// ReelEOF indicates an expected call of ReelEOF.
 func (mr *MockHandlerMockRecorder) ReelEOF() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReelEOF", reflect.TypeOf((*MockHandler)(nil).ReelEOF))


### PR DESCRIPTION
mockgen files do not have to their imports formated, hence makes developers to check-in files every time mockgen generates runs new files.