### PR TITLE
Add automatic publishing of unstable TNF images

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -7,8 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 env:
+  REGISTRY: quay.io
   IMAGE_NAME: testnetworkfunction/test-network-function
-  IMAGE_TAG: latest
+  IMAGE_TAG: unstable
   TNF_MINIKUBE_ONLY: true
   TNF_CONFIG_DIR: /tmp/tnf/config
   TNF_OUTPUT_DIR: /tmp/tnf/output
@@ -118,9 +119,13 @@ jobs:
 
       - name: Build the `test-network-function` image
         run: |
-          docker build --no-cache -t $IMAGE_NAME:$IMAGE_TAG \
-            --build-arg TNF_VERSION=${{ github.sha }} \
-            --build-arg TNF_SRC_URL=$TNF_SRC_URL .
+          docker build --no-cache \
+            -t ${IMAGE_NAME}:${IMAGE_TAG} \
+            -t ${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} \
+            --build-arg TNF_VERSION=${COMMIT_SHA} \
+            --build-arg TNF_SRC_URL=${TNF_SRC_URL} .
+        env:
+          COMMIT_SHA: ${{ github.sha }}
 
       - name: Create required TNF config files and directories
         run: |
@@ -130,3 +135,19 @@ jobs:
 
       - name: 'Test: Run diagnostic test suite'
         run: ./run-container.sh ${{ env.TESTING_CMD_PARAMS }} diagnostic
+
+      # Push the new unstable TNF image to Quay.io.
+
+      - name: (if on main and upstream) Authenticate against Quay.io
+        if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          # Use a Robot Account to authenticate against Quay.io
+          # https://docs.quay.io/glossary/robot-accounts.html
+          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: (if on main and upstream) Push the newly built image to Quay.io
+        if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}
+        run: docker push --all-tags ${REGISTRY}/${IMAGE_NAME}

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -19,7 +19,6 @@ env:
   REGISTRY: quay.io
   IMAGE_NAME: testnetworkfunction/test-network-function
   IMAGE_TAG: latest
-  IMAGE_CONTAINER_FILE_PATH: Dockerfile
   CURRENT_VERSION_GENERIC_BRANCH: 1.0.x
   TNF_MINIKUBE_ONLY: true
   TNF_CONFIG_DIR: /tmp/tnf/config


### PR DESCRIPTION
The `pre-main.yaml` workflow is updated to automatically push an unstable image to Quay.io.
The image is built from the `main` branch.

Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>