### PR TITLE
removing the "interfacer" linter from .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,7 +79,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
     - misspell
     - nakedret


### PR DESCRIPTION
this  request is to eliminate the warning from {make lint}
level=warning msg="[runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner. "