### PR TITLE
Test NodePort services do not exist

### DIFF
--- a/pkg/tnf/dependencies/binaries.go
+++ b/pkg/tnf/dependencies/binaries.go
@@ -40,4 +40,7 @@ const (
 
 	// XargsBinaryName is the name of the Unix `xargs` command.
 	XargsBinaryName = "xargs"
+
+	// GrepBinaryName is the name of the Unix `grep` command
+	GrepBinaryName = "grep"
 )

--- a/pkg/tnf/handlers/nodeport/doc.go
+++ b/pkg/tnf/handlers/nodeport/doc.go
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+// Package nodeport provides a test for testing services in the CNF pod's namespace
+package nodeport

--- a/pkg/tnf/handlers/nodeport/nodeport.go
+++ b/pkg/tnf/handlers/nodeport/nodeport.go
@@ -1,0 +1,99 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package nodeport
+
+import (
+	"strings"
+	"time"
+
+	"github.com/test-network-function/test-network-function/pkg/tnf"
+	"github.com/test-network-function/test-network-function/pkg/tnf/identifier"
+	"github.com/test-network-function/test-network-function/pkg/tnf/reel"
+)
+
+const (
+	npRegex = "(?s).+"
+)
+
+type NodePort struct {
+	result  int
+	timeout time.Duration
+	args    []string
+}
+
+func NewNodePort(timeout time.Duration, podNamespace string) *NodePort {
+	return &NodePort{
+		timeout: timeout,
+		result:  tnf.ERROR,
+		args: []string{"oc", "-n", podNamespace, "get", "services", "-o",
+			"custom-columns=TYPE:.spec.type", "|", "grep", "-E", "'NodePort|TYPE'"},
+	}
+}
+
+// Args returns the command line args for the test.
+func (np *NodePort) Args() []string {
+	return np.args
+}
+
+// GetIdentifier returns the tnf.Test specific identifier.
+func (np *NodePort) GetIdentifier() identifier.Identifier {
+	return identifier.NodePortIdentifier
+}
+
+// Timeout returns the timeout in seconds for the test.
+func (np *NodePort) Timeout() time.Duration {
+	return np.timeout
+}
+
+// Result returns the test result.
+func (np *NodePort) Result() int {
+	return np.result
+}
+
+// ReelFirst returns a step which expects the ping statistics within the test timeout.
+func (np *NodePort) ReelFirst() *reel.Step {
+	return &reel.Step{
+		Expect:  []string{npRegex},
+		Timeout: np.timeout,
+	}
+}
+
+func (np *NodePort) ReelMatch(_, _, match string) *reel.Step {
+	numExpectedLines := 1 // We want to have just the headers/titles line. Any other line is a NodePort line.
+
+	trimmedMatch := strings.Trim(match, "\n")
+
+	lines := strings.Split(trimmedMatch, "\n")
+	numLines := len(lines)
+
+	if numLines == numExpectedLines {
+		np.result = tnf.SUCCESS
+	}
+
+	if numLines > numExpectedLines {
+		np.result = tnf.FAILURE
+	}
+
+	return nil
+}
+
+func (np *NodePort) ReelTimeout() *reel.Step {
+	return nil
+}
+
+func (np *NodePort) ReelEOF() {
+}

--- a/pkg/tnf/handlers/nodeport/nodeport_test.go
+++ b/pkg/tnf/handlers/nodeport/nodeport_test.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package nodeport_test
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/test-network-function/pkg/tnf"
+	np "github.com/test-network-function/test-network-function/pkg/tnf/handlers/nodeport"
+)
+
+func Test_NewNodePort(t *testing.T) {
+	newNp(t)
+	assert.Equal(t, testTimeoutDuration, testNp.Timeout())
+	assert.Equal(t, testNp.Result(), tnf.ERROR)
+}
+
+func Test_Success(t *testing.T) {
+	match(t, testSuccessInput, false)
+}
+
+func Test_Failure(t *testing.T) {
+	match(t, testFailureInput, false)
+}
+
+func Test_Error(t *testing.T) {
+	match(t, testErrorInput, true)
+}
+
+func Test_ReelEof(t *testing.T) {
+	newNp(t)
+	testNp.ReelEOF()
+}
+
+const (
+	testTimeoutDuration   = time.Second * 2
+	testPodNamespace      = "testPodNamespace"
+	testErrorInput        = ""
+	testSuccessInput      = "TYPE\n"
+	testFailureInput      = "TYPE\nNodePort\n"
+	testNumMatchesNoError = 1
+	testNumMatchesError   = 0
+)
+
+var (
+	testNp *np.NodePort // a NodePort object used by all tests. New object is created by calling newNp()
+)
+
+func newNp(t *testing.T) {
+	testNp = np.NewNodePort(testTimeoutDuration, testPodNamespace)
+	assert.NotNil(t, testNp)
+}
+
+func match(t *testing.T, input string, expectError bool) {
+	newNp(t)
+	firstStep := testNp.ReelFirst()
+	re := regexp.MustCompile(firstStep.Expect[0])
+	matches := re.FindStringSubmatch(input)
+	if expectError {
+		assert.Len(t, matches, testNumMatchesError)
+		return
+	}
+	assert.Len(t, matches, testNumMatchesNoError)
+	step := testNp.ReelMatch("", "", matches[0])
+	assert.Nil(t, step)
+}

--- a/pkg/tnf/identifier/identifiers.go
+++ b/pkg/tnf/identifier/identifiers.go
@@ -29,6 +29,7 @@ const (
 	serviceAccountIdentifierURL     = "http://test-network-function.com/tests/serviceaccount"
 	roleBindingIdentifierURL        = "http://test-network-function.com/tests/rolebinding"
 	clusterRoleBindingIdentifierURL = "http://test-network-function.com/tests/clusterrolebinding"
+	nodePortIdentifierURL           = "http://test-network-function.com/tests/nodeport"
 
 	versionOne = "v1.0.0"
 )
@@ -195,6 +196,19 @@ var Catalog = map[string]TestCatalogEntry{
 			dependencies.OcBinaryName,
 		},
 	},
+	nodePortIdentifierURL: {
+		Identifier:  NodePortIdentifier,
+		Description: "A generic test used to test services of CNF pod's namespace.",
+		Type:        Normative,
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.OcBinaryName,
+			dependencies.GrepBinaryName,
+		},
+	},
 }
 
 // HostnameIdentifier is the Identifier used to represent the generic hostname test case.
@@ -254,5 +268,11 @@ var RoleBindingIdentifier = Identifier{
 // ClusterRoleBindingIdentifier is the Identifier used to represent the generic clusterRoleBinding test.
 var ClusterRoleBindingIdentifier = Identifier{
 	URL:             clusterRoleBindingIdentifierURL,
+	SemanticVersion: versionOne,
+}
+
+// NodePortIdentifier is the Identifier used to represent the generic NodePort test.
+var NodePortIdentifier = Identifier{
+	URL:             nodePortIdentifierURL,
 	SemanticVersion: versionOne,
 }

--- a/test-network-function/generic/suite.go
+++ b/test-network-function/generic/suite.go
@@ -29,6 +29,7 @@ import (
 	"github.com/test-network-function/test-network-function/pkg/tnf/handlers/base/redhat"
 	"github.com/test-network-function/test-network-function/pkg/tnf/handlers/clusterrolebinding"
 	"github.com/test-network-function/test-network-function/pkg/tnf/handlers/ipaddr"
+	"github.com/test-network-function/test-network-function/pkg/tnf/handlers/nodeport"
 	"github.com/test-network-function/test-network-function/pkg/tnf/handlers/ping"
 	"github.com/test-network-function/test-network-function/pkg/tnf/handlers/rolebinding"
 	"github.com/test-network-function/test-network-function/pkg/tnf/handlers/serviceaccount"
@@ -169,6 +170,10 @@ var _ = ginkgo.Describe(testsKey, func() {
 
 		for _, containersUnderTest := range containersUnderTest {
 			testRoles(context, containersUnderTest.oc.GetPodName(), containersUnderTest.oc.GetPodNamespace())
+		}
+
+		for _, containersUnderTest := range containersUnderTest {
+			testNodePort(context, containersUnderTest.oc.GetPodNamespace())
 		}
 	}
 })
@@ -322,5 +327,18 @@ func testClusterRoleBindings(context *interactive.Context, podNamespace string, 
 		}
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(testResult).To(gomega.Equal(tnf.SUCCESS))
+	})
+}
+
+func testNodePort(context *interactive.Context, podNamespace string) {
+	ginkgo.When(fmt.Sprintf("Testing services in namespace %s", podNamespace), func() {
+		ginkgo.It("Should not have services of type NodePort", func() {
+			tester := nodeport.NewNodePort(defaultTimeout, podNamespace)
+			test, err := tnf.NewTest(context.GetExpecter(), tester, []reel.Handler{tester}, context.GetErrorChannel())
+			gomega.Expect(err).To(gomega.BeNil())
+			testResult, err := test.Run()
+			gomega.Expect(testResult).To(gomega.Equal(tnf.SUCCESS))
+			gomega.Expect(err).To(gomega.BeNil())
+		})
 	})
 }


### PR DESCRIPTION
We want to make sure that CNF does not use services of type NodePort

https://issues.redhat.com/browse/CTONET-781