### PR TITLE
Add network mode settings to run-container.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ To pull the latest container and run the tests you use the following command. Th
 
 Optional arguments are:
 
-* `-k` gives a path to one or more kubeconfig files to be used by the container to authenticate with the cluster. Paths must be separated by a colon.
 * `-i` gives a name to a custom TNF container image. Supports local images, as well as images from external registries.
+* `-k` gives a path to one or more kubeconfig files to be used by the container to authenticate with the cluster. Paths must be separated by a colon.
+* `-n` gives the network mode of the container. Defaults to `bridge`. See the [docker run --network parameter reference](https://docs.docker.com/engine/reference/run/#network-settings) for more information on how to configure network settings.
 
 If `-k` is not specified, autodiscovery is performed.
 The autodiscovery first looks for paths in the `$KUBECONFIG` environment variable on the host system, and if the variable is not set or is empty, the default configuration stored in `$HOME/.kube/config` is checked.


### PR DESCRIPTION
This change adds an optional -n parameter to run-container.sh allowing to set network settings consumed by a `--network` parameter of the `docker run` command responsible for creating the TNF container.
The network mode defaults to `bridge`, consistent with the equivalent setting provided by the `docker run` command.

The documentation, and the usage prompt have been updated to explain the usage of the -n parameter.

Due to the increase in the number of options available, the list of optional arguments in the documentation is now sorted alphabetically.

Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>