### PR TITLE
Automatic terminal prompt emulation

### DIFF
--- a/pkg/tnf/reel/reel_test.go
+++ b/pkg/tnf/reel/reel_test.go
@@ -90,7 +90,7 @@ func TestNewReel(t *testing.T) {
 
 		var expecter expect.Expecter = mockExpecter
 		var errorChannel <-chan error
-		r, err := reel.NewReel(&expecter, testCase.command, errorChannel)
+		r, err := reel.NewReel(&expecter, testCase.command, errorChannel, reel.DisableTerminalPromptEmulation())
 		assert.Equal(t, testCase.newReelResultErr, err)
 		assert.Equal(t, testCase.newReelResultIsNil, r == nil)
 		// In the event that the Reel instance is good, perform Run()
@@ -234,7 +234,7 @@ func TestReel_Step(t *testing.T) {
 		}
 
 		mockExpecter := mock_interactive.NewMockExpecter(ctrl)
-		mockExpecter.EXPECT().Send(testCommand).Return(nil)
+		mockExpecter.EXPECT().Send(reel.WrapTestCommand(testCommand)).Return(nil)
 		if testCase.expectBatchExpectedInvocationCount > 0 {
 			mockExpecter.EXPECT().ExpectBatch(gomock.Any(), gomock.Any()).Times(testCase.expectBatchExpectedInvocationCount).Return(testCase.expectBatchResResult, testCase.expectBatchErrResult)
 		}

--- a/pkg/tnf/test.go
+++ b/pkg/tnf/test.go
@@ -129,9 +129,9 @@ func (t *Test) ReelEOF() {
 }
 
 // NewTest creates a new Test given a chain of Handlers.
-func NewTest(expecter *expect.Expecter, tester Tester, chain []reel.Handler, errorChannel <-chan error) (*Test, error) {
-	var args []string = tester.Args()
-	runner, err := reel.NewReel(expecter, args, errorChannel)
+func NewTest(expecter *expect.Expecter, tester Tester, chain []reel.Handler, errorChannel <-chan error, opts ...reel.Option) (*Test, error) {
+	args := tester.Args()
+	runner, err := reel.NewReel(expecter, args, errorChannel, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
CTONET-1013 and CTONET-1011 both share a common problem;  it appears that
results are being truncated.  This is true, but it is supposed to happen.  The
way `expect` works is to return the first match of a given regular expression.
Even if greedy quantifiers such as `*` are utilized, google/goexpect is based
on copying an output buffer every so often (the interval is identified by
chkDuration duration.Duration in goexepct).

As such, consider the following regular expression:

`(?s).+`

This could match something as simple as:

`BeginningOfTheOutput...`

When the user fully intended to capture:

```
BeginningOfTheOutput...
EndOfTheOutput
```

The problem compounds for situations in which the command output is arbitrary
in length, and could very well not end with a sentinel at all.  In typical
expect programs, users can just expect the terminal prompt.  In this case
though, google/goexpect delegates consumption of the prompt to the underlying
PTY, so we cannot simply expect the terminal prompt.  As such, we must get a
bit more creative.

This PR introduces the ability to postfix any command with a sentinel,
indicating that the command output has completed successfully.  This allows
us to fully drain the google/goexpect PTY buffers, and greedily capture as much
output as possible.

The mechanism is on by default, but can be turned off per-Test or per-Reel.
The idea is to emulate the resulting terminal prompt which visually lets a user
know that the previous command has completed.  Think of something similar to
the following:

```
[redhat@bastion ~]$ ls /tmp
systemd-private-5a3e10cedce0468fa62fa3e366810b8c-chronyd.service-T66lA8
systemd-private-5a3e10cedce0468fa62fa3e366810b8c-httpd.service-TWeooL
systemd-private-5a3e10cedce0468fa62fa3e366810b8c-systemd-resolved.service-tGDXYz
tmux-1007
[redhat@bastion ~]$
```

We only know the command is done when we see the "[redhat@bastion ~]" prompt.

Unit tests have been augmented.  Cases were modified for both situations in
various places to ensure both strategies work correctly.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>