### PR TITLE
fix documentation issue introduced in 5430a4c

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,13 +68,21 @@ Generally speaking, the CLI API changes much less quickly.
 
 For more details on how to add a new Test either as a JSON definition, or in code, please see [DEVELOPING.md](DEVELOPING.md)
 
-For some examples of existing tests, consult:
+### Unit Testing Tests
+
+Each `tnf.Tester` implementation must have unit tests.  Ideally, it should strive for 100% line coverage when possible.  For some examples of existing unit tests, consult:
 
 * pkg/tnf/handlers/base/version_test.go
 * pkg/tnf/handlers/hostname/hostname_test.go
 * pkg/tnf/handlers/ipaddr/ipaddr_test.go
 * pkg/tnf/handlers/ping/ping_test.go
 
+As always, you should ensure that tests should pass prior to submitting a Pull Request.  To run the unit tests issue the
+following command:
+
+```bash
+make unit-tests
+```
 ## Configuration guidelines
 
 Many Tests will require some form of extra configuration.  To maintain reproducibility and auditability outcomes this

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -13,6 +13,7 @@ variety of `interactive.Context` implementations for each of these.  In general,
 on specific prompts, the framework handles the context transparently.
 * Tests must implement the `tnf.Tester` interface.
 * Tests must implement the `reel.Handler` interface.
+* Tests must be accompanied by appropriate unit tests.
 * Tests adhere to the strict quality and style guidelines set forth in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Test Identifiers


### PR DESCRIPTION
5430a4c incorrectly removed some documentation of unit tests
for TNF tests in the process of re-working parts of the
documentation.
This fixes that omission by re-introducing the strong requirement
for unit test coverage.

Signed-off-by: Charlie Wheeler-Robinson <cwheeler@redhat.com>