### PR TITLE
Cleanup suite_test.go

### DIFF
--- a/cmd/claim/main.go
+++ b/cmd/claim/main.go
@@ -107,7 +107,7 @@ func claimUpdate() {
 		if _, ok := junitMap[reportKeyName]; ok {
 			log.Printf("Skipping: %s already exists in supplied `%s` claim file", reportKeyName, *claimFileTextPtr)
 		} else {
-			junitMap[reportKeyName], err = junit.ExportJUnitAsJSON(fmt.Sprintf("%s/%s", *reportFilesTextPtr, item.Name()))
+			junitMap[reportKeyName], err = junit.ExportJUnitAsMap(fmt.Sprintf("%s/%s", *reportFilesTextPtr, item.Name()))
 			if err != nil {
 				log.Fatalf("Error reading JUnit XML file into JSON: %v", err)
 			}

--- a/pkg/junit/convert.go
+++ b/pkg/junit/convert.go
@@ -45,8 +45,8 @@ const (
 	CouldNotDeriveFailureReason = "could not derive a reason for the failure from the output JSON"
 )
 
-// ExportJUnitAsJSON attempts to read a JUnit XML file and converts it to a generic JSON map.
-func ExportJUnitAsJSON(junitFilename string) (map[string]interface{}, error) {
+// ExportJUnitAsMap attempts to read a JUnit XML file and converts it to a generic map.
+func ExportJUnitAsMap(junitFilename string) (map[string]interface{}, error) {
 	xmlReader, err := os.Open(junitFilename)
 	// An error is encountered reading the file.
 	if err != nil {

--- a/pkg/junit/convert_test.go
+++ b/pkg/junit/convert_test.go
@@ -30,7 +30,7 @@ const (
 )
 
 func TestExtractTestSuiteResults(t *testing.T) {
-	junitResults, err := junit.ExportJUnitAsJSON(path.Join("testdata", testJunitXMLFilename))
+	junitResults, err := junit.ExportJUnitAsMap(path.Join("testdata", testJunitXMLFilename))
 	claim := make(map[string]interface{})
 	claim[testKey] = junitResults
 	assert.Nil(t, err)

--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -33,7 +33,7 @@ while [[ $1 == -* ]]; do
 	esac
 done
 # specify Junit report file name.
-GINKGO_ARGS="-ginkgo.v -junit $OUTPUT_LOC -report $OUTPUT_LOC -claimloc $OUTPUT_LOC -ginkgo.reportFile $OUTPUT_LOC/cnf-certification-tests_junit.xml"
+GINKGO_ARGS="-ginkgo.v -junit $OUTPUT_LOC -claimloc $OUTPUT_LOC -ginkgo.reportFile $OUTPUT_LOC/cnf-certification-tests_junit.xml"
 FOCUS=""
 
 for var in "$@"


### PR DESCRIPTION
After today's presentation, it became clear that the main entrypoint to our
test suite (suite_test.go's TestTest) was extremely messy.  As such, this
commit cleans up the entrypoint by:

* abstracting several helper methods to decrease the complexity of TestTest()
* Renaming the `ExportJunitAsJSON` to `ExportJUnitAsMap`, which is
  linguistically more accurate.
* Eliding useless variables in places.
* Eliding the "-report" flag, as it wasn't actually used for anything.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>