### PR TITLE
Resolves issue in the command to derive machineconfig set for a node

### DIFF
--- a/pkg/tnf/handlers/nodemcname/nodemcname.go
+++ b/pkg/tnf/handlers/nodemcname/nodemcname.go
@@ -42,7 +42,7 @@ func NewNodeMcName(timeout time.Duration, nodeName string) *NodeMcName {
 		timeout: timeout,
 		result:  tnf.ERROR,
 		args: []string{
-			"oc get node " + nodeName + " -o jsonpath=\"{.metadata.annotations}\" " + "| jq '.\"machineconfiguration.openshift.io/currentConfig\"' | xargs echo",
+			"oc get node " + nodeName + ` -o json | jq '.metadata.annotations."machineconfiguration.openshift.io/currentConfig"'`,
 		},
 	}
 }


### PR DESCRIPTION
The provided command was not producing any output, as there was an issue with
quotations and escaping.  This change utilizes a new command which does produce
the intended output.  This change was tested in New Mexico:

```
2021/06/09 17:54:37 Sent: "oc get node worker-113 -o json | jq '.metadata.annotations.\"machineconfiguration.openshift.io/currentConfig\"' && echo END_OF_TEST_SENTINEL\n"
2021/06/09 17:54:37 Match for RE: ".+((.|\n)*END_OF_TEST_SENTINEL\n)" found: ["\"rendered-worker-db680ffdf57f50623cf602c0a665d755\"\nEND_OF_TEST_SENTINEL\n" "\nEND_OF_TEST_SENTINEL\n" "\n"] Buffer: "\"rendered-worker-db680ffdf57f50623cf602c0a665d755\"\nEND_OF_TEST_SENTINEL\n"
```

As seen above, the corrected "rendered-worker-XXXX" machine config set is
extracted and returned.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>