### PR TITLE
Automatically configure generic spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,21 +86,12 @@ make unit-tests
 ## Configuration guidelines
 
 Many Tests will require some form of extra configuration.  To maintain reproducibility and auditability outcomes this
-configuration must be included in a claim file.
-
-To support this each configuration type must be registered with `pkg/config/pool`.  In order to register with the
-configuration pool, use code similar to the following:
-
-```
-(*configpool.GetInstance()).RegisterConfiguration(configurationKey, config)
-```
-
-Additionally the `config` structure for the Test must implement or inherit a working `MarshalJSON` and `UnmarshalJSON`
-interface so it can be automatically included in a
+configuration must be included in a claim file. For all current configuration approaches (see the `generic` test spec)
+this will be done automatically provided the `config` structure for the Test implements or inherits a working `MarshalJSON` and `UnmarshalJSON`
+interface so it can be included in a
 [test-network-function-claim](https://github.com/test-network-function/test-network-function-claim) JSON file.
 
-Any configuration that adheres to these two requirements will automatically be included in the claim.  Any configuration
-needed to reproduce a claim must be added to the pool.
+All configuration must adhere to these two requirements will automatically be included in the claim.
 
 ## Documentation guidelines
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,14 @@ configuration will only happen if the environment variable `TNF_ENABLE_CONFIG_AU
 TNF_ENABLE_CONFIG_AUTODISCOVER=true
 ```
 
+Pods can be labelled at creation by including the label in their definition, or at any time using the `oc label`
+command. Annotations are almost identical:
+
+```shell
+oc label pod test -n tnf test-network-function.com/generic=target
+oc annotate pod test -n tnf test-network-function.com/skip_connectivity_tests=true
+```
+
 **NOTE** Currently when this environment variable is set the `generic` section of the config file will be ENTIRELY
 replaced with the autodiscovered configuration, to avoid potentially non-obvious errors.
 
@@ -250,9 +258,9 @@ single pod with a single container. This is equivalent to having an entry listed
 one such pod. This is equivalent to having a pod listed under `containersUnderTest` in the config file.
 * If an FS Diff Master Pod is present it should be identified with,  `test-network-function.com/generic=fs_diff_master`. This
 is equivalent to listing the pod under `fsDiffMasterContainer` in the config file.
-* If a pod is not suitable for netwrk connectivity tests because it lacks the `ping` and other binaries, it should be
-given the label `test-network-function.com/skip_connectivity_tests` to exclude it from those tests. Equivalent to
-`excludeContainersFromConnectivityTests` in the config file.
+* If a pod is not suitable for network connectivity tests because it lacks binaries (e.g. `ping`), it should be
+given the label `test-network-function.com/skip_connectivity_tests` to exclude it from those tests. The label value is
+not important, only its presence. Equivalent to `excludeContainersFromConnectivityTests` in the config file.
 
 The autodiscovery mechanism will attempt to identify the default network device and all the IP addresses of the pods it
 needs, though that information can be explicitly set using annotations if needed. The following rules apply:
@@ -262,15 +270,17 @@ needs, though that information can be explicitly set using annotations if needed
 * The annotation `test-network-function.com/multusips` is the highest priority, and must contain a JSON-encoded list of
 IP addresses to be tested for the pod. This must be explicitly set.
 * If the above is not present, the `k8s.v1.cni.cncf.io/networks-status` annotation is checked and all IPs from it are
-used. This annotation is automatically managed in OpenShift.
+used. This annotation is automatically managed in OpenShift but may not be present in K8s.
 * If neither of the above is present, then only known IPs associated with the pod are used (the pod `.status.ips` field).
 
 ### Network Interfaces
 
 * The annotation `test-network-function.com/defaultnetworkinterface` is the highest priority, and must contain a
-JSON-encoded string of the primary network interface for the pod. This must be explicitly set if needed.
+JSON-encoded string of the primary network interface for the pod. This must be explicitly set if needed. Examples can
+be seen in [cnf-certification-test-partner](https://github.com/test-network-function/cnf-certification-test-partner/local-test-infra/local-pod-under-test/local-partner-pod.yaml)
 * If the above is not present, the `k8s.v1.cni.cncf.io/networks-status` annotation is checked and the `"interface"` from
-the first entry found with `"default"=true` is used. This annotation is automatically managed in OpenShift.
+the first entry found with `"default"=true` is used. This annotation is automatically managed in OpenShift but may not
+be present in K8s.
 
 ## Test Output
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,53 @@
+## Test Configuration
+
+Configuration is accomplished with `tnf_config.yml` by default. An alternative configuration can be provided using the
+`TNF_CONFIGURATION_PATH` environment variable.
+
+This config file contains several sections, each of which configures one or more test specs:
+
+Config Section|Purpose
+---|---
+generic|Describes containers to be tested with the `generic` and `multus` specs, if they are run.
+cnfs|Defines which containers are to be tested by the `container` spec.
+operators|Defines which containers are to be tested by the `operator` spec.
+certifiedcontainerinfo|Describes cnf names and repositories to be checked for certification status.
+certifiedoperatorinfo|Describes operator names and organisations to be checked for certification status.
+
+`testconfigure.yml` defines roles, and which tests are appropriate for which roles. It should not be necessary to modify this.
+
+
+### generic
+
+The `generic` section contains three subsections:
+
+* `containersUnderTest:` describes the CNFs that will be tested.  Each container is defined by the combination of its
+`namespace`, `podName`, and `containerName`, which are also used to connect to the container when required.
+
+  * Each entry for `containersUnderTest` must also define the `defaultNetworkDevice` of that container.  There is also
+  an optional `multusIpAddresses` that can be omitted if the multus tests are not run.
+
+* `partnerContainers:` describes the containers that support the testing.  Multiple `partnerContainers` allows
+for more complex testing scenarios.  At the time of writing, only one is used, which will also be the test
+orchestrator.
+
+* `testOrchestrator:` references a partner containers that is used for the generic test suite.  The test partner is used
+to send various types of traffic to each container under test.  For example the orchestrator is used to ping a container
+under test, and to be the ping target of a container under test.
+
+The [included default](test-network-function/tnf_config.yml) defines a single container to be tested,
+and a single partner to do the testing.
+
+### cnfs and operators
+
+The `cnfs` and `operators` sections define the roles under which operators and containers are to be tested.
+
+[The default config](test-network-function/tnf_config.yml) is set up with some examples of this:
+It will run the `"OPERATOR_STATUS"` tests (as defined in `testconfigure.yml`) against an etcd operator, and the
+`"PRIVILEGED_POD"` and `"PRIVILEGED_ROLE"` tests against an nginx container.
+
+A more extensive example of all these sections is provided in [example/example_config.yaml](example/example_config.yaml)
+
+### certifiedcontainerinfo and certifiedoperatorinfo
+
+The `certifiedcontainerinfo` and `certifiedoperatorinfo` sections contain information about CNFs and Operators that are
+to be checked for certification status on Red Hat catalogs.

--- a/pkg/config/autodiscover/autodiscover.go
+++ b/pkg/config/autodiscover/autodiscover.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2020 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package autodiscover
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	labelNamespace = "test-network-function.com"
+	labelTemplate  = "%s/%s"
+
+	// AnyLabelValue is the value that will allow any value for a label when building the label query.
+	AnyLabelValue = ""
+)
+
+func buildLabelName(labelName string) string {
+	return fmt.Sprintf(labelTemplate, labelNamespace, labelName)
+}
+
+func buildAnnotationName(annotationName string) string {
+	return buildLabelName(annotationName)
+}
+
+func buildLabelQuery(labelName, labelValue string) string {
+	namespacedLabel := buildLabelName(labelName)
+	if labelValue != AnyLabelValue {
+		return fmt.Sprintf("%s=%s", namespacedLabel, labelValue)
+	}
+	return namespacedLabel
+}
+
+func makeGetCommand(resourceType, labelQuery string) *exec.Cmd {
+	// TODO: shell expecter
+	cmd := exec.Command("oc", "get", resourceType, "-A", "-o", "json", "-l", labelQuery)
+	log.Info("Issuing get command ", cmd.Args)
+
+	return cmd
+}
+
+// GetPodsByLabel will return all pods with a given label value. If `labelValue` is an empty string, all pods with that
+// label will be returned, regardless of the labels value.
+func GetPodsByLabel(labelName, labelValue string) (*PodList, error) {
+	cmd := makeGetCommand("pods", buildLabelQuery(labelName, labelValue))
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var podList PodList
+	err = json.Unmarshal(out, &podList)
+	if err != nil {
+		return nil, err
+	}
+
+	return &podList, nil
+}

--- a/pkg/config/autodiscover/autodiscover.go
+++ b/pkg/config/autodiscover/autodiscover.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Red Hat, Inc.
+// Copyright (C) 2021 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -25,8 +25,9 @@ import (
 )
 
 const (
-	labelNamespace = "test-network-function.com"
-	labelTemplate  = "%s/%s"
+	labelNamespace   = "test-network-function.com"
+	labelTemplate    = "%s/%s"
+	resourceTypePods = "pods"
 
 	// AnyLabelValue is the value that will allow any value for a label when building the label query.
 	AnyLabelValue = ""
@@ -51,7 +52,7 @@ func buildLabelQuery(labelName, labelValue string) string {
 func makeGetCommand(resourceType, labelQuery string) *exec.Cmd {
 	// TODO: shell expecter
 	cmd := exec.Command("oc", "get", resourceType, "-A", "-o", "json", "-l", labelQuery)
-	log.Info("Issuing get command ", cmd.Args)
+	log.Debug("Issuing get command ", cmd.Args)
 
 	return cmd
 }
@@ -59,7 +60,7 @@ func makeGetCommand(resourceType, labelQuery string) *exec.Cmd {
 // GetPodsByLabel will return all pods with a given label value. If `labelValue` is an empty string, all pods with that
 // label will be returned, regardless of the labels value.
 func GetPodsByLabel(labelName, labelValue string) (*PodList, error) {
-	cmd := makeGetCommand("pods", buildLabelQuery(labelName, labelValue))
+	cmd := makeGetCommand(resourceTypePods, buildLabelQuery(labelName, labelValue))
 
 	out, err := cmd.Output()
 	if err != nil {

--- a/pkg/config/autodiscover/autodiscover_generic.go
+++ b/pkg/config/autodiscover/autodiscover_generic.go
@@ -1,0 +1,110 @@
+// Copyright (C) 2020 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package autodiscover
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/test-network-function/test-network-function/pkg/config/configsections"
+)
+
+const (
+	genericLabelName = "generic"
+	underTestValue   = "target"
+	// partnerLabelValue = "partner"
+	orchestratorValue          = "orchestrator"
+	fsDiffMasterValue          = "fs_diff_master"
+	skipConnectivityTestsLabel = "skip_connectivity_tests"
+)
+
+// BuildGenericConfig builds a `configsections.TestConfiguration` from the current state of the cluster,
+// using labels and annotations to populate the data.
+func BuildGenericConfig() (conf configsections.TestConfiguration) {
+	var partnerContainers []configsections.Container // PartnerContainers is built from all non-target containers
+
+	// an orchestrator must be identified
+	orchestrator, err := getContainerByLabel(genericLabelName, orchestratorValue)
+	if err != nil {
+		log.Fatalf("failed to identify a single test orchestrator container: %s", err)
+	}
+	partnerContainers = append(partnerContainers, orchestrator)
+	conf.TestOrchestrator = orchestrator.ContainerIdentifier
+
+	// there must be containers to test
+	containersUnderTest, err := getContainersByLabel(genericLabelName, underTestValue)
+	if err != nil {
+		log.Fatalf("found no containers to test: %s", err)
+	}
+	conf.ContainersUnderTest = containersUnderTest
+
+	// the FS Diff master container is optional
+	fsDiffMasterContainer, err := getContainerByLabel(genericLabelName, fsDiffMasterValue)
+	if err == nil {
+		partnerContainers = append(partnerContainers, fsDiffMasterContainer)
+		conf.FsDiffMasterContainer = fsDiffMasterContainer.ContainerIdentifier
+	} else {
+		log.Warnf("an error (%s) occurred when getting the FS Diff Master Container. Attempting to continue", err)
+	}
+
+	// Containers to exclude from connectivity tests are optional
+	connectivityExcludedContainers, err := getContainerIdentifiersByLabel(skipConnectivityTestsLabel, AnyLabelValue)
+	if err != nil {
+		log.Warnf("an error (%s) occurred when getting the containers to exclude from connectivity tests. Attempting to continue", err)
+	}
+	conf.ExcludeContainersFromConnectivityTests = connectivityExcludedContainers
+
+	conf.PartnerContainers = partnerContainers
+	return conf
+}
+
+// getContainersByLabel builds `config.Container`s from containers in pods matching a label.
+func getContainersByLabel(labelName, labelValue string) (containers []configsections.Container, err error) {
+	pods, err := GetPodsByLabel(labelName, labelValue)
+	if err != nil {
+		return nil, err
+	}
+	for i := range pods.Items {
+		containers = append(containers, pods.Items[i].GetContainers()...)
+	}
+	return containers, nil
+}
+
+// getContainerIdentifiersByLabel builds `config.ContainerIdentifier`s from containers in pods matching a label.
+func getContainerIdentifiersByLabel(labelName, labelValue string) (containerIDs []configsections.ContainerIdentifier, err error) {
+	containers, err := getContainersByLabel(labelName, labelValue)
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range containers {
+		containerIDs = append(containerIDs, c.ContainerIdentifier)
+	}
+	return containerIDs, nil
+}
+
+// getContainerByLabel returns exactly one container with the given label. If any other number of containers is found
+// then an error is returned along with an empty `config.Container`.
+func getContainerByLabel(labelName, labelValue string) (container configsections.Container, err error) {
+	containers, err := getContainersByLabel(labelName, labelValue)
+	if err != nil {
+		return container, err
+	}
+	if len(containers) != 1 {
+		return container, fmt.Errorf("expected exactly one container, got %d for label %s=%s", len(containers), labelName, labelValue)
+	}
+	return containers[0], nil
+}

--- a/pkg/config/autodiscover/autodiscover_generic.go
+++ b/pkg/config/autodiscover/autodiscover_generic.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Red Hat, Inc.
+// Copyright (C) 2021 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/config/autodiscover/doc.go
+++ b/pkg/config/autodiscover/doc.go
@@ -1,0 +1,2 @@
+// Package autodiscover provides methods and data structures necessary for finding cluster resources from their labels.
+package autodiscover

--- a/pkg/config/autodiscover/pod_info.go
+++ b/pkg/config/autodiscover/pod_info.go
@@ -1,0 +1,171 @@
+// Copyright (C) 2020 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package autodiscover
+
+import (
+	"encoding/json"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/test-network-function/test-network-function/pkg/config/configsections"
+)
+
+const (
+	cnfDefaultNetworkInterfaceKey = "defaultnetworkinterface"
+	cnfIPsKey                     = "multusips"
+
+	cniNetworksStatusKey = "k8s.v1.cni.cncf.io/networks-status"
+)
+
+var (
+	namespacedDefaultNetworkInterfaceKey = buildAnnotationName(cnfDefaultNetworkInterfaceKey)
+	namespacedIPsKey                     = buildAnnotationName(cnfIPsKey)
+)
+
+// PodList holds the data from an `oc get pods -o json` command
+type PodList struct {
+	Items []PodResource `json:"items"`
+}
+
+// PodResource is a single Pod from an `oc get pods -o json` command
+type PodResource struct {
+	Metadata struct {
+		Name        string            `json:"name"`
+		Namespace   string            `json:"namespace"`
+		Labels      map[string]string `json:"labels"`
+		Annotations map[string]string `json:"annotations"`
+	} `json:"metadata"`
+	Spec struct {
+		Containers []struct {
+			Name string `json:"name"`
+		} `json:"containers"`
+	} `json:"spec"`
+	Status struct {
+		PodIPs []map[string]string `json:"podIPs"`
+	} `json:"status"`
+}
+
+type cniNetworkInterface struct {
+	Name      string                 `json:"name"`
+	Interface string                 `json:"interface"`
+	IPs       []string               `json:"ips"`
+	Default   bool                   `json:"default"`
+	DNS       map[string]interface{} `json:"dns"`
+}
+
+// GetContainers builds `config.Container`s from a `PodResource`
+func (pr *PodResource) GetContainers() (containers []configsections.Container) {
+	for _, containerResource := range pr.Spec.Containers {
+		var err error
+		var container configsections.Container
+		container.Namespace = pr.Metadata.Namespace
+		container.PodName = pr.Metadata.Name
+		container.ContainerName = containerResource.Name
+		container.DefaultNetworkDevice, err = pr.getDefaultNetworkDeviceFromAnnotations()
+		if err != nil {
+			log.Warnf("error encountered getting default network device: %s", err)
+		}
+		container.MultusIPAddresses, err = pr.getPodIPs()
+		if err != nil {
+			log.Warnf("error encountered getting multus IPs: %s", err)
+			err = nil
+		}
+
+		containers = append(containers, container)
+	}
+	return
+}
+
+func (pr *PodResource) hasAnnotation(annotationKey string) (present bool) {
+	_, present = pr.Metadata.Annotations[annotationKey]
+	return
+}
+
+// GetAnnotationValue will get the value stored in the given annotation and
+// Unmarshal it into the given var `v`.
+func (pr *PodResource) GetAnnotationValue(annotationKey string, v interface{}) (err error) {
+	if !pr.hasAnnotation(annotationKey) {
+		return fmt.Errorf("failed to find annotation '%s' on pod '%s/%s'", annotationKey, pr.Metadata.Namespace, pr.Metadata.Namespace)
+	}
+	val := pr.Metadata.Annotations[annotationKey]
+	err = json.Unmarshal([]byte(val), v)
+	if err != nil {
+		return pr.annotationUnmarshalError(err)
+	}
+	return
+}
+
+// getDefaultNetworkDeviceFromAnnotations examins the pod annotations to try and determine the primary network device.
+// First, if the cnf-certification-specific annotation "test-network-function.com/defaultnetworkinterface" is present
+// then the value of that will be decoded and returned. It must be a single JSON-encoded string.
+// Next, if the "k8s.v1.cni.cncf.io/networks-status" annotation is present then the first entry where `default == true`
+// will be used. Note that this annotation may not be present outside OpenShift.
+func (pr *PodResource) getDefaultNetworkDeviceFromAnnotations() (iface string, err error) {
+	// Note: The `GetAnnotationValue` method does not distinguish between bad encoding and a missing annotation, which is needed here.
+	if val, present := pr.Metadata.Annotations[namespacedDefaultNetworkInterfaceKey]; present {
+		err = json.Unmarshal([]byte(val), &iface)
+		return
+	}
+	if val, present := pr.Metadata.Annotations[cniNetworksStatusKey]; present {
+		var cniInfo []cniNetworkInterface
+		err = json.Unmarshal([]byte(val), &cniInfo)
+		if err != nil {
+			return "", pr.annotationUnmarshalError(err)
+		}
+		for _, cniInterface := range cniInfo {
+			if cniInterface.Default {
+				return cniInterface.Interface, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("unable to determine a default network interface for %s/%s", pr.Metadata.Namespace, pr.Metadata.Name)
+}
+
+// getPodIPs gets the IPs of a pod.
+// In precedence, it uses the cnf-certification specific annotation if it is present. If set,
+// "test-network-function.com/multusips" must be a json-encoded list of string IPs.
+// The fallback option is the
+// CNI annotation "k8s.v1.cni.cncf.io/networks-status". If neither are available, then `pod.status.ips` is used, though
+// this may not contain all IPs in all cases and will not be _only_ multus IPs.
+func (pr *PodResource) getPodIPs() (ips []string, err error) {
+	// Note: The `GetAnnotationValue` method does not distinguish between bad encoding and a missing annotation, which is needed here.
+	if val, present := pr.Metadata.Annotations[namespacedIPsKey]; present {
+		err = json.Unmarshal([]byte(val), &ips)
+		return
+	}
+	if val, present := pr.Metadata.Annotations[cniNetworksStatusKey]; present {
+		var cniInfo []cniNetworkInterface
+		err = json.Unmarshal([]byte(val), &cniInfo)
+		if err != nil {
+			return nil, pr.annotationUnmarshalError(err)
+		}
+		for _, cniInterface := range cniInfo {
+			ips = append(ips, cniInterface.IPs...)
+		}
+		return
+	}
+	log.Warn("Could not establish pod IPs from annotations, please manually set the 'test-network-function.com/multusips' annotation for complete test coverage")
+	for _, ip := range pr.Status.PodIPs {
+		ips = append(ips, ip["ip"])
+	}
+	return
+}
+
+func (pr *PodResource) annotationUnmarshalError(err error) error {
+	return fmt.Errorf("error (%s) attempting to unmarshal value of annotation '%s' on pod '%s/%s'",
+		err, cniNetworksStatusKey, pr.Metadata.Namespace, pr.Metadata.Name)
+}

--- a/pkg/config/autodiscover/pod_info_test.go
+++ b/pkg/config/autodiscover/pod_info_test.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2020-2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package autodiscover_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/test-network-function/pkg/config/autodiscover"
+)
+
+const (
+	filePath             = "testdata"
+	testOrchestratorFile = "testorchestrator.json"
+	testSubjectFile      = "testtarget.json"
+)
+
+var (
+	testOrchestratorFilePath = path.Join(filePath, testOrchestratorFile)
+	testSubjectFilePath      = path.Join(filePath, testSubjectFile)
+)
+
+func loadPodResource(filePath string) (pod autodiscover.PodResource) {
+	contents, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		log.Fatalf("error (%s) loading PodResource %s for testing", err, filePath)
+	}
+	err = json.Unmarshal(contents, &pod)
+	if err != nil {
+		log.Fatalf("error (%s) loading PodResource %s for testing", err, filePath)
+	}
+	return
+}
+
+func TestGetAnnotationValue(t *testing.T) {
+	pod := loadPodResource(testOrchestratorFilePath)
+	var val string
+	err := pod.GetAnnotationValue("notPresent", &val)
+	assert.Equal(t, "", val)
+	assert.NotNil(t, err)
+
+	err = pod.GetAnnotationValue("test-network-function.com/defaultnetworkinterface", &val)
+	assert.Equal(t, "eth0", val)
+	assert.Nil(t, err)
+}
+
+func TestGetContainers(t *testing.T) {
+	orchestratorPod := loadPodResource(testOrchestratorFilePath)
+	orchestratorContainers := orchestratorPod.GetContainers()
+	assert.Equal(t, 1, len(orchestratorContainers))
+
+	subjectPod := loadPodResource(testSubjectFilePath)
+	subjectContainers := subjectPod.GetContainers()
+	assert.Equal(t, 1, len(subjectContainers))
+
+	assert.Equal(t, "tnf", orchestratorContainers[0].Namespace)
+	assert.Equal(t, "I'mAPodName", orchestratorContainers[0].PodName)
+	assert.Equal(t, "I'mAContainer", orchestratorContainers[0].ContainerName)
+
+	// Check correct order of precedence for network devices
+	assert.Equal(t, "eth0", orchestratorContainers[0].DefaultNetworkDevice)
+	assert.NotEqual(t, "LowerPriorityInterface", orchestratorContainers[0].DefaultNetworkDevice)
+	assert.Equal(t, "eth1", subjectContainers[0].DefaultNetworkDevice)
+
+	// Check correct IPs are chosen
+	assert.Equal(t, 1, len(orchestratorContainers[0].MultusIPAddresses))
+	assert.Equal(t, "1.1.1.1", orchestratorContainers[0].MultusIPAddresses[0])
+	assert.NotEqual(t, "2.2.2.2", orchestratorContainers[0].MultusIPAddresses[0])
+	// test-network-function.com/multusips should be used for the test subject container.
+	assert.Equal(t, 2, len(subjectContainers[0].MultusIPAddresses))
+	assert.Equal(t, "3.3.3.3", subjectContainers[0].MultusIPAddresses[0])
+	assert.Equal(t, "4.4.4.4", subjectContainers[0].MultusIPAddresses[1])
+}

--- a/pkg/config/autodiscover/pod_info_test.go
+++ b/pkg/config/autodiscover/pod_info_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2021 Red Hat, Inc.
+// Copyright (C) 2021 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/config/autodiscover/testdata/testorchestrator.json
+++ b/pkg/config/autodiscover/testdata/testorchestrator.json
@@ -1,0 +1,29 @@
+
+{
+    "metadata": {
+        "annotations": {
+            "k8s.v1.cni.cncf.io/networks-status": "[{\n    \"name\": \"\",\n    \"interface\": \"LowerPriorityInterface\",\n    \"ips\": [\n        \"1.1.1.1\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n}]",
+            "test-network-function.com/defaultnetworkinterface": "\"eth0\""
+        },
+        "labels": {
+            "app": "partner",
+            "test-network-function.com/generic": "orchestrator"
+        },
+        "name": "I'mAPodName",
+        "namespace": "tnf"
+    },
+    "spec": {
+        "containers": [
+            {
+                "name": "I'mAContainer"
+            }
+        ]
+    },
+    "status": {
+        "podIPs": [
+            {
+                "ip": "2.2.2.2"
+            }
+        ]
+    }
+}

--- a/pkg/config/autodiscover/testdata/testtarget.json
+++ b/pkg/config/autodiscover/testdata/testtarget.json
@@ -1,0 +1,30 @@
+
+{
+    "metadata": {
+        "annotations": {
+            "k8s.v1.cni.cncf.io/networks-status": "[{\n    \"name\": \"\",\n    \"interface\": \"eth1\",\n    \"ips\": [\n        \"10.217.1.89\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n}]",
+            "test-network-function.com/multusips": "[\"3.3.3.3\",\"4.4.4.4\"]"
+        },
+        "labels": {
+            "app": "test",
+            "test-network-function.com/generic": "target"
+        },
+        "name": "test",
+        "namespace": "tnf"
+    },
+    "spec": {
+        "containers": [
+            {
+                "image": "quay.io/testnetworkfunction/cnf-test-partner:latest",
+                "name": "test"
+            }
+        ]
+    },
+    "status": {
+        "podIPs": [
+            {
+                "ip": "10.217.1.89"
+            }
+        ]
+    }
+}

--- a/pkg/config/configsections/certified_request_test.go
+++ b/pkg/config/configsections/certified_request_test.go
@@ -14,7 +14,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-package config_test
+package configsections_test
 
 import (
 	"encoding/json"
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/test-network-function/pkg/config"
+	"github.com/test-network-function/test-network-function/pkg/config/configsections"
 	"gopkg.in/yaml.v2"
 )
 
@@ -39,22 +40,22 @@ type unmarshalFunc func([]byte, interface{}) error
 // test data
 var (
 	// bananas go in the fruit bowl.
-	fruitbowlRequestInfo = config.CertifiedContainerRequestInfo{
+	fruitbowlRequestInfo = configsections.CertifiedContainerRequestInfo{
 		Name:       "banana",
 		Repository: "fruitbowl",
 	}
 	// apples go in the fridge.
-	fridgeRequestInfo = config.CertifiedContainerRequestInfo{
+	fridgeRequestInfo = configsections.CertifiedContainerRequestInfo{
 		Name:       "apple",
 		Repository: "fridge",
 	}
 
-	jenkinsOperatorRequestInfo = config.CertifiedOperatorRequestInfo{
+	jenkinsOperatorRequestInfo = configsections.CertifiedOperatorRequestInfo{
 		Name:         "jenkins",
 		Organization: "Red Hat",
 	}
 
-	etcdOperatorRequestInfo = config.CertifiedOperatorRequestInfo{
+	etcdOperatorRequestInfo = configsections.CertifiedOperatorRequestInfo{
 		Name:         "etcd",
 		Organization: "Core OS",
 	}
@@ -114,11 +115,11 @@ func cleanupTempfiles() {
 
 func buildRequestConfig() *config.File {
 	conf := &config.File{}
-	conf.CertifiedContainerInfo = []config.CertifiedContainerRequestInfo{
+	conf.CertifiedContainerInfo = []configsections.CertifiedContainerRequestInfo{
 		fruitbowlRequestInfo,
 		fridgeRequestInfo,
 	}
-	conf.CertifiedOperatorInfo = []config.CertifiedOperatorRequestInfo{
+	conf.CertifiedOperatorInfo = []configsections.CertifiedOperatorRequestInfo{
 		jenkinsOperatorRequestInfo,
 		etcdOperatorRequestInfo,
 	}

--- a/pkg/config/configsections/container_config.go
+++ b/pkg/config/configsections/container_config.go
@@ -14,7 +14,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-package config
+package configsections
 
 // CNFType defines a type to be either Operator or Container
 type CNFType string

--- a/pkg/config/configsections/container_test.go
+++ b/pkg/config/configsections/container_test.go
@@ -14,7 +14,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-package config_test
+package configsections_test
 
 import (
 	"encoding/json"
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/test-network-function/test-network-function/pkg/config"
+	"github.com/test-network-function/test-network-function/pkg/config/configsections"
 	"github.com/test-network-function/test-network-function/pkg/tnf/testcases"
 	"gopkg.in/yaml.v2"
 )
@@ -108,7 +109,7 @@ func newConfig(configPath string) (*config.File, error) {
 
 func loadCnfConfig() {
 	// CNF only
-	test.CNFs = []config.Cnf{
+	test.CNFs = []configsections.Cnf{
 		{
 			Name:      cnfName,
 			Namespace: testNameSpace,
@@ -122,11 +123,11 @@ func loadCnfConfig() {
 }
 
 func loadOperatorConfig() {
-	operator := config.Operator{}
+	operator := configsections.Operator{}
 	operator.Name = operatorName
 	operator.Namespace = operatorNameSpace
 	setCrdsAndInstances()
-	dep := config.Deployment{}
+	dep := configsections.Deployment{}
 	dep.Name = deploymentName
 	dep.Replicas = deploymentReplicas
 	operator.Tests = []string{testcases.OperatorStatus}
@@ -136,16 +137,16 @@ func loadOperatorConfig() {
 }
 
 func setCrdsAndInstances() {
-	crd := config.Crd{}
+	crd := configsections.Crd{}
 	crd.Name = crdNameOne
 	crd.Namespace = testNameSpace
-	instance := config.Instance{}
+	instance := configsections.Instance{}
 	instance.Name = instanceNameOne
 	crd.Instances = append(crd.Instances, instance)
-	crd2 := config.Crd{}
+	crd2 := configsections.Crd{}
 	crd2.Name = crdNameTwo
 	crd2.Namespace = testNameSpace
-	instance2 := config.Instance{}
+	instance2 := configsections.Instance{}
 	instance2.Name = instanceNameTwo
 	crd2.Instances = append(crd2.Instances, instance2)
 }

--- a/pkg/config/configsections/generic_config.go
+++ b/pkg/config/configsections/generic_config.go
@@ -14,7 +14,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-package config
+package configsections
 
 // ContainerIdentifier is a complex key representing a unique container.
 type ContainerIdentifier struct {

--- a/test-network-function/container/suite.go
+++ b/test-network-function/container/suite.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/test-network-function/test-network-function/internal/api"
 	"github.com/test-network-function/test-network-function/pkg/config"
+	"github.com/test-network-function/test-network-function/pkg/config/configsections"
 	"github.com/test-network-function/test-network-function/pkg/tnf"
 	"github.com/test-network-function/test-network-function/pkg/tnf/handlers/container"
 	"github.com/test-network-function/test-network-function/pkg/tnf/interactive"
@@ -49,7 +50,7 @@ var (
 	defaultTimeout = time.Duration(defaultTimeoutSeconds) * time.Second
 	context        *interactive.Context
 	err            error
-	cnfsInTest     []config.Cnf
+	cnfsInTest     []configsections.Cnf
 	certAPIClient  api.CertAPIClient
 )
 

--- a/test-network-function/generic/suite.go
+++ b/test-network-function/generic/suite.go
@@ -28,6 +28,7 @@ import (
 	"github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 	"github.com/test-network-function/test-network-function/pkg/config"
+	"github.com/test-network-function/test-network-function/pkg/config/configsections"
 	"github.com/test-network-function/test-network-function/pkg/tnf"
 	"github.com/test-network-function/test-network-function/pkg/tnf/handlers/base/redhat"
 	"github.com/test-network-function/test-network-function/pkg/tnf/handlers/clusterrolebinding"
@@ -69,7 +70,7 @@ var drainTimeout = time.Duration(drainTimeoutMinutes) * time.Minute
 
 // containersToExcludeFromConnectivityTests is a set used for storing the containers that should be excluded from
 // connectivity testing.
-var containersToExcludeFromConnectivityTests = make(map[config.ContainerIdentifier]interface{})
+var containersToExcludeFromConnectivityTests = make(map[configsections.ContainerIdentifier]interface{})
 
 // Helper used to instantiate an OpenShift Client Session.
 func getOcSession(pod, container, namespace string, timeout time.Duration, options ...interactive.Option) *interactive.Oc {
@@ -108,16 +109,16 @@ func getOcSession(pod, container, namespace string, timeout time.Duration, optio
 // as the reference to the interactive.Oc instance, the reference to the test configuration, and the default network
 // IP address.
 type container struct {
-	containerConfiguration  config.Container
+	containerConfiguration  configsections.Container
 	oc                      *interactive.Oc
 	defaultNetworkIPAddress string
-	containerIdentifier     config.ContainerIdentifier
+	containerIdentifier     configsections.ContainerIdentifier
 }
 
 // createContainers contains the general steps involved in creating "oc" sessions and other configuration. A map of the
 // aggregate information is returned.
-func createContainers(containerDefinitions []config.Container) map[config.ContainerIdentifier]*container {
-	createdContainers := make(map[config.ContainerIdentifier]*container)
+func createContainers(containerDefinitions []configsections.Container) map[configsections.ContainerIdentifier]*container {
+	createdContainers := make(map[configsections.ContainerIdentifier]*container)
 	for _, c := range containerDefinitions {
 		oc := getOcSession(c.PodName, c.ContainerName, c.Namespace, defaultTimeout, interactive.Verbose(true))
 		var defaultIPAddress = "UNKNOWN"
@@ -135,12 +136,12 @@ func createContainers(containerDefinitions []config.Container) map[config.Contai
 }
 
 // createContainersUnderTest sets up the test containers.
-func createContainersUnderTest(conf *config.TestConfiguration) map[config.ContainerIdentifier]*container {
+func createContainersUnderTest(conf *configsections.TestConfiguration) map[configsections.ContainerIdentifier]*container {
 	return createContainers(conf.ContainersUnderTest)
 }
 
 // createPartnerContainers sets up the partner containers.
-func createPartnerContainers(conf *config.TestConfiguration) map[config.ContainerIdentifier]*container {
+func createPartnerContainers(conf *configsections.TestConfiguration) map[configsections.ContainerIdentifier]*container {
 	return createContainers(conf.PartnerContainers)
 }
 
@@ -320,12 +321,9 @@ func getContainerDefaultNetworkIPAddress(oc *interactive.Oc, dev string) string 
 }
 
 // GetTestConfiguration returns the cnf-certification-generic-tests test configuration.
-func GetTestConfiguration() *config.TestConfiguration {
-	var conf config.TestConfiguration
-	c := config.GetConfigInstance()
-	conf = c.Generic
-	gomega.Expect(conf).ToNot(gomega.BeNil())
-	return &conf
+func GetTestConfiguration() *configsections.TestConfiguration {
+	conf := config.GetConfigInstance()
+	return &conf.Generic
 }
 
 func testNamespace(oc *interactive.Oc) {

--- a/test-network-function/operator/suite.go
+++ b/test-network-function/operator/suite.go
@@ -26,6 +26,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/test-network-function/test-network-function/internal/api"
 	"github.com/test-network-function/test-network-function/pkg/config"
+	"github.com/test-network-function/test-network-function/pkg/config/configsections"
 	"github.com/test-network-function/test-network-function/pkg/tnf"
 	"github.com/test-network-function/test-network-function/pkg/tnf/handlers/operator"
 	"github.com/test-network-function/test-network-function/pkg/tnf/interactive"
@@ -70,7 +71,7 @@ var _ = ginkgo.Describe(testSpecName, func() {
 	}
 })
 
-func getConfig() ([]config.CertifiedOperatorRequestInfo, []config.Operator) {
+func getConfig() ([]configsections.CertifiedOperatorRequestInfo, []configsections.Operator) {
 	conf := config.GetConfigInstance()
 	operatorsToQuery := conf.CertifiedOperatorInfo
 	operatorsInTest := conf.Operators


### PR DESCRIPTION
This establishes the patterns and approaches for label- and annotation- -based config from the cluster by implementing it for the `generic` spec.