### PR TITLE
removing custom ginkgo reporters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,5 +20,4 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	google.golang.org/grpc v1.37.0
 	gopkg.in/yaml.v2 v2.4.0
-	kubevirt.io/qe-tools v0.1.7
 )

--- a/go.sum
+++ b/go.sum
@@ -171,7 +171,6 @@ github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.1 h1:foqVmeWDD6yYpK+Yz3fHyNIxFYNxswxqNFjSKe+vI54=
 github.com/onsi/ginkgo v1.16.1/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
@@ -318,7 +317,6 @@ golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091 h1:DMyOG0U+gKfu8JZzg2UQe9MeaC1X+xQWlAKcRnjxjCw=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -417,6 +415,4 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-kubevirt.io/qe-tools v0.1.7 h1:7fdEwwqKKiLa5wlrrTboqpjX7MMzR7CMZfyzZIQ1iUw=
-kubevirt.io/qe-tools v0.1.7/go.mod h1:O1EynUeGswOi4Embakmv+SsGwr+U3ILHgit9pptK2qk=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -36,6 +36,9 @@ done
 GINKGO_ARGS="-ginkgo.v -junit . -report $OUTPUT_LOC -claimloc $OUTPUT_LOC"
 FOCUS=""
 
+# specify Junit report file name.
+GINKGO_ARGS2="-ginkgo.reportFile $OUTPUT_LOC/"cnf-certification-tests_junit.xml""
+
 for var in "$@"
 do
 	case "$var" in
@@ -54,4 +57,4 @@ done
 FOCUS=${FOCUS%?}  # strip the trailing "|" from the concatenation
 
 echo "Running with focus '$FOCUS'. Report will be output to '$OUTPUT_LOC'"
-cd ./test-network-function && ./test-network-function.test -ginkgo.focus="$FOCUS" ${GINKGO_ARGS}
+cd ./test-network-function && ./test-network-function.test -ginkgo.focus="$FOCUS" ${GINKGO_ARGS} ${GINKGO_ARGS2}

--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -32,12 +32,10 @@ while [[ $1 == -* ]]; do
 		-*) echo "invalid option: $1" 1>&2; usage_error;;
 	esac
 done
-
-GINKGO_ARGS="-ginkgo.v -junit . -report $OUTPUT_LOC -claimloc $OUTPUT_LOC"
+# specify Junit report file name here.
+GINKGO_ARGS="-ginkgo.v -junit . -claimloc $OUTPUT_LOC -ginkgo.reportFile $OUTPUT_LOC/"cnf-certification-tests_junit.xml""
 FOCUS=""
 
-# specify Junit report file name.
-GINKGO_ARGS2="-ginkgo.reportFile $OUTPUT_LOC/"cnf-certification-tests_junit.xml""
 
 for var in "$@"
 do
@@ -57,4 +55,4 @@ done
 FOCUS=${FOCUS%?}  # strip the trailing "|" from the concatenation
 
 echo "Running with focus '$FOCUS'. Report will be output to '$OUTPUT_LOC'"
-cd ./test-network-function && ./test-network-function.test -ginkgo.focus="$FOCUS" ${GINKGO_ARGS} ${GINKGO_ARGS2}
+cd ./test-network-function && ./test-network-function.test -ginkgo.focus="$FOCUS" ${GINKGO_ARGS}

--- a/test-network-function/suite_test.go
+++ b/test-network-function/suite_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 	"github.com/test-network-function/test-network-function-claim/pkg/claim"
@@ -37,7 +36,6 @@ import (
 	_ "github.com/test-network-function/test-network-function/test-network-function/generic"
 	_ "github.com/test-network-function/test-network-function/test-network-function/operator"
 	"github.com/test-network-function/test-network-function/test-network-function/version"
-	ginkgoreporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
 const (
@@ -109,17 +107,7 @@ func TestTest(t *testing.T) {
 		Tnf: tnfVersion.Tag,
 	}
 
-	var ginkgoReporters []ginkgo.Reporter
-	if ginkgoreporters.Polarion.Run {
-		ginkgoReporters = append(ginkgoReporters, &ginkgoreporters.Polarion)
-	}
-
-	if *junitPath != "" {
-		junitFile := path.Join(*junitPath, JunitXMLFileName)
-		ginkgoReporters = append(ginkgoReporters, reporters.NewJUnitReporter(junitFile))
-	}
-
-	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, CnfCertificationTestSuiteName, ginkgoReporters)
+	ginkgo.RunSpecs(t, CnfCertificationTestSuiteName)
 	junitMap := make(map[string]interface{})
 	var extension = filepath.Ext(JunitXMLFileName)
 	reportKeyName := JunitXMLFileName[0 : len(JunitXMLFileName)-len(extension)]


### PR DESCRIPTION
Ginkgo has added junit support to the core so the custom
reporters are no longer needed and can be removed.