### PR TITLE
ensure a CNF is usable after cordoning a node

### DIFF
--- a/pkg/tnf/handlers/deployments/deployments.go
+++ b/pkg/tnf/handlers/deployments/deployments.go
@@ -1,0 +1,140 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package deployments
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/test-network-function/test-network-function/pkg/tnf"
+	"github.com/test-network-function/test-network-function/pkg/tnf/identifier"
+	"github.com/test-network-function/test-network-function/pkg/tnf/reel"
+)
+
+const (
+	dpRegex = "(?s).+"
+)
+
+// Deployment holds information about a single deployment
+type Deployment struct {
+	Replicas    int
+	Ready       int
+	UpToDate    int
+	Available   int
+	Unavailable int
+}
+
+// DeploymentMap name to Deployment
+type DeploymentMap map[string]Deployment
+
+// Deployments holds information derived from running "oc -n <namespace> get deployments" on the command line.
+type Deployments struct {
+	deployments DeploymentMap
+	result      int
+	timeout     time.Duration
+	args        []string
+}
+
+// NewDeployments creates a new Deployments tnf.Test.
+func NewDeployments(timeout time.Duration, namespace string) *Deployments {
+	return &Deployments{
+		timeout: timeout,
+		result:  tnf.ERROR,
+		args: []string{"oc", "-n", namespace, "get", "deployments", "-o", "custom-columns=" +
+			"NAME:.metadata.name," +
+			"REPLICAS:.spec.replicas," +
+			"READY:.status.readyReplicas," +
+			"UPDATED:.status.updatedReplicas," +
+			"AVAILABLE:.status.availableReplicas," +
+			"UNAVAILABLE:.status.unavailableReplicas",
+		},
+		deployments: DeploymentMap{},
+	}
+}
+
+// GetDeployments returns deployments extracted from running the Deployments tnf.Test.
+func (dp *Deployments) GetDeployments() DeploymentMap {
+	return dp.deployments
+}
+
+// Args returns the command line args for the test.
+func (dp *Deployments) Args() []string {
+	return dp.args
+}
+
+// GetIdentifier returns the tnf.Test specific identifiesa.
+func (dp *Deployments) GetIdentifier() identifier.Identifier {
+	return identifier.DeploymentsIdentifier
+}
+
+// Timeout returns the timeout in seconds for the test.
+func (dp *Deployments) Timeout() time.Duration {
+	return dp.timeout
+}
+
+// Result returns the test result.
+func (dp *Deployments) Result() int {
+	return dp.result
+}
+
+// ReelFirst returns a step which expects the ping statistics within the test timeout.
+func (dp *Deployments) ReelFirst() *reel.Step {
+	return &reel.Step{
+		Expect:  []string{dpRegex},
+		Timeout: dp.timeout,
+	}
+}
+
+// ReelMatch ensures that list of nodes is not empty and stores the names as []string
+func (dp *Deployments) ReelMatch(_, _, match string) *reel.Step {
+	const numExepctedFields = 6
+	trimmedMatch := strings.Trim(match, "\n")
+	lines := strings.Split(trimmedMatch, "\n")[1:] // First line is the headers/titles line
+
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != numExepctedFields {
+			return nil
+		}
+		dp.deployments[fields[0]] = Deployment{atoi(fields[1]), atoi(fields[2]), atoi(fields[3]), atoi(fields[4]), atoi(fields[5])}
+	}
+
+	dp.result = tnf.SUCCESS
+	return nil
+}
+
+// ReelTimeout does nothing;  no action is necessary upon timeout.
+func (dp *Deployments) ReelTimeout() *reel.Step {
+	return nil
+}
+
+// ReelEOF does nothing;  no action is necessary upon EOF.
+func (dp *Deployments) ReelEOF() {
+}
+
+func atoi(s string) int {
+	const noneStr = "<none>"
+	var num int
+	if s != noneStr {
+		num, _ = strconv.Atoi(s)
+	}
+	return num
+}

--- a/pkg/tnf/handlers/deployments/deployments_test.go
+++ b/pkg/tnf/handlers/deployments/deployments_test.go
@@ -1,0 +1,109 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package deployments_test
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/test-network-function/pkg/tnf"
+	dp "github.com/test-network-function/test-network-function/pkg/tnf/handlers/deployments"
+)
+
+func Test_NewDeployments(t *testing.T) {
+	newDp := dp.NewDeployments(testTimeoutDuration, testNamespace)
+	assert.NotNil(t, newDp)
+	assert.Equal(t, testTimeoutDuration, newDp.Timeout())
+	assert.Equal(t, newDp.Result(), tnf.ERROR)
+	assert.NotNil(t, newDp.GetDeployments())
+}
+
+func Test_ReelFirstPositive(t *testing.T) {
+	newDp := dp.NewDeployments(testTimeoutDuration, testNamespace)
+	assert.NotNil(t, newDp)
+	firstStep := newDp.ReelFirst()
+	re := regexp.MustCompile(firstStep.Expect[0])
+	matches := re.FindStringSubmatch(testInputSuccess)
+	assert.Len(t, matches, 1)
+	assert.Equal(t, testInputSuccess, matches[0])
+}
+
+func Test_ReelFirstNegative(t *testing.T) {
+	newDp := dp.NewDeployments(testTimeoutDuration, testNamespace)
+	assert.NotNil(t, newDp)
+	firstStep := newDp.ReelFirst()
+	re := regexp.MustCompile(firstStep.Expect[0])
+	matches := re.FindStringSubmatch(testInputError)
+	assert.Len(t, matches, 0)
+}
+
+func Test_ReelMatchSuccess(t *testing.T) {
+	newDp := dp.NewDeployments(testTimeoutDuration, testNamespace)
+	assert.NotNil(t, newDp)
+	step := newDp.ReelMatch("", "", testInputSuccess)
+	assert.Nil(t, step)
+	assert.Equal(t, tnf.SUCCESS, newDp.Result())
+	assert.Len(t, newDp.GetDeployments(), testInputSuccessNumLines)
+
+	expectedDeployments := dp.DeploymentMap{
+		"cdi-apiserver":                   {1, 1, 1, 1, 0},
+		"hyperconverged-cluster-operator": {1, 0, 1, 0, 1},
+		"virt-api":                        {2, 2, 2, 2, 0},
+		"vm-import-operator":              {0, 0, 0, 0, 0},
+	}
+	deployments := newDp.GetDeployments()
+
+	for name, expected := range expectedDeployments {
+		deployment, ok := deployments[name]
+		assert.True(t, ok)
+		assert.Equal(t, expected, deployment)
+	}
+}
+
+// Just ensure there are no panics.
+func Test_ReelEof(t *testing.T) {
+	newDp := dp.NewDeployments(testTimeoutDuration, testNamespace)
+	assert.NotNil(t, newDp)
+	newDp.ReelEOF()
+}
+
+const (
+	testTimeoutDuration      = time.Second * 2
+	testNamespace            = "testNamespace"
+	testInputError           = ""
+	testInputSuccessNumLines = 17
+	testInputSuccess         = `NAME                                 REPLICAS   READY    UPDATED   AVAILABLE   UNAVAILABLE
+	cdi-apiserver                        1          1        1         1           <none>
+	cdi-deployment                       1          1        1         1           <none>
+	cdi-operator                         1          1        1         1           <none>
+	cdi-uploadproxy                      1          1        1         1           <none>
+	cluster-network-addons-operator      1          1        1         1           <none>
+	hostpath-provisioner-operator        1          1        1         1           <none>
+	hyperconverged-cluster-operator      1          <none>   1         <none>      1
+	kubemacpool-mac-controller-manager   1          1        1         1           <none>
+	kubevirt-ssp-operator                1          <none>   1         <none>      1
+	nmstate-webhook                      2          2        2         2           <none>
+	node-maintenance-operator            1          <none>   1         <none>      1
+	v2v-vmware                           1          1        1         1           <none>
+	virt-api                             2          2        2         2           <none>
+	virt-controller                      2          2        2         2           <none>
+	virt-operator                        2          2        2         2           <none>
+	virt-template-validator              2          2        2         2           <none>
+	vm-import-operator                   0          <none>   <none>    <none>      <none>`
+)

--- a/pkg/tnf/handlers/deployments/doc.go
+++ b/pkg/tnf/handlers/deployments/doc.go
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+// Package deployments provides a test for reading the namespace's deployments
+package deployments

--- a/pkg/tnf/handlers/deploymentsdrain/deploymentsdrain.go
+++ b/pkg/tnf/handlers/deploymentsdrain/deploymentsdrain.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package deploymentsdrain
+
+import (
+	"time"
+
+	"github.com/test-network-function/test-network-function/pkg/tnf"
+	"github.com/test-network-function/test-network-function/pkg/tnf/identifier"
+	"github.com/test-network-function/test-network-function/pkg/tnf/reel"
+)
+
+const (
+	ddRegex                = "SUCCESS"
+	drainTimeoutPercentage = 90 // drain timeout is a percentage of test timeout
+)
+
+// DeploymentsDrain holds information derived from running "oc adm drain" on the command line.
+type DeploymentsDrain struct {
+	result  int
+	timeout time.Duration
+	args    []string
+}
+
+// NewDeploymentsDrain creates a new DeploymentsDrain tnf.Test.
+func NewDeploymentsDrain(timeout time.Duration, node string) *DeploymentsDrain {
+	drainTimeout := timeout * drainTimeoutPercentage / 100
+	drainTimeoutString := drainTimeout.String()
+	return &DeploymentsDrain{
+		timeout: timeout,
+		result:  tnf.ERROR,
+		args: []string{
+			"oc", "adm", "drain", node, "--pod-selector=pod-template-hash", "--disable-eviction=true",
+			"--delete-local-data=true", "--ignore-daemonsets=true", "--timeout=" + drainTimeoutString,
+			"&&", "echo", "SUCCESS",
+		},
+	}
+}
+
+// Args returns the command line args for the test.
+func (dd *DeploymentsDrain) Args() []string {
+	return dd.args
+}
+
+// GetIdentifier returns the tnf.Test specific identifiesa.
+func (dd *DeploymentsDrain) GetIdentifier() identifier.Identifier {
+	return identifier.DeploymentsDrainIdentifier
+}
+
+// Timeout returns the timeout in seconds for the test.
+func (dd *DeploymentsDrain) Timeout() time.Duration {
+	return dd.timeout
+}
+
+// Result returns the test result.
+func (dd *DeploymentsDrain) Result() int {
+	return dd.result
+}
+
+// ReelFirst returns a step which expects the output within the test timeout.
+func (dd *DeploymentsDrain) ReelFirst() *reel.Step {
+	return &reel.Step{
+		Expect:  []string{ddRegex},
+		Timeout: dd.timeout,
+	}
+}
+
+// ReelMatch sets result
+func (dd *DeploymentsDrain) ReelMatch(_, _, _ string) *reel.Step {
+	dd.result = tnf.SUCCESS
+	return nil
+}
+
+// ReelTimeout does nothing;  no action is necessary upon timeout.
+func (dd *DeploymentsDrain) ReelTimeout() *reel.Step {
+	return nil
+}
+
+// ReelEOF does nothing;  no action is necessary upon EOF.
+func (dd *DeploymentsDrain) ReelEOF() {
+}

--- a/pkg/tnf/handlers/deploymentsdrain/deploymentsdrain_test.go
+++ b/pkg/tnf/handlers/deploymentsdrain/deploymentsdrain_test.go
@@ -1,0 +1,171 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package deploymentsdrain_test
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/test-network-function/pkg/tnf"
+	dd "github.com/test-network-function/test-network-function/pkg/tnf/handlers/deploymentsdrain"
+)
+
+func Test_NewDeploymentsDrain(t *testing.T) {
+	newDd := dd.NewDeploymentsDrain(testTimeoutDuration, testNode)
+	assert.NotNil(t, newDd)
+	assert.Equal(t, testTimeoutDuration, newDd.Timeout())
+	assert.Equal(t, newDd.Result(), tnf.ERROR)
+}
+
+func Test_ReelFirstPositive(t *testing.T) {
+	newDd := dd.NewDeploymentsDrain(testTimeoutDuration, testNode)
+	assert.NotNil(t, newDd)
+	firstStep := newDd.ReelFirst()
+	re := regexp.MustCompile(firstStep.Expect[0])
+	matches := re.FindStringSubmatch(testInputSuccess)
+	assert.Len(t, matches, 1)
+}
+
+func Test_ReelFirstNegative(t *testing.T) {
+	newDd := dd.NewDeploymentsDrain(testTimeoutDuration, testNode)
+	assert.NotNil(t, newDd)
+	firstStep := newDd.ReelFirst()
+	re := regexp.MustCompile(firstStep.Expect[0])
+	matches := re.FindStringSubmatch(testInputError)
+	assert.Len(t, matches, 0)
+}
+
+func Test_ReelMatchSuccess(t *testing.T) {
+	newDd := dd.NewDeploymentsDrain(testTimeoutDuration, testNode)
+	assert.NotNil(t, newDd)
+	step := newDd.ReelMatch("", "", "")
+	assert.Nil(t, step)
+	assert.Equal(t, tnf.SUCCESS, newDd.Result())
+}
+
+// Just ensure there are no panics.
+func Test_ReelEof(t *testing.T) {
+	newDd := dd.NewDeploymentsDrain(testTimeoutDuration, testNode)
+	assert.NotNil(t, newDd)
+	newDd.ReelEOF()
+}
+
+const (
+	testTimeoutDuration = time.Second * 2
+	testNode            = "testNode"
+	testInputError      = `node/worker-0-0 cordoned
+	pod/cert-manager-webhook-5f57f59fbc-fp4j4 deleted
+	pod/cdi-apiserver-58ccb6859d-kq4jj deleted
+	pod/cdi-operator-5d865dbf9b-q5sfn deleted
+	pod/hco-webhook-645d67694f-cx4lz deleted
+	pod/hco-operator-845485f57d-csh9h deleted
+	pod/hostpath-provisioner-operator-9df4ccdb-ddvbp deleted
+	pod/kubevirt-ssp-operator-6594456c66-4m6wb deleted
+	pod/virt-api-7d9f6484c8-sjb7z deleted
+	pod/virt-api-7d9f6484c8-zh5wb deleted
+	pod/virt-controller-cc5d899b8-v72fv deleted
+	pod/virt-controller-cc5d899b8-wczxc deleted
+	pod/virt-operator-5f47db64cc-97nlq deleted
+	pod/virt-operator-5f47db64cc-n7ztz deleted
+	pod/virt-template-validator-6866fc5854-g9xp5 deleted
+	pod/virt-template-validator-6866fc5854-pbgtz deleted
+	pod/vm-import-controller-75b64fcc85-64dkh deleted
+	pod/vm-import-operator-db4787bb5-7clwz deleted
+	pod/image-registry-bcb6f5f56-mkg49 deleted
+	pod/migrator-598bf8d49b-9zqct deleted
+	pod/grafana-74657cc99d-97fzd deleted
+	pod/kube-state-metrics-6f9495ff98-gwxdv deleted
+	pod/openshift-state-metrics-7466679bfb-s9ggg deleted
+	pod/prometheus-adapter-76cc597d7d-4q686 deleted
+	pod/prometheus-adapter-76cc597d7d-8kmzh deleted
+	pod/telemeter-client-6dc8858fc-25w96 deleted
+	pod/thanos-querier-5b5c97b84f-4ggt5 deleted
+	pod/thanos-querier-5b5c97b84f-f9tt2 deleted
+	pod/network-check-source-85c57b85d7-xhqpf deleted
+	pod/cert-manager-5597cff495-9bjrb deleted
+	pod/cert-manager-cainjector-bd5f9c764-87j2v deleted
+	pod/cdi-deployment-84d9d6bcb8-7974j deleted
+	pod/dep1-7959744869-jtt7j deleted
+	pod/dep1-7959744869-ths9l deleted
+	pod/dep2-75fdb9b54b-t75hj deleted
+	pod/cdi-uploadproxy-67f696bcb9-6wq69 deleted
+	pod/router-default-57cbd67577-pvdnq deleted
+	pod/dep1-7959744869-2m787 deleted
+	pod/dep2-75fdb9b54b-kclpx deleted
+	pod/dep2-75fdb9b54b-v8jng deleted
+	There are pending pods in node "worker-0-0" when an error occurred: timed out waiting for the condition
+	pod/cluster-network-addons-operator-57bddf6b86-qkq4m
+	pod/hco-webhook-5ccd87ff7c-kzwnp
+	error: unable to drain node "worker-0-0", aborting command...
+	
+	There are pending nodes to be drained:
+	 worker-0-0
+	error: timed out waiting for the condition
+	`
+	testInputSuccess = `node/worker-0-0 cordoned
+	pod/cert-manager-webhook-5f57f59fbc-fp4j4 deleted
+	pod/cdi-apiserver-58ccb6859d-kq4jj deleted
+	pod/cdi-operator-5d865dbf9b-q5sfn deleted
+	pod/hco-webhook-645d67694f-cx4lz deleted
+	pod/hco-operator-845485f57d-csh9h deleted
+	pod/hostpath-provisioner-operator-9df4ccdb-ddvbp deleted
+	pod/kubevirt-ssp-operator-6594456c66-4m6wb deleted
+	pod/virt-api-7d9f6484c8-sjb7z deleted
+	pod/virt-api-7d9f6484c8-zh5wb deleted
+	pod/virt-controller-cc5d899b8-v72fv deleted
+	pod/virt-controller-cc5d899b8-wczxc deleted
+	pod/virt-operator-5f47db64cc-97nlq deleted
+	pod/virt-operator-5f47db64cc-n7ztz deleted
+	pod/virt-template-validator-6866fc5854-g9xp5 deleted
+	pod/virt-template-validator-6866fc5854-pbgtz deleted
+	pod/vm-import-controller-75b64fcc85-64dkh deleted
+	pod/vm-import-operator-db4787bb5-7clwz deleted
+	pod/image-registry-bcb6f5f56-mkg49 deleted
+	pod/migrator-598bf8d49b-9zqct deleted
+	pod/grafana-74657cc99d-97fzd deleted
+	pod/kube-state-metrics-6f9495ff98-gwxdv deleted
+	pod/openshift-state-metrics-7466679bfb-s9ggg deleted
+	pod/prometheus-adapter-76cc597d7d-4q686 deleted
+	pod/prometheus-adapter-76cc597d7d-8kmzh deleted
+	pod/telemeter-client-6dc8858fc-25w96 deleted
+	pod/thanos-querier-5b5c97b84f-4ggt5 deleted
+	pod/thanos-querier-5b5c97b84f-f9tt2 deleted
+	pod/network-check-source-85c57b85d7-xhqpf deleted
+	pod/cert-manager-5597cff495-9bjrb deleted
+	pod/cert-manager-cainjector-bd5f9c764-87j2v deleted
+	pod/cdi-deployment-84d9d6bcb8-7974j deleted
+	pod/dep1-7959744869-jtt7j deleted
+	pod/dep1-7959744869-ths9l deleted
+	pod/dep2-75fdb9b54b-t75hj deleted
+	pod/cdi-uploadproxy-67f696bcb9-6wq69 deleted
+	pod/router-default-57cbd67577-pvdnq deleted
+	pod/dep1-7959744869-2m787 deleted
+	pod/dep2-75fdb9b54b-kclpx deleted
+	pod/dep2-75fdb9b54b-v8jng deleted
+	There are pending pods in node "worker-0-0" when an error occurred: timed out waiting for the condition
+	pod/cluster-network-addons-operator-57bddf6b86-qkq4m
+	pod/hco-webhook-5ccd87ff7c-kzwnp
+	error: unable to drain node "worker-0-0", aborting command...
+	
+	There are pending nodes to be drained:
+	 worker-0-0
+	error: timed out waiting for the condition
+	SUCCESS
+	`
+)

--- a/pkg/tnf/handlers/deploymentsdrain/doc.go
+++ b/pkg/tnf/handlers/deploymentsdrain/doc.go
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+// Package deploymentsdrain provides a test for draining a node from deployments pods
+package deploymentsdrain

--- a/pkg/tnf/handlers/deploymentsnodes/deploymentsnodes.go
+++ b/pkg/tnf/handlers/deploymentsnodes/deploymentsnodes.go
@@ -1,0 +1,150 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package deploymentsnodes
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/test-network-function/test-network-function/pkg/tnf"
+	"github.com/test-network-function/test-network-function/pkg/tnf/identifier"
+	"github.com/test-network-function/test-network-function/pkg/tnf/reel"
+)
+
+const (
+	dnRegex      = "(?s).+"
+	podNameRegex = "(.+)-[0-9a-z]+-[0-9a-z]+$" // pod name is <deployment>-<pod-template-hash>-<pod-hash>
+)
+
+// NodesMap node name to deployments map
+type NodesMap map[string]map[string]bool
+
+// DeploymentsNodes holds a mapping of nodes to deployments
+type DeploymentsNodes struct {
+	nodes   NodesMap // map nodes to deployments
+	result  int
+	timeout time.Duration
+	args    []string
+}
+
+// NewDeploymentsNodes creates a new DeploymentsNodes tnf.Test.
+func NewDeploymentsNodes(timeout time.Duration, namespace string) *DeploymentsNodes {
+	return &DeploymentsNodes{
+		timeout: timeout,
+		result:  tnf.ERROR,
+		args: []string{"oc", "-n", namespace, "get", "pods",
+			"-l", "pod-template-hash",
+			"-o", "custom-columns=" +
+				"NAME:.metadata.name," +
+				"NODE:.spec.nodeName",
+		},
+		nodes: NodesMap{},
+	}
+}
+
+// GetNodes returns nodes to deployments mapping extracted from running the NodesDeployments tnf.Test.
+func (dn *DeploymentsNodes) GetNodes() NodesMap {
+	return dn.nodes
+}
+
+// Args returns the command line args for the test.
+func (dn *DeploymentsNodes) Args() []string {
+	return dn.args
+}
+
+// GetIdentifier returns the tnf.Test specific identifiesa.
+func (dn *DeploymentsNodes) GetIdentifier() identifier.Identifier {
+	return identifier.DeploymentsNodesIdentifier
+}
+
+// Timeout returns the timeout in seconds for the test.
+func (dn *DeploymentsNodes) Timeout() time.Duration {
+	return dn.timeout
+}
+
+// Result returns the test result.
+func (dn *DeploymentsNodes) Result() int {
+	return dn.result
+}
+
+// ReelFirst returns a step which expects the ping statistics within the test timeout.
+func (dn *DeploymentsNodes) ReelFirst() *reel.Step {
+	return &reel.Step{
+		Expect:  []string{dnRegex},
+		Timeout: dn.timeout,
+	}
+}
+
+// ReelMatch ensures that list of nodes is not empty and stores the names as []string
+func (dn *DeploymentsNodes) ReelMatch(_, _, match string) *reel.Step {
+	const (
+		numExepctedFields = 2
+		podNameIdx        = 0
+		nodeNameIdx       = 1
+	)
+	trimmedMatch := strings.Trim(match, "\n")
+	lines := strings.Split(trimmedMatch, "\n")[1:] // First line is the headers/titles line
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != numExepctedFields {
+			return nil
+		}
+		podName := fields[podNameIdx]
+		nodeName := fields[nodeNameIdx]
+		node, ok := dn.nodes[nodeName]
+		if !ok {
+			node = map[string]bool{}
+			dn.nodes[nodeName] = node
+		}
+		deploymentName := extractDeployment(podName)
+		if deploymentName == "" {
+			return nil
+		}
+		node[deploymentName] = true
+	}
+
+	dn.result = tnf.SUCCESS
+	return nil
+}
+
+// ReelTimeout does nothing;  no action is necessary upon timeout.
+func (dn *DeploymentsNodes) ReelTimeout() *reel.Step {
+	return nil
+}
+
+// ReelEOF does nothing;  no action is necessary upon EOF.
+func (dn *DeploymentsNodes) ReelEOF() {
+}
+
+func extractDeployment(podName string) string {
+	const (
+		numExpectedMatches = 2
+		deploymentIdx      = 1
+	)
+	re := regexp.MustCompile(podNameRegex)
+	matched := re.FindStringSubmatch(podName)
+	if len(matched) != numExpectedMatches {
+		return ""
+	}
+	return matched[deploymentIdx]
+}

--- a/pkg/tnf/handlers/deploymentsnodes/deploymentsnodes_test.go
+++ b/pkg/tnf/handlers/deploymentsnodes/deploymentsnodes_test.go
@@ -1,0 +1,134 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package deploymentsnodes_test
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/test-network-function/pkg/tnf"
+	dn "github.com/test-network-function/test-network-function/pkg/tnf/handlers/deploymentsnodes"
+)
+
+func Test_NewDeployments(t *testing.T) {
+	newDn := dn.NewDeploymentsNodes(testTimeoutDuration, testNamespace)
+	assert.NotNil(t, newDn)
+	assert.Equal(t, testTimeoutDuration, newDn.Timeout())
+	assert.Equal(t, newDn.Result(), tnf.ERROR)
+	assert.NotNil(t, newDn.GetNodes())
+}
+
+func Test_ReelFirstPositive(t *testing.T) {
+	newDn := dn.NewDeploymentsNodes(testTimeoutDuration, testNamespace)
+	assert.NotNil(t, newDn)
+	firstStep := newDn.ReelFirst()
+	re := regexp.MustCompile(firstStep.Expect[0])
+	matches := re.FindStringSubmatch(testInputSuccess)
+	assert.Len(t, matches, 1)
+	assert.Equal(t, testInputSuccess, matches[0])
+}
+
+func Test_ReelFirstNegative(t *testing.T) {
+	newDn := dn.NewDeploymentsNodes(testTimeoutDuration, testNamespace)
+	assert.NotNil(t, newDn)
+	firstStep := newDn.ReelFirst()
+	re := regexp.MustCompile(firstStep.Expect[0])
+	matches := re.FindStringSubmatch(testInputError)
+	assert.Len(t, matches, 0)
+}
+
+func Test_ReelMatchSuccess(t *testing.T) {
+	newDn := dn.NewDeploymentsNodes(testTimeoutDuration, testNamespace)
+	assert.NotNil(t, newDn)
+	step := newDn.ReelMatch("", "", testInputSuccess)
+	assert.Nil(t, step)
+	assert.Equal(t, tnf.SUCCESS, newDn.Result())
+	assert.Len(t, newDn.GetNodes(), testInputSuccessNumNodes)
+
+	nodes := newDn.GetNodes()
+
+	for name, expected := range expectedNodes {
+		node, ok := nodes[name]
+		assert.True(t, ok)
+		assert.Equal(t, expected, node)
+	}
+}
+
+// Just ensure there are no panics.
+func Test_ReelEof(t *testing.T) {
+	newDn := dn.NewDeploymentsNodes(testTimeoutDuration, testNamespace)
+	assert.NotNil(t, newDn)
+	newDn.ReelEOF()
+}
+
+const (
+	testTimeoutDuration      = time.Second * 2
+	testNamespace            = "testNamespace"
+	testInputError           = ""
+	testInputSuccessNumNodes = 2
+	testInputSuccess         = `NAME                                                  NODE
+								cdi-apiserver-7b7bdc4745-8mz2m                        crc-mk4pg-master-0
+								cdi-deployment-5f68bcf958-qm4pf                       crc-mk4pg-master-0
+								cdi-operator-5fcd9d7cb6-8h9bj                         crc-mk4pg-master-0
+								cdi-uploadproxy-869d4956c9-2x4dx                      crc-mk4pg-master-0
+								cluster-network-addons-operator-7d9bb9b998-66kh9      crc-mk4pg-master-0
+								hostpath-provisioner-operator-86d9d964b4-zrcc6        crc-mk4pg-master-0
+								hyperconverged-cluster-operator-75bcff9b79-jbh6x      crc-mk4pg-master-0
+								kubemacpool-mac-controller-manager-5699f48684-4ntmx   crc-mk4pg-master-0
+								kubevirt-ssp-operator-864775bd4b-x7dgb                crc-mk4pg-master-0
+								nmstate-webhook-5bc9777476-n7sqj                      crc-mk4pg-master-0
+								nmstate-webhook-5bc9777476-vb2jg                      crc-mk4pg-master-1
+								node-maintenance-operator-6cbcd9ccd-hnd8n             crc-mk4pg-master-1
+								v2v-vmware-57c468498-srmst                            crc-mk4pg-master-1
+								virt-api-65c85544b-7pmkj                              crc-mk4pg-master-1
+								virt-api-65c85544b-w5hvm                              crc-mk4pg-master-1
+								virt-controller-6d85889844-99qhn                      crc-mk4pg-master-1
+								virt-controller-6d85889844-knfvm                      crc-mk4pg-master-1
+								virt-operator-799985df85-g5sgj                        crc-mk4pg-master-1
+								virt-operator-799985df85-lhk49                        crc-mk4pg-master-1
+								virt-template-validator-76db69664c-4znj9              crc-mk4pg-master-1
+								virt-template-validator-76db69664c-grzxf              crc-mk4pg-master-1
+	`
+)
+
+var (
+	expectedNodes = dn.NodesMap{
+		"crc-mk4pg-master-1": {
+			"nmstate-webhook":           true,
+			"node-maintenance-operator": true,
+			"v2v-vmware":                true,
+			"virt-api":                  true,
+			"virt-controller":           true,
+			"virt-operator":             true,
+			"virt-template-validator":   true,
+		},
+		"crc-mk4pg-master-0": {
+			"cdi-apiserver":                      true,
+			"cdi-deployment":                     true,
+			"cdi-operator":                       true,
+			"cdi-uploadproxy":                    true,
+			"cluster-network-addons-operator":    true,
+			"hostpath-provisioner-operator":      true,
+			"hyperconverged-cluster-operator":    true,
+			"kubemacpool-mac-controller-manager": true,
+			"kubevirt-ssp-operator":              true,
+			"nmstate-webhook":                    true,
+		},
+	}
+)

--- a/pkg/tnf/handlers/deploymentsnodes/doc.go
+++ b/pkg/tnf/handlers/deploymentsnodes/doc.go
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+// Package deploymentsnodes provides a test for reading node names of pods owned by deployments in a namespace
+package deploymentsnodes

--- a/pkg/tnf/identifier/identifiers.go
+++ b/pkg/tnf/identifier/identifiers.go
@@ -37,6 +37,9 @@ const (
 	gracePeriodIdentifierURL        = "http://test-network-function.com/tests/gracePeriod"
 	hugepagesIdentifierURL          = "http://test-network-function.com/tests/hugepages"
 	nodehugepagesIdentifierURL      = "http://test-network-function.com/tests/nodehugepages"
+	deploymentsIdentifierURL        = "http://test-network-function.com/tests/deployments"
+	deploymentsnodesIdentifierURL   = "http://test-network-function.com/tests/deploymentsnodes"
+	deploymentsdrainIdentifierURL   = "http://test-network-function.com/tests/deploymentsdrain"
 
 	versionOne = "v1.0.0"
 )
@@ -310,6 +313,44 @@ var Catalog = map[string]TestCatalogEntry{
 			dependencies.GrepBinaryName,
 		},
 	},
+	deploymentsIdentifierURL: {
+		Identifier:  DeploymentsIdentifier,
+		Description: "A generic test used to read namespace's deployments",
+		Type:        Normative,
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.OcBinaryName,
+		},
+	},
+	deploymentsnodesIdentifierURL: {
+		Identifier:  DeploymentsNodesIdentifier,
+		Description: "A generic test used to read node names of pods owned by deployments in namespace",
+		Type:        Normative,
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.OcBinaryName,
+			dependencies.GrepBinaryName,
+		},
+	},
+	deploymentsdrainIdentifierURL: {
+		Identifier:  DeploymentsNodesIdentifier,
+		Description: "A generic test used to drain node from its deployment pods",
+		Type:        Normative,
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.OcBinaryName,
+			dependencies.EchoBinaryName,
+		},
+	},
 }
 
 // HostnameIdentifier is the Identifier used to represent the generic hostname test case.
@@ -417,5 +458,23 @@ var HugepagesIdentifier = Identifier{
 // NodeHugepagesIdentifier is the Identifier used to represent the generic NodeHugepages test.
 var NodeHugepagesIdentifier = Identifier{
 	URL:             nodehugepagesIdentifierURL,
+	SemanticVersion: versionOne,
+}
+
+// DeploymentsIdentifier is the Identifier used to represent the generic Deployments test.
+var DeploymentsIdentifier = Identifier{
+	URL:             deploymentsIdentifierURL,
+	SemanticVersion: versionOne,
+}
+
+// DeploymentsNodesIdentifier is the Identifier used to represent the generic DeploymentsNodes test.
+var DeploymentsNodesIdentifier = Identifier{
+	URL:             deploymentsnodesIdentifierURL,
+	SemanticVersion: versionOne,
+}
+
+// DeploymentsDrainIdentifier is the Identifier used to represent the generic DeploymentsDrain test.
+var DeploymentsDrainIdentifier = Identifier{
+	URL:             deploymentsdrainIdentifierURL,
 	SemanticVersion: versionOne,
 }


### PR DESCRIPTION
Read the CNF namespace's deployments
Drain at least one node that is executing deployment pods

https://issues.redhat.com/browse/CTONET-877
