### PR TITLE
Query for operator/container certification only when present

### DIFF
--- a/test-network-function/container/suite.go
+++ b/test-network-function/container/suite.go
@@ -72,19 +72,20 @@ var _ = ginkgo.Describe(testSpecName, func() {
 		ginkgo.When("getting certification status", func() {
 			conf := config.GetConfigInstance()
 			cnfsToQuery := conf.CertifiedContainerInfo
-			gomega.Expect(cnfsToQuery).ToNot(gomega.BeNil())
-			certAPIClient = api.NewHTTPClient()
-			for _, cnfRequestInfo := range cnfsToQuery {
-				cnf := cnfRequestInfo
-				// Care: this test takes some time to run, failures at later points while before this has finished may be reported as a failure here. Read the failure reason carefully.
-				ginkgo.It(fmt.Sprintf("container %s/%s should eventually be verified as certified", cnf.Repository, cnf.Name), func() {
-					defer results.RecordResult(identifiers.TestContainerIsCertifiedIdentifier)
-					cnf := cnf // pin
-					gomega.Eventually(func() bool {
-						isCertified := certAPIClient.IsContainerCertified(cnf.Repository, cnf.Name)
-						return isCertified
-					}, eventuallyTimeoutSeconds, interval).Should(gomega.BeTrue())
-				})
+			if len(cnfsToQuery) > 0 {
+				certAPIClient = api.NewHTTPClient()
+				for _, cnfRequestInfo := range cnfsToQuery {
+					cnf := cnfRequestInfo
+					// Care: this test takes some time to run, failures at later points while before this has finished may be reported as a failure here. Read the failure reason carefully.
+					ginkgo.It(fmt.Sprintf("container %s/%s should eventually be verified as certified", cnf.Repository, cnf.Name), func() {
+						defer results.RecordResult(identifiers.TestContainerIsCertifiedIdentifier)
+						cnf := cnf // pin
+						gomega.Eventually(func() bool {
+							isCertified := certAPIClient.IsContainerCertified(cnf.Repository, cnf.Name)
+							return isCertified
+						}, eventuallyTimeoutSeconds, interval).Should(gomega.BeTrue())
+					})
+				}
 			}
 		})
 		// Run the tests that interact with the containers

--- a/test-network-function/operator/suite.go
+++ b/test-network-function/operator/suite.go
@@ -83,18 +83,19 @@ func getConfig() ([]configsections.CertifiedOperatorRequestInfo, []configsection
 
 func itRunsTestsOnOperator() {
 	operatorsToQuery, operatorsInTest := getConfig()
-	gomega.Expect(operatorsToQuery).ToNot(gomega.BeNil())
-	certAPIClient := api.NewHTTPClient()
-	for _, certified := range operatorsToQuery {
-		// Care: this test takes some time to run, failures at later points while before this has finished may be reported as a failure here. Read the failure reason carefully.
-		ginkgo.It(fmt.Sprintf("should eventually be verified as certified (operator %s/%s)", certified.Organization, certified.Name), func() {
-			defer results.RecordResult(identifiers.TestOperatorIsCertifiedIdentifier)
-			certified := certified // pin
-			gomega.Eventually(func() bool {
-				isCertified := certAPIClient.IsOperatorCertified(certified.Organization, certified.Name)
-				return isCertified
-			}, eventuallyTimeoutSeconds, interval).Should(gomega.BeTrue())
-		})
+	if len(operatorsToQuery) > 0 {
+		certAPIClient := api.NewHTTPClient()
+		for _, certified := range operatorsToQuery {
+			// Care: this test takes some time to run, failures at later points while before this has finished may be reported as a failure here. Read the failure reason carefully.
+			ginkgo.It(fmt.Sprintf("should eventually be verified as certified (operator %s/%s)", certified.Organization, certified.Name), func() {
+				defer results.RecordResult(identifiers.TestOperatorIsCertifiedIdentifier)
+				certified := certified // pin
+				gomega.Eventually(func() bool {
+					isCertified := certAPIClient.IsOperatorCertified(certified.Organization, certified.Name)
+					return isCertified
+				}, eventuallyTimeoutSeconds, interval).Should(gomega.BeTrue())
+			})
+		}
 	}
 	gomega.Expect(operatorsInTest).ToNot(gomega.BeNil())
 	for _, op := range operatorsInTest {


### PR DESCRIPTION
Only query for container/operator certification when they are present.  This
ultimately makes these sections of config optional.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>