### PR TITLE
Disable kernel boot params test on minikube

### DIFF
--- a/test-network-function/generic/suite.go
+++ b/test-network-function/generic/suite.go
@@ -235,8 +235,10 @@ var _ = ginkgo.Describe(testsKey, func() {
 			testOwner(containerUnderTest.oc.GetPodNamespace(), containerUnderTest.oc.GetPodName())
 		}
 
-		for _, containersUnderTest := range containersUnderTest {
-			testBootParams(getContext(), containersUnderTest.oc.GetPodName(), containersUnderTest.oc.GetPodNamespace(), containersUnderTest.oc)
+		if !isMinikube() {
+			for _, containersUnderTest := range containersUnderTest {
+				testBootParams(getContext(), containersUnderTest.oc.GetPodName(), containersUnderTest.oc.GetPodNamespace(), containersUnderTest.oc)
+			}
 		}
 	}
 })


### PR DESCRIPTION
The test uses a custom `MachineConfig` resource that is not available
on minikube.

Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>