### PR TITLE
CTONET-782 - Subscription verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ accessed in user space, the test is unidirectional.
 
 ### operator tests
 
-Currently, the `operator` test spec is limited to a single test case called `OPERATOR_STATUS`.  `OPERATOR_STATUS` just
-checks that the `CSV` corresponding to the CNF Operator is properly installed.
+Currently, the `operator` test spec is limited to two test cases called `OPERATOR_STATUS`.  `OPERATOR_STATUS`
+checks that the `CSV` corresponding to the CNF Operator is properly installed and operator `Subscription` is available.
 
 In the future, tests surrounding `Operational Lifecycle Management` will be added.
 
@@ -326,6 +326,33 @@ operator
     /Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:121
       tests for: CSV_INSTALLED [It]
       /Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:122
+
+      Expected
+          <int>: 0
+      to equal
+          <int>: 1
+
+```
+
+The following is the output from a Test failure.  In this case, the test is checking that a Subscription
+is installed correctly, but does not find it (the operator was not present on the cluster under test):
+
+```shell
+------------------------------
+operator Runs test on operators when under test is: my-etcd/etcd
+  tests for: SUBSCRIPTION_INSTALLED
+  /Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:129
+2021/04/09 12:37:10 Sent: "oc get subscription etcd -n my-etcd -ojson | jq -r '.spec.name'\n"
+
+• Failure [10.000 seconds]
+operator
+/Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:55
+  Runs test on operators
+  /Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:68
+    when under test is: default/etcdoperator.v0.9.4 
+    /Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:128
+      tests for: SUBSCRIPTION_INSTALLED [It]
+      /Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:129
 
       Expected
           <int>: 0

--- a/pkg/config/cnf.go
+++ b/pkg/config/cnf.go
@@ -77,6 +77,9 @@ type Operator struct {
 	// Tests this is list of test that need to run against the operator.
 	Tests []string `yaml:"tests" json:"tests"`
 
+	// Subscription name is required field, Name of used subscription.
+	SubscriptionName string `yaml:"subscriptionName" json:"subscriptionName"`
+
 	// CertifiedOperatorRequestInfos  is list of  operator bundle names (`package-name`)
 	// that are queried for certificate status
 	CertifiedOperatorRequestInfos []CertifiedOperatorRequestInfo `yaml:"certifiedoperatorrequestinfo,omitempty" json:"certifiedoperatorrequestinfo,omitempty"`

--- a/pkg/config/example.yaml
+++ b/pkg/config/example.yaml
@@ -1,6 +1,7 @@
 operators:
   - name: etcdoperator.v0.9.4
     namespace: my-etcd
+    subscriptionName: etcd
     status: Succeeded
     autogenerate: "true"
     crds:
@@ -26,6 +27,7 @@ operators:
           - PRIVILEGED_POD
     tests:
       - CSV_INSTALLED
+      - SUBSCRIPTION_INSTALLED
     certifiedoperatorrequestinfo:
       - name: "etcd-operator"
         organization: "redhat-marketplace"

--- a/pkg/tnf/handlers/operator/operator_test.go
+++ b/pkg/tnf/handlers/operator/operator_test.go
@@ -34,6 +34,8 @@ const (
 	name                = "CSV_INSTALLED"
 	namespace           = "test"
 	command             = "oc get csv %s -n %s -o json | jq -r '.status.phase'"
+	subName             = "SUBSCRIPTION_INSTALLED"
+	subCommand          = "oc get subscription %s -n %s -ojson | jq -r '.spec.name'"
 )
 
 var (
@@ -43,11 +45,17 @@ var (
 	resultSliceExpectedStatus        = `["Running", "Installed"]`
 	resultSliceExpectedStatusInvalid = `["Not_Running", "Not_Installed"]`
 	args                             = strings.Split(fmt.Sprintf(command, name, namespace), " ")
+	subArgs                          = strings.Split(fmt.Sprintf(subCommand, subName, namespace), " ")
 )
 
 func TestOperator_Args(t *testing.T) {
 	c := operator.NewOperator(args, name, namespace, stringExpectedStatus, testcases.StringType, testcases.Allow, testTimeoutDuration)
 	assert.Equal(t, args, c.Args())
+}
+
+func TestOperator_SubArgs(t *testing.T) {
+	c := operator.NewOperator(subArgs, subName, namespace, stringExpectedStatus, testcases.StringType, testcases.Allow, testTimeoutDuration)
+	assert.Equal(t, subArgs, c.Args())
 }
 
 func TestOperator_GetIdentifier(t *testing.T) {

--- a/pkg/tnf/testcases/base_test.go
+++ b/pkg/tnf/testcases/base_test.go
@@ -135,11 +135,12 @@ func TestBaseTestCase_CNFExpectedStatusFn(t *testing.T) {
 func TestConfiguredTest_Operator_RenderTestCaseSpec(t *testing.T) {
 	var c = testcases.ConfiguredTest{}
 	c.Name = "OPERATOR_STATUS"
-	c.Tests = []string{"CSV_INSTALLED"}
+	c.Tests = []string{"CSV_INSTALLED", "SUBSCRIPTION_INSTALLED"}
 	b, err := c.RenderTestCaseSpec(testcases.Operator, testcases.OperatorStatus)
 	assert.Nil(t, err)
 	assert.NotNil(t, b)
 	assert.Equal(t, "CSV_INSTALLED", b.TestCase[0].Name)
+	assert.Equal(t, "SUBSCRIPTION_INSTALLED", b.TestCase[1].Name)
 
 	c.Name = "PRIVILEGED_POD"
 	c.Tests = []string{"HOST_NETWORK_CHECK"}

--- a/pkg/tnf/testcases/data/operator/operator.go
+++ b/pkg/tnf/testcases/data/operator/operator.go
@@ -28,6 +28,16 @@ var OperatorJSON = string(`{
       "expectedstatus": [
         "Succeeded"
       ]
+    },
+    {
+      "name": "SUBSCRIPTION_INSTALLED",
+      "skiptest": true,
+      "command": "oc get subscription %s -n %s -ojson | jq -r '.spec.name'",
+      "action": "allow",
+      "resulttype": "string",
+      "expectedstatus": [
+        "etcd"
+      ]
     }
   ]
 }`)

--- a/pkg/tnf/testcases/files/operator/operatorstatus.yml
+++ b/pkg/tnf/testcases/files/operator/operatorstatus.yml
@@ -7,4 +7,12 @@ testcase:
     expectedType: "string"
     expectedstatus:
       - "Succeeded"
+  - name: "SUBSCRIPTION_INSTALLED"
+    skiptest: false
+    command: "oc get subscription %s -n %s -ojson | jq -r '.spec.name'"
+    action: "allow"
+    resulttype: "string"
+    expectedType: "string"
+    expectedstatus:
+      - "etcd"
 

--- a/test-network-function/cnf_test_configuration.yml
+++ b/test-network-function/cnf_test_configuration.yml
@@ -1,6 +1,7 @@
 operators:
   - name: etcdoperator.v0.9.4
     namespace: my-etcd
+    subscriptionName: etcd
     autogenerate: false
     tests:
       - OPERATOR_STATUS

--- a/test-network-function/testconfigure.yml
+++ b/test-network-function/testconfigure.yml
@@ -16,3 +16,4 @@ operatortest:
   - name: "OPERATOR_STATUS"
     tests:
       - "CSV_INSTALLED"
+      - "SUBSCRIPTION_INSTALLED"


### PR DESCRIPTION
In order to make sure that an operator was installed via OLM we need to check whether Subscription was created for the operator. This PR adds `SUBSCRIPTION_INSTALLED` test case to existing operator tests.

Related-To: https://issues.redhat.com/browse/CTONET-782
Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>