### PR TITLE
fix a bug that caused each operator test to run twice

### DIFF
--- a/test-network-function/operator/suite.go
+++ b/test-network-function/operator/suite.go
@@ -101,14 +101,13 @@ func itRunsTestsOnOperator() {
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(renderedTestCase).ToNot(gomega.BeNil())
 			for _, testCase := range renderedTestCase.TestCase {
-				if !testCase.SkipTest {
-					if testCase.ExpectedType == testcases.Function {
-						for _, val := range testCase.ExpectedStatus {
-							testCase.ExpectedStatusFn(op.Name, testcases.StatusFunctionType(val))
-						}
+				if testCase.SkipTest {
+					continue
+				}
+				if testCase.ExpectedType == testcases.Function {
+					for _, val := range testCase.ExpectedStatus {
+						testCase.ExpectedStatusFn(op.Name, testcases.StatusFunctionType(val))
 					}
-					args := []interface{}{op.Name, op.Namespace}
-					runTestsOnOperator(args, op.Name, op.Namespace, testCase)
 				}
 				name := agrName(op.Name, op.SubscriptionName, testCase.Name)
 				args := []interface{}{name, op.Namespace}


### PR DESCRIPTION
An error in rebasing a change to flow control resulted in
some operator tests being run twice. This change restores
the intended operation.

The error occurred in rebasing prior to merging
d2275b183dd8842d4d74ee198f6391903b47f198
and resulted in some of the changes from commit
5811e2c6cc1670908803407817c6ef3311e1e909
being lost. Luckily the main manifestation of the
error was to cause each test to be run twice rather
than anything more serious.

Signed-off-by: Charlie Wheeler-Robinson <cwheeler@redhat.com>