### PR TITLE
CTONET-645 - scc verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ accessed in user space, the test is unidirectional.
 
 ### operator tests
 
-Currently, the `operator` test spec is limited to two test cases called `OPERATOR_STATUS`.  `OPERATOR_STATUS`
+Currently, the `operator` test spec is limited to three test cases called `OPERATOR_STATUS`.  `OPERATOR_STATUS`
 checks that the `CSV` corresponding to the CNF Operator is properly installed and operator `Subscription` is available.
+It checks whether operator is using privileged permissions by inspecting `clusterPermissions` specified in `CSV`. 
 
 In the future, tests surrounding `Operational Lifecycle Management` will be added.
 
@@ -352,6 +353,33 @@ operator
     when under test is: default/etcdoperator.v0.9.4 
     /Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:128
       tests for: SUBSCRIPTION_INSTALLED [It]
+      /Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:129
+
+      Expected
+          <int>: 0
+      to equal
+          <int>: 1
+
+```
+
+The following is the output from a Test failure.  In this case, the test is checking clusterPermissions for
+specific CSV, but does not find it (the operator was not present on the cluster under test):
+
+```shell
+------------------------------
+operator Runs test on operators when under test is: my-etcd/etcdoperator.v0.9.4  
+  tests for: CSV_SCC
+  /Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:129
+2021/04/20 14:47:52 Sent: "oc get csv etcdoperator.v0.9.4 -n my-etcd -o json | jq -r 'if .spec.install.spec.clusterPermissions == null then null else . end | if . == null then \"EMPTY\" else .spec.install.spec.clusterPermissions[].rules[].resourceNames end'\n"
+
+• Failure [10.001 seconds]
+operator
+/Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:55
+  Runs test on operators
+  /Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:68
+    when under test is: my-etcd/etcdoperator.v0.9.4 
+    /Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:128
+      tests for: CSV_SCC [It]
       /Users/$USER/cnf-cert/test-network-function/test-network-function/operator/suite.go:129
 
       Expected

--- a/pkg/config/example.yaml
+++ b/pkg/config/example.yaml
@@ -28,6 +28,7 @@ operators:
     tests:
       - CSV_INSTALLED
       - SUBSCRIPTION_INSTALLED
+      - CSV_SCC
     certifiedoperatorrequestinfo:
       - name: "etcd-operator"
         organization: "redhat-marketplace"

--- a/pkg/tnf/handlers/operator/operator_test.go
+++ b/pkg/tnf/handlers/operator/operator_test.go
@@ -36,6 +36,8 @@ const (
 	command             = "oc get csv %s -n %s -o json | jq -r '.status.phase'"
 	subName             = "SUBSCRIPTION_INSTALLED"
 	subCommand          = "oc get subscription %s -n %s -ojson | jq -r '.spec.name'"
+	sccName             = "CSV_SCC"
+	sccCommand          = "oc get csv %s -n %s -o json | jq -r 'if .spec.install.spec.clusterPermissions == null then null else . end | if . == null then \"EMPTY\" else .spec.install.spec.clusterPermissions[].rules[].resourceNames end'"
 )
 
 var (
@@ -46,6 +48,7 @@ var (
 	resultSliceExpectedStatusInvalid = `["Not_Running", "Not_Installed"]`
 	args                             = strings.Split(fmt.Sprintf(command, name, namespace), " ")
 	subArgs                          = strings.Split(fmt.Sprintf(subCommand, subName, namespace), " ")
+	sccArgs                          = strings.Split(fmt.Sprintf(sccCommand, sccName, namespace), " ")
 )
 
 func TestOperator_Args(t *testing.T) {
@@ -56,6 +59,11 @@ func TestOperator_Args(t *testing.T) {
 func TestOperator_SubArgs(t *testing.T) {
 	c := operator.NewOperator(subArgs, subName, namespace, stringExpectedStatus, testcases.StringType, testcases.Allow, testTimeoutDuration)
 	assert.Equal(t, subArgs, c.Args())
+}
+
+func TestOperator_SccArgs(t *testing.T) {
+	c := operator.NewOperator(sccArgs, sccName, namespace, stringExpectedStatus, testcases.StringType, testcases.Allow, testTimeoutDuration)
+	assert.Equal(t, sccArgs, c.Args())
 }
 
 func TestOperator_GetIdentifier(t *testing.T) {

--- a/pkg/tnf/testcases/base_test.go
+++ b/pkg/tnf/testcases/base_test.go
@@ -135,12 +135,13 @@ func TestBaseTestCase_CNFExpectedStatusFn(t *testing.T) {
 func TestConfiguredTest_Operator_RenderTestCaseSpec(t *testing.T) {
 	var c = testcases.ConfiguredTest{}
 	c.Name = "OPERATOR_STATUS"
-	c.Tests = []string{"CSV_INSTALLED", "SUBSCRIPTION_INSTALLED"}
+	c.Tests = []string{"CSV_INSTALLED", "SUBSCRIPTION_INSTALLED", "CSV_SCC"}
 	b, err := c.RenderTestCaseSpec(testcases.Operator, testcases.OperatorStatus)
 	assert.Nil(t, err)
 	assert.NotNil(t, b)
 	assert.Equal(t, "CSV_INSTALLED", b.TestCase[0].Name)
 	assert.Equal(t, "SUBSCRIPTION_INSTALLED", b.TestCase[1].Name)
+	assert.Equal(t, "CSV_SCC", b.TestCase[2].Name)
 
 	c.Name = "PRIVILEGED_POD"
 	c.Tests = []string{"HOST_NETWORK_CHECK"}

--- a/pkg/tnf/testcases/data/operator/operator.go
+++ b/pkg/tnf/testcases/data/operator/operator.go
@@ -38,6 +38,16 @@ var OperatorJSON = string(`{
       "expectedstatus": [
         "etcd"
       ]
+    },
+    {
+      "name": "CSV_SCC",
+      "skiptest": true,
+      "command": "oc get csv %s -n %s -o json | jq -r 'if .spec.install.spec.clusterPermissions == null then null else . end | if . == null then \"EMPTY\" else .spec.install.spec.clusterPermissions[].rules[].resourceNames end'",
+      "action": "allow",
+      "resulttype": "string",
+      "expectedstatus": [
+        "EMPTY"
+      ]
     }
   ]
 }`)

--- a/pkg/tnf/testcases/files/operator/operatorstatus.yml
+++ b/pkg/tnf/testcases/files/operator/operatorstatus.yml
@@ -15,4 +15,12 @@ testcase:
     expectedType: "string"
     expectedstatus:
       - "etcd"
+  - name: "CSV_SCC"
+    skiptest: false
+    command: "oc get csv %s -n %s -o json | jq -r 'if .spec.install.spec.clusterPermissions == null then null else . end | if . == null then \"EMPTY\" else .spec.install.spec.clusterPermissions[].rules[].resourceNames end'"
+    action: "allow"
+    resulttype: "string"
+    expectedtype: "string"
+    expectedstatus: 
+      - "EMPTY"
 

--- a/test-network-function/testconfigure.yml
+++ b/test-network-function/testconfigure.yml
@@ -17,3 +17,4 @@ operatortest:
     tests:
       - "CSV_INSTALLED"
       - "SUBSCRIPTION_INSTALLED"
+      - "CSV_SCC"


### PR DESCRIPTION
In this test we check whether `clusterPermissions` are set for specific `ClusterServiceVersion` is installed. We test etcd operator which is not using the permissions but this tests enable us to check whether operator in test is using `privileged` and in this case we should fail and analyze why such permission is needed.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>