### PR TITLE
remove hosts configuration, which will be generated

### DIFF
--- a/test-network-function/generic/configuration.go
+++ b/test-network-function/generic/configuration.go
@@ -172,5 +172,4 @@ type TestConfiguration struct {
 	ContainersUnderTest map[ContainerIdentifier]Container `yaml:"containersUnderTest" json:"containersUnderTest"`
 	PartnerContainers   map[ContainerIdentifier]Container `yaml:"partnerContainers" json:"partnerContainers"`
 	TestOrchestrator    ContainerIdentifier               `yaml:"testOrchestrator" json:"testOrchestrator"`
-	Hosts               []string                          `yaml:"hosts" json:"hosts"`
 }

--- a/test-network-function/generic/configuration_test.go
+++ b/test-network-function/generic/configuration_test.go
@@ -80,13 +80,10 @@ var expectedTestOrchestrator = generic.ContainerIdentifier{
 	ContainerName: "partner",
 }
 
-var expectedHosts = []string{"192.168.1.1"}
-
 var goodExpectedConfiguration = &generic.TestConfiguration{
 	ContainersUnderTest: expectedContainersUnderTest,
 	PartnerContainers:   expectedPartnerContainers,
 	TestOrchestrator:    expectedTestOrchestrator,
-	Hosts:               expectedHosts,
 }
 
 var testConfigurationTestCases = map[string]*testConfigurationTestCase{
@@ -111,7 +108,6 @@ var testConfigurationTestCases = map[string]*testConfigurationTestCase{
 			ContainersUnderTest: nil,
 			PartnerContainers:   nil,
 			TestOrchestrator:    generic.ContainerIdentifier{},
-			Hosts:               nil,
 		},
 		expectedMarshalErr: nil,
 	},

--- a/test-network-function/suite_test.go
+++ b/test-network-function/suite_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/redhat-nfvpe/test-network-function/pkg/junit"
 	containerTestConfig "github.com/redhat-nfvpe/test-network-function/pkg/tnf/config"
 	_ "github.com/redhat-nfvpe/test-network-function/test-network-function/container"
-	"github.com/redhat-nfvpe/test-network-function/test-network-function/generic"
+	_ "github.com/redhat-nfvpe/test-network-function/test-network-function/generic"
 	_ "github.com/redhat-nfvpe/test-network-function/test-network-function/operator"
 	"github.com/redhat-nfvpe/test-network-function/test-network-function/version"
 	log "github.com/sirupsen/logrus"
@@ -103,10 +103,7 @@ func TestTest(t *testing.T) {
 	claimData.Configurations = make(map[string]interface{})
 
 	equipmentMap := make(map[string]interface{})
-	for _, key := range generic.GetTestConfiguration().Hosts {
-		// For now, just initialize the payload as empty.
-		equipmentMap[key] = make(map[string]interface{})
-	}
+
 	claimData.Nodes = equipmentMap
 	claimData.Versions = &claim.Versions{
 		Tnf: tnfVersion.Tag,

--- a/test-network-function/test-configuration.yaml
+++ b/test-network-function/test-configuration.yaml
@@ -16,5 +16,3 @@ testOrchestrator:
   namespace: default
   podName: partner
   containerName: partner
-hosts:
-  - 192.168.1.1


### PR DESCRIPTION
hosts will be polled from the environment as a part of CTONET-528.  As
such, we should no longer require the explicit definition of cluster
hosts in test-configuration.yaml.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>