### PR TITLE
CTONET-645 - fix empty resourceNames

### DIFF
--- a/pkg/tnf/handlers/operator/operator_test.go
+++ b/pkg/tnf/handlers/operator/operator_test.go
@@ -37,7 +37,7 @@ const (
 	subName             = "SUBSCRIPTION_INSTALLED"
 	subCommand          = "oc get subscription %s -n %s -ojson | jq -r '.spec.name'"
 	sccName             = "CSV_SCC"
-	sccCommand          = "oc get csv %s -n %s -o json | jq -r 'if .spec.install.spec.clusterPermissions == null then null else . end | if . == null then \"EMPTY\" else .spec.install.spec.clusterPermissions[].rules[].resourceNames end'"
+	sccCommand          = "oc get csv %s -n %s -o json | jq -r 'if .spec.install.spec.clusterPermissions == null then null else . end | if . == null then \"EMPTY\" else .spec.install.spec.clusterPermissions[].rules[].resourceNames end | if length == 0 then \"EMPTY\" else . end'"
 )
 
 var (

--- a/pkg/tnf/testcases/data/operator/operator.go
+++ b/pkg/tnf/testcases/data/operator/operator.go
@@ -42,7 +42,8 @@ var OperatorJSON = string(`{
     {
       "name": "CSV_SCC",
       "skiptest": true,
-      "command": "oc get csv %s -n %s -o json | jq -r 'if .spec.install.spec.clusterPermissions == null then null else . end | if . == null then \"EMPTY\" else .spec.install.spec.clusterPermissions[].rules[].resourceNames end'",
+      "command": "oc get csv %s -n %s -o json | jq -r 'if .spec.install.spec.clusterPermissions == null then null else . end ` +
+	`| if . == null then \"EMPTY\" else .spec.install.spec.clusterPermissions[].rules[].resourceNames end | if length == 0 then \"EMPTY\" else . end'",
       "action": "allow",
       "resulttype": "string",
       "expectedstatus": [

--- a/pkg/tnf/testcases/files/operator/operatorstatus.yml
+++ b/pkg/tnf/testcases/files/operator/operatorstatus.yml
@@ -17,7 +17,7 @@ testcase:
       - "etcd"
   - name: "CSV_SCC"
     skiptest: false
-    command: "oc get csv %s -n %s -o json | jq -r 'if .spec.install.spec.clusterPermissions == null then null else . end | if . == null then \"EMPTY\" else .spec.install.spec.clusterPermissions[].rules[].resourceNames end'"
+    command: "oc get csv %s -n %s -o json | jq -r 'if .spec.install.spec.clusterPermissions == null then null else . end | if . == null then \"EMPTY\" else .spec.install.spec.clusterPermissions[].rules[].resourceNames end | if length == 0 then \"EMPTY\" else . end'"
     action: "allow"
     resulttype: "string"
     expectedtype: "string"

--- a/test-network-function/tnf_config.yml
+++ b/test-network-function/tnf_config.yml
@@ -28,6 +28,7 @@ generic:
 operators:
   - name: etcdoperator.v0.9.4
     namespace: default
+    subscriptionName: etcd
     autogenerate: false
     tests:
       - OPERATOR_STATUS


### PR DESCRIPTION
In case when resourceNames is not defined we returned empty string which failed the test. This PR checks whether there are no resource names and make sure we use well know token `EMPTY` to indicate this. The token was introduced to help validate whether path to

``` json
.spec.install.spec.clusterPermissions[].rules[].resourceNames
```

is valid. In order to use command introduced by this test in a test description we can use action deny with expectedstatus `privileged`.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>