### PR TITLE
Introduce a "diagnostic" test spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ build-cnf-tests:
 
 .PHONY: run-generic-cnf-tests
 run-generic-cnf-tests:
-	cd ./test-network-function && ./test-network-function.test -ginkgo.focus="generic" ${COMMON_GINKGO_ARGS}
+	cd ./test-network-function && ./test-network-function.test -ginkgo.focus="(diagnostic|generic)" ${COMMON_GINKGO_ARGS}
 
 .PHONY: run-cnf-tests
 run-cnf-tests:
@@ -55,11 +55,11 @@ run-cnf-tests:
 
 .PHONY: run-operator-tests
 run-operator-tests:
-	cd ./test-network-function && ./test-network-function.test -ginkgo.focus="operator" ${COMMON_GINKGO_ARGS}
+	cd ./test-network-function && ./test-network-function.test -ginkgo.focus="(diagnostic|operator)" ${COMMON_GINKGO_ARGS}
 
 .PHONY: run-container-tests
 run-container-tests:
-	cd ./test-network-function && ./test-network-function.test -ginkgo.focus="container" ${COMMON_GINKGO_ARGS}
+	cd ./test-network-function && ./test-network-function.test -ginkgo.focus="(diagnostic|container)" ${COMMON_GINKGO_ARGS}
 
 deps-update:
 	go mod tidy && \

--- a/pkg/tnf/handlers/generic/generic.go
+++ b/pkg/tnf/handlers/generic/generic.go
@@ -104,6 +104,11 @@ func (g *Generic) GetIdentifier() identifier.Identifier {
 	return g.Identifier
 }
 
+// GetMatches extracts all Matches.
+func (g *Generic) GetMatches() []Match {
+	return g.Matches
+}
+
 // Timeout returns the test timeout.
 func (g *Generic) Timeout() time.Duration {
 	return g.TestTimeout

--- a/pkg/tnf/handlers/generic/testdata/assertion_error.json
+++ b/pkg/tnf/handlers/generic/testdata/assertion_error.json
@@ -1,4 +1,8 @@
 {
+  "identifier": {
+    "url": "http://test-network-function.com/tests/unit/assertion_error",
+    "version": "v1.0.0"
+  },
   "description": "checks for RHEL version.",
   "reelFirstStep": {
     "execute": "if [ -e /etc/redhat-release ]; then cat /etc/redhat-release; else echo \"Unknown Base Image\"; fi\n",

--- a/pkg/tnf/handlers/generic/testdata/base.json
+++ b/pkg/tnf/handlers/generic/testdata/base.json
@@ -1,4 +1,8 @@
 {
+  "identifier": {
+    "url": "http://test-network-function.com/tests/unit/base",
+    "version": "v1.0.0"
+  },
   "description": "checks for RHEL version.",
   "reelFirstStep": {
     "execute": "if [ -e /etc/redhat-release ]; then cat /etc/redhat-release; else echo \"Unknown Base Image\"; fi\n",

--- a/pkg/tnf/handlers/generic/testdata/hostname.json
+++ b/pkg/tnf/handlers/generic/testdata/hostname.json
@@ -1,4 +1,8 @@
 {
+  "identifier": {
+    "url": "http://test-network-function.com/tests/unit/hostname",
+    "version": "v1.0.0"
+  },
   "arguments": [
     "cat",
     "/etc/redhat-release"

--- a/pkg/tnf/handlers/node/doc.go
+++ b/pkg/tnf/handlers/node/doc.go
@@ -1,0 +1,2 @@
+// Package node provides a tnf.Test implementation for getting OpenShift node information for a cluster.
+package node

--- a/pkg/tnf/handlers/node/nodes.json
+++ b/pkg/tnf/handlers/node/nodes.json
@@ -1,0 +1,22 @@
+{
+  "identifier": {
+    "url": "http://test-network-function.com/tests/nodes",
+    "version": "v1.0.0"
+  },
+  "description": "Runs `oc get nodes -o json` on a target machine.",
+  "testResult": 0,
+  "testTimeout": 10000000000,
+  "reelFirstStep": {
+    "execute": "oc get nodes -o json\n",
+    "expect": [
+      "(?m)(.|\n)+"
+    ],
+    "timeout": 10000000000
+  },
+  "resultContexts": [
+    {
+      "pattern": "(?m)(.|\n)+",
+      "defaultResult": 1
+    }
+  ]
+}

--- a/pkg/tnf/handlers/node/nodes_test.go
+++ b/pkg/tnf/handlers/node/nodes_test.go
@@ -1,0 +1,122 @@
+// Copyright (C) 2020 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package node_test
+
+import (
+	"path"
+	"testing"
+	"time"
+
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/handlers/generic"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/identifier"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/reel"
+	"github.com/stretchr/testify/assert"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+const (
+	testTimeoutDuration = time.Second * 10
+)
+
+var (
+	genericTestSchemaFile = path.Join("schemas", "generic-test.schema.json")
+	nodesFilename         = "nodes.json"
+	expectedPattern       = "(?m)(.|\n)+"
+	pathRelativeToRoot    = path.Join("..", "..", "..", "..")
+	pathToTestSchemaFile  = path.Join(pathRelativeToRoot, genericTestSchemaFile)
+)
+
+func createTest() (*tnf.Tester, []reel.Handler, *gojsonschema.Result, error) {
+	return generic.NewGenericFromJSONFile(nodesFilename, pathToTestSchemaFile)
+}
+
+func TestNodes_Args(t *testing.T) {
+	test, handlers, jsonParseResult, err := createTest()
+
+	assert.Nil(t, err)
+	assert.True(t, jsonParseResult.Valid())
+	assert.NotNil(t, handlers)
+
+	assert.Nil(t, (*test).Args())
+}
+
+func TestNodes_GetIdentifier(t *testing.T) {
+	test, handlers, jsonParseResult, err := createTest()
+
+	assert.Nil(t, err)
+	assert.True(t, jsonParseResult.Valid())
+	assert.NotNil(t, handlers)
+
+	assert.Equal(t, identifier.NodesIdentifier, (*test).GetIdentifier())
+}
+
+func TestNodes_ReelFirst(t *testing.T) {
+	_, handlers, jsonParseResult, err := createTest()
+
+	assert.Nil(t, err)
+	assert.True(t, jsonParseResult.Valid())
+	assert.NotNil(t, handlers)
+
+	assert.Equal(t, 1, len(handlers))
+	handler := handlers[0]
+	step := handler.ReelFirst()
+	assert.Equal(t, "oc get nodes -o json\n", step.Execute)
+	assert.Equal(t, []string{expectedPattern}, step.Expect)
+	assert.Equal(t, testTimeoutDuration, step.Timeout)
+}
+
+func TestNodes_ReelEof(t *testing.T) {
+	_, handlers, jsonParseResult, err := createTest()
+
+	assert.Nil(t, err)
+	assert.True(t, jsonParseResult.Valid())
+	assert.NotNil(t, handlers)
+
+	assert.Equal(t, 1, len(handlers))
+	handler := handlers[0]
+	// just ensure there isn't a panic
+	handler.ReelEOF()
+}
+
+func TestNodes_ReelTimeout(t *testing.T) {
+	_, handlers, jsonParseResult, err := createTest()
+
+	assert.Nil(t, err)
+	assert.True(t, jsonParseResult.Valid())
+	assert.NotNil(t, handlers)
+
+	assert.Equal(t, 1, len(handlers))
+	handler := handlers[0]
+	assert.Nil(t, handler.ReelTimeout())
+}
+
+// Also tests GetNodes() and Result()
+func TestNodes_ReelMatch(t *testing.T) {
+	tester, handlers, jsonParseResult, err := createTest()
+
+	assert.Nil(t, err)
+	assert.True(t, jsonParseResult.Valid())
+	assert.NotNil(t, handlers)
+
+	assert.Equal(t, 1, len(handlers))
+	handler := handlers[0]
+
+	step := handler.ReelMatch(expectedPattern, "", "anythingMatches")
+	assert.Nil(t, step)
+	assert.Equal(t, tnf.SUCCESS, (*tester).Result())
+}

--- a/pkg/tnf/identifier/identifiers.go
+++ b/pkg/tnf/identifier/identifiers.go
@@ -21,6 +21,7 @@ import "github.com/redhat-nfvpe/test-network-function/pkg/tnf/dependencies"
 const (
 	hostnameIdentifierURL = "http://test-network-function.com/tests/hostname"
 	ipAddrIdentifierURL   = "http://test-network-function.com/tests/ipaddr"
+	nodesIdentifierURL    = "http://test-network-function.com/tests/nodes"
 	operatorIdentifierURL = "http://test-network-function.com/tests/operator"
 	pingIdentifierURL     = "http://test-network-function.com/tests/ping"
 	podIdentifierURL      = "http://test-network-function.com/tests/container/pod"
@@ -91,6 +92,17 @@ var Catalog = map[string]TestCatalogEntry{
 			dependencies.IPBinaryName,
 		},
 	},
+	nodesIdentifierURL: {
+		Identifier:  NodesIdentifier,
+		Description: "Polls the state of the OpenShift cluster nodes using \"oc get nodes -o json\".",
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.OcBinaryName,
+		},
+	},
 	operatorIdentifierURL: {
 		Identifier: OperatorIdentifier,
 		Description: "An operator-specific test used to exercise the behavior of a given operator.  In the current " +
@@ -155,6 +167,12 @@ var HostnameIdentifier = Identifier{
 // IPAddrIdentifier is the Identifier used to represent the generic IP Addr test case.
 var IPAddrIdentifier = Identifier{
 	URL:             ipAddrIdentifierURL,
+	SemanticVersion: versionOne,
+}
+
+// NodesIdentifier is the Identifier used to represent the nodes test case.
+var NodesIdentifier = Identifier{
+	URL:             nodesIdentifierURL,
 	SemanticVersion: versionOne,
 }
 

--- a/pkg/tnf/interactive/spawner.go
+++ b/pkg/tnf/interactive/spawner.go
@@ -209,3 +209,11 @@ func (g *GoExpectSpawner) extractStdoutPipe(spawnFunc *SpawnFunc) (io.Reader, er
 	}
 	return stdout, err
 }
+
+// CreateGoExpectSpawner creates a GoExpectSpawner implementation and returns it as a *Spawner for type compatibility
+// reasons.
+func CreateGoExpectSpawner() *Spawner {
+	goExpectSpawner := NewGoExpectSpawner()
+	var spawner Spawner = goExpectSpawner
+	return &spawner
+}

--- a/schemas/generic-test.schema.json
+++ b/schemas/generic-test.schema.json
@@ -3,6 +3,25 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "version": "0.0.1",
   "definitions": {
+    "identifier": {
+      "$id": "#identifier",
+      "description": "identifier is a per tnf.Test unique identifier.  For more information, consult https://github.com/redhat-nfvpe/test-network-function/blob/master/DEVELOPING.md#test-identifiers.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "url stores the unique identifier for a test."
+        },
+        "version": {
+          "type": "string",
+          "description": "version stores the semantic version of the test."
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "version"
+      ]
+    },
     "step": {
       "$id": "#step",
       "type": "object",
@@ -223,6 +242,10 @@
   "type": "object",
   "description": "generic-test is a construct for defining an arbitrary simple test with prescriptive confines.  Essentially, the definition of the state machine for a Generic reel.Handler is restricted in this facade implementation, since most common use cases do not require too much heavy lifting.",
   "properties": {
+    "identifier": {
+      "$ref": "#identifier",
+      "description": "identifier is a per tnf.Test unique identifier.  For more information, consult https://github.com/redhat-nfvpe/test-network-function/blob/master/DEVELOPING.md#test-identifiers."
+    },
     "arguments": {
       "description": "arguments is the Unix command array.",
       "type": "array",
@@ -273,6 +296,7 @@
   "additionalProperties": false,
   "required": [
     "description",
+    "identifier",
     "reelFirstStep",
     "resultContexts",
     "testResult",

--- a/test-network-function/diagnostic/suite.go
+++ b/test-network-function/diagnostic/suite.go
@@ -1,0 +1,88 @@
+package diagnostic
+
+import (
+	"encoding/json"
+	"path"
+	"time"
+
+	expect "github.com/google/goexpect"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/handlers/generic"
+	"github.com/redhat-nfvpe/test-network-function/pkg/tnf/interactive"
+)
+
+const (
+	// testSuiteSpec contains the name of the Ginkgo test specification.
+	testSuiteSpec = "diagnostic"
+	// defaultTimeoutSeconds contains the default timeout in secons.
+	defaultTimeoutSeconds = 20
+)
+
+var (
+	// defaultTestTimeout is the timeout for the test.
+	defaultTestTimeout = time.Duration(defaultTimeoutSeconds) * time.Second
+
+	// nodeSummary stores the raw JSON output of `oc get nodes -o json`
+	nodeSummary = make(map[string]interface{})
+
+	// nodesTestPath is the file location of the nodes.json test case relative to the project root.
+	nodesTestPath = path.Join("pkg", "tnf", "handlers", "node", "nodes.json")
+
+	// pathRelativeToRoot is used to calculate relative filepaths for the `test-network-function` executable entrypoint.
+	pathRelativeToRoot = path.Join("..")
+
+	// relativeNodesTestPath is the relative path to the nodes.json test case.
+	relativeNodesTestPath = path.Join(pathRelativeToRoot, nodesTestPath)
+
+	// relativeSchemaPath is the relative path to the generic-test.schema.json JSON schema.
+	relativeSchemaPath = path.Join(pathRelativeToRoot, schemaPath)
+
+	// schemaPath is the path to the generic-test.schema.json JSON schema relative to the project root.
+	schemaPath = path.Join("schemas", "generic-test.schema.json")
+)
+
+// createShell sets up a local shell expect.Expecter, checking errors along the way.
+func createShell() *interactive.Context {
+	context, err := interactive.SpawnShell(interactive.CreateGoExpectSpawner(), defaultTestTimeout, expect.Verbose(true))
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(context).ToNot(gomega.BeNil())
+	return context
+}
+
+var _ = ginkgo.Describe(testSuiteSpec, func() {
+	ginkgo.When("a cluster is set up and installed with OpenShift", func() {
+		ginkgo.It("should report all available nodeSummary", func() {
+			context := createShell()
+
+			test, handlers, jsonParseResult, err := generic.NewGenericFromJSONFile(relativeNodesTestPath, relativeSchemaPath)
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(jsonParseResult).ToNot(gomega.BeNil())
+			gomega.Expect(jsonParseResult.Valid()).To(gomega.BeTrue())
+			gomega.Expect(handlers).ToNot(gomega.BeNil())
+			gomega.Expect(test).ToNot(gomega.BeNil())
+
+			tester, err := tnf.NewTest(context.GetExpecter(), *test, handlers, context.GetErrorChannel())
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(tester).ToNot(gomega.BeNil())
+
+			result, err := tester.Run()
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(result).To(gomega.Equal(tnf.SUCCESS))
+
+			genericTest := (*test).(*generic.Generic)
+			gomega.Expect(genericTest).ToNot(gomega.BeNil())
+			matches := genericTest.Matches
+			gomega.Expect(len(matches)).To(gomega.Equal(1))
+			match := genericTest.GetMatches()[0]
+			err = json.Unmarshal([]byte(match.Match), &nodeSummary)
+			gomega.Expect(err).To(gomega.BeNil())
+		})
+	})
+})
+
+// GetNodeSummary returns the result of running `oc get nodes -o json`.
+func GetNodeSummary() map[string]interface{} {
+	return nodeSummary
+}

--- a/test-network-function/suite_test.go
+++ b/test-network-function/suite_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/redhat-nfvpe/test-network-function/pkg/junit"
 	containerTestConfig "github.com/redhat-nfvpe/test-network-function/pkg/tnf/config"
 	_ "github.com/redhat-nfvpe/test-network-function/test-network-function/container"
+	"github.com/redhat-nfvpe/test-network-function/test-network-function/diagnostic"
 	_ "github.com/redhat-nfvpe/test-network-function/test-network-function/generic"
 	_ "github.com/redhat-nfvpe/test-network-function/test-network-function/operator"
 	"github.com/redhat-nfvpe/test-network-function/test-network-function/version"
@@ -136,6 +137,9 @@ func TestTest(t *testing.T) {
 	if err != nil {
 		log.Fatalf("error converting configurations to JSON: %v", err)
 	}
+
+	claimData.Nodes = diagnostic.GetNodeSummary()
+
 	err = j.Unmarshal(configurations, &claimData.Configurations)
 	if err != nil {
 		log.Fatalf("error unmarshalling configurations: %v", err)


### PR DESCRIPTION
The diagnostic test suite fulfills capturing a profile of the hardware under
test as according to CTONET-528.  This PR contains the implementation only;
documentation will be added following the close of CTONET-669.  CTONET-669
heavily augments the documentation, and I do not want to introduce a
non-trivial merge conflict;  so I will wait until that is done.

The "diagnostic" test suite is simple;  it just runs the following command:
`oc get nodes -o json`
Due to the fact that we recommend deploying worker nodes on top of CoreOS,
and CoreOS does not have `lspci` or `lshw` baked in, we cannot get any of this
information.  `oc get nodes -o json` does provide us enough information to get
an idea the cluster hardware, and is sufficient for CTONET-528.

As a part of this exercise, I decided to use a JSON based test called
`nodes.json`.  I quickly discovered that a few schema changes were needed in
order to enforce mandatory test identifiers.  As such, some of the generic
tests also required changes, as they did not include identifiers.

`nodes.json` was tested as a part of `nodes_test`.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>