### PR TITLE
Add configuration and documentation surrounding buffer sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,3 +348,28 @@ You will need an [OpenShift 4.4 installation](https://docs.openshift.com/contain
 running your CNF, and at least one other machine available to host the test suite.  The
 [cnf-certification-test-partner](https://github.com/test-network-function/cnf-certification-test-partner) repository has a very
 simple example of this you can model your setup on.
+
+# Known Issues
+
+## Issue #146:  Shell Output larger than 16KB requires specification of the TNF_DEFAULT_BUFFER_SIZE environment variable
+
+When dealing with large output, you may occasionally overrun the default buffer size. The manifestation of this issue is
+a `json.SyntaxError`, and may look similar to the following:
+
+```shell script
+    Expected
+        <*json.SyntaxError | 0xc0002bc020>: {
+            msg: "unexpected end of JSON input",
+            Offset: 660,
+        }
+    to be nil
+```
+
+In such cases, you will need to set the TNF_DEFAULT_BUFFER_SIZE to a sufficient size (in bytes) to handle the expected
+output.
+
+For example:
+
+```shell script
+TNF_DEFAULT_BUFFER_SIZE=32768 ./run-cnf-suites.sh diagnostic generic
+```


### PR DESCRIPTION
Buffer sizes cannot be made variable.  This is an unfortunate limitation of
the PTY library used by google/goexpect.  The issue is rooted in the fact that
a PTY is treated like a file that is not meant to close (receive io.EOF)
between commands.

As such, a configuration knob was added to allow setting interactive.BufferSize
for each interactive context.  If a client does not supply a BufferSize, then
the default is determined.

The default is determined by attempting to read the TNF_DEFAULT_BUFFER_SIZE
environment variable, and then parsing the result as an int.  If the
environment variable is not set or cannot be parsed as an int, then a const
default is used (16KB).

Additionally, this PR adds documentation to the README explaining the situation
in which the default buffer size may need to be set.  An example of setting the
environment variable and then running run-cnf-suites.sh is provided.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>