### PR TITLE
Disable `tnf-image.yaml` workflow on forked repos

### DIFF
--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -30,6 +30,7 @@ env:
 jobs:
   get-latest-tnf-version-number:
     name: 'Get the version number of the latest release'
+    if: ${{ github.repository_owner == 'test-network-function' }}
     runs-on: ubuntu-20.04
     outputs:
       TNF_VERSION: ${{ steps.set_tnf_version.outputs.version_number }}


### PR DESCRIPTION
The workflow's execution will be skipped if run outside of test-network-function.

Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>