### PR TITLE
Fix debug messages for run-container.sh

### DIFF
--- a/run-container.sh
+++ b/run-container.sh
@@ -160,7 +160,7 @@ perform_kubeconfig_autodiscovery
 
 # Parge args beginning with -
 while [[ $1 == -* ]]; do
-	echo $1 $2
+	echo "$1 $2"
     case "$1" in
       -h|--help|-\?) usage; exit 0;;
       -k) if (($# > 1)); then


### PR DESCRIPTION
When `-n` was given, an unquoted variable in `echo` would break a debug message, as `-n` in echo is responsible for stripping trailing newlines.

Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>