### PR TITLE
CTONET-999: Resolves issues with generic test suite

### DIFF
--- a/pkg/tnf/handlers/deploymentsnodes/deploymentsnodes_test.go
+++ b/pkg/tnf/handlers/deploymentsnodes/deploymentsnodes_test.go
@@ -71,7 +71,7 @@ func Test_ReelMatchSuccess(t *testing.T) {
 }
 
 // Just ensure there are no panics.
-func Test_ReelEof(t *testing.T) {
+func Test_ReelEOF(t *testing.T) {
 	newDn := dn.NewDeploymentsNodes(testTimeoutDuration, testNamespace)
 	assert.NotNil(t, newDn)
 	newDn.ReelEOF()

--- a/pkg/tnf/handlers/owners/owners.go
+++ b/pkg/tnf/handlers/owners/owners.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	owRegex = "(?s).+"
+	owRegex = "(?s)OWNERKIND\n.+"
 )
 
 // Owners tests pod owners
@@ -42,7 +42,7 @@ func NewOwners(timeout time.Duration, podNamespace, podName string) *Owners {
 		timeout: timeout,
 		result:  tnf.ERROR,
 		args: []string{"oc", "-n", podNamespace, "get", "pods", podName,
-			"-o", "custom-columns=OWNERKIND:.metadata.ownerReferences[*].kind"},
+			"-o", `custom-columns=OWNERKIND:.metadata.ownerReferences\[\*\].kind`},
 	}
 }
 

--- a/pkg/tnf/handlers/owners/owners_test.go
+++ b/pkg/tnf/handlers/owners/owners_test.go
@@ -38,11 +38,9 @@ func Test_ReelFirstPositive(t *testing.T) {
 	assert.NotNil(t, newOw)
 	firstStep := newOw.ReelFirst()
 	re := regexp.MustCompile(firstStep.Expect[0])
-	positiveInputs := append(testInputFailureSlice, testInputFailureSlice...)
-	for _, positiveInput := range positiveInputs {
+	for _, positiveInput := range testInputSuccessSlice {
 		matches := re.FindStringSubmatch(positiveInput)
 		assert.Len(t, matches, 1)
-		assert.Equal(t, positiveInput, matches[0])
 	}
 }
 
@@ -95,7 +93,7 @@ var (
 		"NAME\nOwner\nOwner\n",
 	}
 	testInputSuccessSlice = []string{
-		"NAME\nOwner\nReplicaSet\n",
-		"NAME\nDaemonSet\nOwner\n",
+		"OWNERKIND\nReplicaSet\n",
+		"OWNERKIND\nDaemonSet\n",
 	}
 )


### PR DESCRIPTION
The generic test suite was failing the Pod ownership test.  This change
resolves a few issues with the test including:

1) The ReelFirst() regular expression was made to be more specific.  Namely,
   the test now expects the proper "OWNERKIND" header, and parses output after
   ignoring the header line.
2) The "-o custom-columns"... line was modified to properly escape brackets and
   the asterisk character.  In many versions of `oc`, these characters must be
   either quoted or escaped.
3) Existing positive unit tests seeded test data from the negative test cases.
   This change switches to accurate positive test data mock output.
   Additionally, the requirement of an exact match is dropped due to the fact
   that trailing newlines may occur with the modified regular expression from
   step 1.

I have tested this change locally several times to ensure that the results are
not sporadically failing.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>
