### PR TITLE
Add a link to CATALOG.md in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This repository contains a set of network function test cases and the framework to build more.  It also generates reports
 (claim.json) on the result of a test run.
+
+Please consult [CATALOG.md](./CATALOG.md) for a catalog of the included test cases and test case building blocks.
+
 The tests and framework are intended to test the interaction of Cloud-Native Network Functions (CNFs) with OpenShift
 Container Platform.
 


### PR DESCRIPTION
Link the available tests in README.md so people actually
know what tests we include.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>