### PR TITLE
Update to `test-network-function-claim` v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.3
-	github.com/redhat-nfvpe/test-network-function-claim v0.0.8
+	github.com/redhat-nfvpe/test-network-function-claim v1.0.0
 	github.com/ryandgoulding/goexpect v0.0.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-nfvpe/test-network-function-claim v0.0.8 h1:hJFFUSP/JpAm6o12yFEDDu5ZKq+3JsiRqriUCmjdg0k=
-github.com/redhat-nfvpe/test-network-function-claim v0.0.8/go.mod h1:hswacvCvO0o9aZAero2OU4A6mHzELv2wqfR+cqyMMVg=
+github.com/redhat-nfvpe/test-network-function-claim v1.0.0 h1:4XXxR6I1sQ9t829mheqrLhqd1kNtcmQtvwSLzGrZHr4=
+github.com/redhat-nfvpe/test-network-function-claim v1.0.0/go.mod h1:hswacvCvO0o9aZAero2OU4A6mHzELv2wqfR+cqyMMVg=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
Adapt the `v1.0.0` changes, the first non-draft release of
`test-network-function-claim`.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>