### PR TITLE
Explicitly allow use of "docker" instead of "podman"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ Currently supported environment variables include:
 - `TNF_MINIKUBE_ONLY`
 - `TNF_ENABLE_CONFIG_AUTODISCOVER`
 
+#### Running using `docker` instead of `podman`
+
+By default, `run-container.sh` utilizes `podman`.  However, you can configure an alternate container virtualization
+client using `TNF_CONTAINER_CLIENT`.  This is particularly useful for operating systems that do not readily support
+`podman`, such as macOS.  In order to configure the test harness to use `docker`, issue the following prior to
+`run-tnf-container.sh`:
+
+```shell script
+export TNF_CONAINER_CLIENT="docker"
+```
+
 ### Building
 
 You can build an image locally by using the command below. Use the value of `TNF_VERSION` to set a branch, a tag, or a hash of a commit that will be installed into the image.

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,5 +1,24 @@
 #!/usr/bin/env bash
 
+# configure_tnf_container_client configures the underlying container virtualization client.  If the user sets the
+# TNF_CONTAINER_CLIENT environment variable, then that value is utilized.  Otherwise, "podman" is used by default.
+# This is particularly useful for Operating Systems which do not readily support "podman", and "docker" must be used.
+function configure_tnf_container_client() {
+  PODMAN_EXECUTABLE="podman"
+  DEFAULT_CONTAINER_EXECUTABLE="${PODMAN_EXECUTABLE}"
+
+  if [ "" == "${TNF_CONTAINER_CLIENT}" ]
+  then
+    echo "The \$TNF_CONTAINER_CLIENT environment variable is not set; defaulting to use: ${DEFAULT_CONTAINER_EXECUTABLE}"
+    export TNF_CONTAINER_CLIENT="${DEFAULT_CONTAINER_EXECUTABLE}"
+  else
+    echo "\$TNF_CONTAINER_CLIENT is set;  using: ${TNF_CONTAINER_CLIENT}"
+  fi
+}
+
+# call the function to configure "podman" or something else if specified by TNF_CONTAINER_CLIENT
+configure_tnf_container_client
+
 CONTAINER_TNF_DIR=/usr/tnf
 CONTAINER_TNF_KUBECONFIG_FILE_BASE_PATH="$CONTAINER_TNF_DIR/kubeconfig/config"
 CONTAINER_DEFAULT_NETWORK_MODE=bridge
@@ -76,7 +95,7 @@ if [ ! -z "${DNS_ARG}" ]; then
 fi
 
 set -x
-podman run --rm $DNS_ARG \
+${TNF_CONTAINER_CLIENT} run --rm $DNS_ARG \
 	--network $CONTAINER_NETWORK_MODE \
 	${container_tnf_kubeconfig_volumes_cmd_args[@]} \
 	$CONFIG_VOLUME_MOUNT_ARG:Z \


### PR DESCRIPTION
Resolves #238.

There are a whole host of issues with using "podman" on many non-linux
Operating Systems.  For example, support in macOS currently involves federation
with a remote linux based server.  As such, we should support multiple
platforms and allow the use of alternative container virtualization clients.

This change adds the auto-detection of a user-specified container
virtualization client through the TNF_CONTAINER_CLIENT environment variable.
If the user does not set the variable, then "podman" is used by default.

Additionally, documentation was added to give an example of how to use
"docker" instead of "podman".

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>