### PR TITLE
correct example config files

### DIFF
--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -62,10 +62,10 @@ cnfs:
     status: ""
     tests:
       - PRIVILEGED_POD
-certifiedcontainerrequestinfo:
+certifiedcontainerinfo:
   - name: nginx-116
     repository: rhel8
-certifiedoperatorrequestinfo:
+certifiedoperatorinfo:
   - name: etcd-operator
     organization: redhat-marketplace
 cnfavailabletestcases:

--- a/pkg/config/testdata/tnf_test_config.yml
+++ b/pkg/config/testdata/tnf_test_config.yml
@@ -35,9 +35,9 @@ cnfs:
     tests:
       - PRIVILEGED_POD
       - PRIVILEGED_ROLE
-certifiedcontainerrequestinfo:
+certifiedcontainerinfo:
   - name: nginx-116  # working example
     repository: rhel8
-certifiedoperatorrequestinfo:
+certifiedoperatorinfo:
   - name: etcd-operator
     organization: redhat-marketplace

--- a/test-network-function/tnf_config.yml
+++ b/test-network-function/tnf_config.yml
@@ -30,9 +30,9 @@ cnfs:
     tests:
       - PRIVILEGED_POD
       - PRIVILEGED_ROLE
-certifiedcontainerrequestinfo:
+certifiedcontainerinfo:
   - name: nginx-116  # working example
     repository: rhel8
-certifiedoperatorrequestinfo:
+certifiedoperatorinfo:
   - name: etcd-operator
     organization: redhat-marketplace


### PR DESCRIPTION
In restructuring the configuration file to separate the certification
information from the cluster resource information, these configuration
files were not completely updated. This change remedies that.