### PR TITLE
remove ununsed configuration options

### DIFF
--- a/pkg/config/cnf.go
+++ b/pkg/config/cnf.go
@@ -74,24 +74,6 @@ type Operator struct {
 	// If its all namespace then you can replace it with ALL_NAMESPACE TODO: add check for ALL_NAMESPACE
 	Namespace string `yaml:"namespace" json:"namespace"`
 
-	// Status is a required field , specified what status of the csv to be checked.
-	Status string `yaml:"status" json:"status"`
-
-	// AutoGenerate if set to true will generate the config with operator related artifacts.
-	AutoGenerate string `yaml:"autogenerate,omitempty" json:"autogenerate"`
-
-	// CRDs If AutoGenerate is set to true, then the program will populate the CRD data from the CSV file.
-	CRDs []Crd `yaml:"crds" json:"crds"`
-
-	// Deployments If AutoGenerate is set to true, then the program will populate the Deployment data from the CSV file.
-	Deployments []Deployment `yaml:"deployments" json:"deployments"`
-
-	// CNFs If AutoGenerate is set to true, then the program will populate the CNFs data from the CSV file.
-	CNFs []Cnf `yaml:"cnfs" json:"cnfs"`
-
-	// Permissions If AutoGenerate is set to true, then the program will populate the Permission data from the CSV file.
-	Permissions []Permission `yaml:"permissions" json:"permissions"`
-
 	// Tests this is list of test that need to run against the operator.
 	Tests []string `yaml:"tests" json:"tests"`
 
@@ -137,9 +119,6 @@ type Cnf struct {
 
 	// Namespace where the CNF is deployed
 	Namespace string `yaml:"namespace" json:"namespace"`
-
-	// Status is the status of the CNF
-	Status string `yaml:"status" json:"status"`
 
 	// Tests this is list of test that need to run against the CNF.
 	Tests []string `yaml:"tests" json:"tests"`

--- a/pkg/config/cnf_test.go
+++ b/pkg/config/cnf_test.go
@@ -66,14 +66,8 @@ const (
 	operatorNameSpace = "my-etcd"
 	// operatorPackageName operator package name in the bundle
 	operatorPackageName = "amq-streams"
-	// operatorStatus specifies status of the CSV in the cluster
-	operatorStatus = "Succeeded"
 	// organization is under which operator is published
 	organization = "redhat-marketplace"
-	// permissionName type of permission
-	permissionName = "Cluster-wide-permission"
-	// permissionRole type of role
-	permissionRole = "ClusterRole"
 	// imageRepository for  container images
 	imageRepository = "rhel8"
 	// testNameSpace k8s namespace
@@ -86,7 +80,6 @@ func loadCnfConfig() {
 		{
 			Name:      cnfName,
 			Namespace: testNameSpace,
-			Status:    "",
 			Tests:     []string{testcases.PrivilegedPod},
 			CertifiedContainerRequestInfos: []tnfConfig.CertifiedContainerRequestInfo{
 				{
@@ -106,13 +99,10 @@ func loadOperatorConfig() {
 	operator := tnfConfig.Operator{}
 	operator.Name = operatorName
 	operator.Namespace = operatorNameSpace
-	operator.Status = operatorStatus
-	setCrdsAndInstances(&operator)
+	setCrdsAndInstances()
 	dep := tnfConfig.Deployment{}
 	dep.Name = deploymentName
 	dep.Replicas = deploymentReplicas
-	operator.Deployments = append(operator.Deployments, dep)
-	setCnfAndPermissions(&operator)
 	operator.Tests = []string{testcases.OperatorStatus}
 	operator.CertifiedOperatorRequestInfos = []tnfConfig.CertifiedOperatorRequestInfo{
 		{
@@ -125,33 +115,19 @@ func loadOperatorConfig() {
 	loadCnfConfig()
 }
 
-func setCrdsAndInstances(op *tnfConfig.Operator) {
+func setCrdsAndInstances() {
 	crd := tnfConfig.Crd{}
 	crd.Name = crdNameOne
 	crd.Namespace = testNameSpace
 	instance := tnfConfig.Instance{}
 	instance.Name = instanceNameOne
 	crd.Instances = append(crd.Instances, instance)
-	op.CRDs = append(op.CRDs, crd)
 	crd2 := tnfConfig.Crd{}
 	crd2.Name = crdNameTwo
 	crd2.Namespace = testNameSpace
 	instance2 := tnfConfig.Instance{}
 	instance2.Name = instanceNameTwo
 	crd2.Instances = append(crd2.Instances, instance2)
-	op.CRDs = append(op.CRDs, crd2)
-}
-
-func setCnfAndPermissions(op *tnfConfig.Operator) {
-	cnf := tnfConfig.Cnf{}
-	cnf.Name = cnfName
-	cnf.Namespace = testNameSpace
-	cnf.Tests = []string{testcases.PrivilegedPod}
-	permission := tnfConfig.Permission{}
-	permission.Name = permissionName
-	permission.Role = permissionRole
-	op.Permissions = append(op.Permissions, permission)
-	op.CNFs = append(op.CNFs, cnf)
 }
 
 func loadFullConfig() {

--- a/test-network-function/cnf_test_configuration.yml
+++ b/test-network-function/cnf_test_configuration.yml
@@ -1,7 +1,6 @@
 operators:
   - name: etcdoperator.v0.9.4
     namespace: my-etcd
-    status: Succeeded
     autogenerate: false
     tests:
       - OPERATOR_STATUS
@@ -11,11 +10,9 @@ operators:
 cnfs:
   - name: ubuntu
     namespace: default
-    status: Running
     tests:
       - PRIVILEGED_POD
       - PRIVILEGED_ROLE
     certifiedcontainerrequestinfo:
       - name: nginx-116  # working example
         repository: rhel8
-        certificatetype: CONTAINER


### PR DESCRIPTION
These config options are not used in functional code, and
serve only to confuse the configuration.

Signed-off-by: Charlie Wheeler-Robinson <cwheeler@redhat.com>