### PR TITLE
Fixing configsection name

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,7 +55,7 @@ type File struct {
 	CertifiedContainerInfo []configsections.CertifiedContainerRequestInfo `yaml:"certifiedcontainerinfo,omitempty" json:"certifiedcontainerinfo,omitempty"`
 
 	// CertifiedOperatorInfo is list of operator bundle names that are queried for certification status.
-	CertifiedOperatorInfo []configsections.CertifiedOperatorRequestInfo `yaml:"certifiedoperatorinfo,omitempty" json:"certifiedoperatorinfo,omitempty"`
+	CertifiedOperatorInfo []configsections.CertifiedOperatorInfo `yaml:"certifiedoperatorinfo,omitempty" json:"certifiedoperatorinfo,omitempty"`
 
 	// CnfAvailableTestCases list the available test cases for  reference.
 	CnfAvailableTestCases []string `yaml:"cnfavailabletestcases,omitempty" json:"cnfavailabletestcases,omitempty"`


### PR DESCRIPTION
When the CertifiedOperatorInfo is missing from the config files, it complains about CertifiedOperatorRequestInfo is required. But it should complain about CertifiedOperatorInfo.

```
should be created without error [It]                                                                                                                                        [149/1855]
    /home/redhat/beto/master/test-network-function/test-network-function/operator/suite.go:62                                                                                             
                                                                                                                                                                                          
    Expected                                                                                                                                                                              
        <[]configsections.CertifiedOperatorRequestInfo | len:0, cap:0>: nil                                                                                                               
    not to be nil  
```