### PR TITLE
Add support for external TNF source repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN yum install -y golang-${GOLANG_VERSION} jq make git
 
 # Build oc from source
 ADD ${OC_SRC_URL} ${TEMP_DIR}
-RUN mkdir ${OC_SRC_DIR} && \ 
+RUN mkdir ${OC_SRC_DIR} && \
 	tar -xf ${TEMP_DIR}/${OC_SRC_ARCHIVE} -C ${OC_SRC_DIR} --strip-components=1 && \
 	cd ${OC_SRC_DIR} && \
 	make oc && \
@@ -33,8 +33,13 @@ ENV PATH="/root/go/bin:${PATH}"
 
 # Git identifier to checkout
 ARG TNF_VERSION
-# Pull the required version of TNF
-RUN git clone --depth=1 --branch=${TNF_VERSION} https://github.com/test-network-function/test-network-function ${TNF_SRC_DIR}
+ARG TNF_SRC_URL=https://github.com/test-network-function/test-network-function
+ARG GIT_CHECKOUT_TARGET=$TNF_VERSION
+
+# Clone the TNF source repository and checkout the target branch/tag/commit
+RUN git clone --no-single-branch --depth=1 ${TNF_SRC_URL} ${TNF_SRC_DIR}
+RUN git -C ${TNF_SRC_DIR} fetch origin ${GIT_CHECKOUT_TARGET}
+RUN git -C ${TNF_SRC_DIR} checkout ${GIT_CHECKOUT_TARGET}
 
 # Build TNF binary
 WORKDIR ${TNF_SRC_DIR}

--- a/README.md
+++ b/README.md
@@ -36,11 +36,18 @@ The autodiscovery first looks for paths in the `$KUBECONFIG` environment variabl
 
 ### Building
 
-You can build an image locally by using the command below. Use the value of `TNF_VERSION` to set a branch or tag that will be
-installed into the image.
+You can build an image locally by using the command below. Use the value of `TNF_VERSION` to set a branch, a tag, or a hash of a commit that will be installed into the image.
 
 ```shell-script
 docker build -t test-network-function:v1.0.5 --build-arg TNF_VERSION=v1.0.5 .
+```
+
+To build an image that installs TNF from an unofficial source (e.g. a fork of the TNF repository), use the `TNF_SRC_URL` build argument to override the URL to a source repository.
+
+```shell-script
+docker build -t test-network-function:v1.0.5 \
+  --build-arg TNF_VERSION=v1.0.5 \
+  --build-arg TNF_SRC_URL=https://github.com/test-network-function/test-network-function .
 ```
 
 To make `run-container.sh` use the newly built image, specify the custom TNF image using the `-i` parameter.


### PR DESCRIPTION
This change adds an optional build argument `TNF_SRC_URL` to the Dockerfile that allows to override the URL the TNF framework will be downloaded from during the image build process.
The value of the build argument points to the official TNF repository by default.

Also, the Dockerfile now supports checking out a commit of a TNF source repository, in addition to branches and tags.

Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>