### PR TITLE
Resolves issues with checking operator subscription

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -6,94 +6,14 @@ test-network-function contains a variety of `Test Cases`, as well as `Test Case 
 ## Test Case Catalog
 
 Test Cases are the specifications used to perform a meaningful test.  Test cases may run once, or several times against several targets.  CNF Certification includes a number of normative and informative tests to ensure CNFs follow best practices.  Here is the list of available Test Cases:
-### http://test-network-function.com/testcases/generic/services-do-not-use-nodeports
+### http://test-network-function.com/testcases/operator/operator-is-installed-via-olm
 
 Property|Description
 ---|---
 Version|v1.0.0
-Description|http://test-network-function.com/testcases/generic/services-do-not-use-nodeports tests that each CNF Service does not utilize NodePort(s).
+Description|http://test-network-function.com/testcases/operator/operator-is-installed-via-olm tests whether a CNF Operator is installed via OLM.
 Result Type|normative
-Suggested Remediation|Ensure Services are not configured to not use NodePort(s).
-### http://test-network-function.com/testcases/container/container-best-practices
-
-Property|Description
----|---
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/container/container-best-practices tests several aspects of CNF best practices, including: 1. The Pod does not have access to Host Node Networking. 2. The Pod does not have access to Host Node Ports. 3. The Pod cannot access Host Node IPC space. 4. The Pod cannot access Host Node PID space. 5. The Pod is not granted NET_ADMIN SCC. 6. The Pod is not granted SYS_ADMIN SCC. 7. The Pod does not run as root. 8. The Pod does not allow privileged escalation. 
-Result Type|normative
-Suggested Remediation|Ensure that each Pod in the CNF abides by the suggested best practices listed in the test description.  In some rare cases, not all best practices can be followed.  For example, some CNFs may be required to run as root.  Such exceptions should be handled on a case-by-case basis, and should provide a proper justification as to why the best practice(s) cannot be followed.
-### http://test-network-function.com/testcases/container/container-is-certified
-
-Property|Description
----|---
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/container/container-is-certified tests whether container images have passed the Red Hat Container Certification Program (CCP).
-Result Type|normative
-Suggested Remediation|Ensure that your container has passed the Red Hat Container Certification Program (CCP).
-### http://test-network-function.com/testcases/generic/pod-node-selector-node-affinity-best-practices
-
-Property|Description
----|---
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/generic/pod-node-selector-node-affinity-best-practices ensures that CNF Pods do not specify nodeSelector or nodeAffinity.  In most cases, Pods should allow for instantiation on any underlying Node.
-Result Type|informative
-Suggested Remediation|In most cases, Pod's should not specify their host Nodes through nodeSelector or nodeAffinity.  However, there are cases in which CNFs require specialized hardware specific to a particular class of Node.  As such, this test is purely informative,  and will not prevent a CNF from being certified.  However, one should have an appropriate justification as to why nodeSelector and/or nodeAffinity is utilized by a CNF.
-### http://test-network-function.com/testcases/generic/pod-deployment-best-practices
-
-Property|Description
----|---
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/generic/pod-deployment-best-practices tests that CNF Pod(s) are deployed as part of either DaemonSet(s) or a ReplicaSet(s).
-Result Type|normative
-Suggested Remediation|Deploy the CNF using DaemonSet or ReplicaSet.
-### http://test-network-function.com/testcases/generic/pod-role-bindings-best-practices
-
-Property|Description
----|---
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/generic/pod-role-bindings-best-practices ensures that a CNF does not utilize RoleBinding(s) in a non-CNF Namespace.
-Result Type|normative
-Suggested Remediation|Ensure the CNF is not configured to use RoleBinding(s) in a non-CNF Namespace.
-### http://test-network-function.com/testcases/diagnostic/extract-node-information
-
-Property|Description
----|---
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/diagnostic/extract-node-information extracts informational information about the cluster.
-Result Type|informative
-Suggested Remediation|
-### http://test-network-function.com/testcases/generic/non-default-grace-period
-
-Property|Description
----|---
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/generic/non-default-grace-period tests whether the terminationGracePeriod is CNF-specific, or if the default (30s) is utilized.  This test is informative, and will not affect CNF Certification.  In many cases, the default terminationGracePeriod is perfectly acceptable for a CNF.
-Result Type|informative
-Suggested Remediation|Choose a terminationGracePeriod that is appropriate for your given CNF.  If the default (30s) is appropriate, then feel free to ignore this informative message.  This test is meant to raise awareness around how Pods are terminated, and to suggest that a CNF is configured based on its requirements.  In addition to a terminationGracePeriod, consider utilizing a termination hook in the case that your application requires special shutdown instructions.
-### http://test-network-function.com/testcases/operator/operator-best-practices
-
-Property|Description
----|---
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/operator/operator-best-practices Ensures that CNF Operators abide by best practices.  The following is tested: 1. The Operator CSV reports "Installed" status. 2. The Operator is installed using through an Operator subscription catalog.
-Result Type|normative
-Suggested Remediation|Ensure that your Operator abides by the Operator Best Practices mentioned in the description.
-### http://test-network-function.com/testcases/operator/operator-is-certified
-
-Property|Description
----|---
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/operator/operator-is-certified tests whether CNF Operators have passed the Red Hat Operator Certification Program (OCP).
-Result Type|normative
-Suggested Remediation|Ensure that your Operator has passed Red Hat's Operator Certification Program (OCP).
-### http://test-network-function.com/testcases/generic/pod-cluster-role-bindings-best-practices
-
-Property|Description
----|---
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/generic/pod-cluster-role-bindings-best-practices tests that a Pod does not specify ClusterRoleBindings.
-Result Type|normative
-Suggested Remediation|In most cases, Pod's should not have ClusterRoleBindings.  The suggested remediation is to remove the need for ClusterRoleBindings, if possible.
+Suggested Remediation|Ensure that your Operator is installed via OLM.
 ### http://test-network-function.com/testcases/generic/pod-service-account-best-practices
 
 Property|Description
@@ -102,30 +22,22 @@ Version|v1.0.0
 Description|http://test-network-function.com/testcases/generic/pod-service-account-best-practices tests that each CNF Pod utilizes a valid Service Account.
 Result Type|normative
 Suggested Remediation|Ensure that the each CNF Pod is configured to use a valid Service Account
-### http://test-network-function.com/testcases/generic/unaltered-startup-boot-params
+### http://test-network-function.com/testcases/container/container-is-certified
 
 Property|Description
 ---|---
 Version|v1.0.0
-Description|http://test-network-function.com/testcases/generic/unaltered-startup-boot-params tests that boot parameters are set through the MachineConfigOperator, and not set manually on the Node.
+Description|http://test-network-function.com/testcases/container/container-is-certified tests whether container images have passed the Red Hat Container Certification Program (CCP).
 Result Type|normative
-Suggested Remediation|Ensure that boot parameters are set directly through the MachineConfigOperator, or indirectly through the PerfromanceAddonOperator.  Boot parameters should not be changed directly through the Node, as OpenShift should manage the changes for you.
-### http://test-network-function.com/testcases/generic/unaltered-base-image
+Suggested Remediation|Ensure that your container has passed the Red Hat Container Certification Program (CCP).
+### http://test-network-function.com/testcases/diagnostic/extract-node-information
 
 Property|Description
 ---|---
 Version|v1.0.0
-Description|http://test-network-function.com/testcases/generic/unaltered-base-image ensures that the Container Base Image is not altered post-startup.  This test is a heuristic, and ensures that there are no changes to the following directories: 1) /var/lib/rpm 2) /var/lib/dpkg 3) /bin 4) /sbin 5) /lib 6) /lib64 7) /usr/bin 8) /usr/sbin 9) /usr/lib 10) /usr/lib64
-Result Type|normative
-Suggested Remediation|Ensure that Container applications do not modify the Container Base Image.  In particular, ensure that the following directories are not modified: 1) /var/lib/rpm 2) /var/lib/dpkg 3) /bin 4) /sbin 5) /lib 6) /lib64 7) /usr/bin 8) /usr/sbin 9) /usr/lib 10) /usr/lib64 Ensure that all required binaries are built directly into the container image, and are not installed post startup.
-### http://test-network-function.com/testcases/generic/hugepages-not-manually-manipulated
-
-Property|Description
----|---
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/generic/hugepages-not-manually-manipulated checks to see that HugePage settings have been configured through MachineConfig, and not manually on the underlying Node.  This test case applies only to Nodes that are configured with the "worker" MachineConfigSet.  First, the "worker" MachineConfig is polled, and the Hugepage settings are extracted.  Next, the underlying Nodes are polled for configured HugePages through inspection of /proc/meminfo.  The results are compared, and the test passes only if they are the same.
-Result Type|normative
-Suggested Remediation|HugePage settings should be configured either directly through the MachineConfigOperator or indirectly using the PeformanceAddonOperator.  This ensures that OpenShift is aware of the special MachineConfig requirements, and can provision your CNF on a Node that is part of the corresponding MachineConfigSet.  Avoid making changes directly to an underlying Node, and let OpenShift handle the heavy lifting of configuring advanced settings.
+Description|http://test-network-function.com/testcases/diagnostic/extract-node-information extracts informational information about the cluster.
+Result Type|informative
+Suggested Remediation|
 ### http://test-network-function.com/testcases/generic/icmpv4-connectivity
 
 Property|Description
@@ -142,6 +54,78 @@ Version|v1.0.0
 Description|http://test-network-function.com/testcases/generic/namespace-best-practices tests that CNFs utilize a CNF-specific namespace, and that the namespace does not start with "openshift-". OpenShift may host a variety of CNF and software applications, and multi-tenancy of such applications is supported through namespaces.  As such, each CNF should be a good neighbor, and utilize an appropriate, unique namespace.
 Result Type|normative
 Suggested Remediation|Ensure that your CNF utilizes a CNF-specific namespace.  Additionally, the CNF-specific namespace should not start with "openshift-", except in rare cases.
+### http://test-network-function.com/testcases/generic/non-default-grace-period
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/generic/non-default-grace-period tests whether the terminationGracePeriod is CNF-specific, or if the default (30s) is utilized.  This test is informative, and will not affect CNF Certification.  In many cases, the default terminationGracePeriod is perfectly acceptable for a CNF.
+Result Type|informative
+Suggested Remediation|Choose a terminationGracePeriod that is appropriate for your given CNF.  If the default (30s) is appropriate, then feel free to ignore this informative message.  This test is meant to raise awareness around how Pods are terminated, and to suggest that a CNF is configured based on its requirements.  In addition to a terminationGracePeriod, consider utilizing a termination hook in the case that your application requires special shutdown instructions.
+### http://test-network-function.com/testcases/operator/operator-is-certified
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/operator/operator-is-certified tests whether CNF Operators have passed the Red Hat Operator Certification Program (OCP).
+Result Type|normative
+Suggested Remediation|Ensure that your Operator has passed Red Hat's Operator Certification Program (OCP).
+### http://test-network-function.com/testcases/generic/unaltered-base-image
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/generic/unaltered-base-image ensures that the Container Base Image is not altered post-startup.  This test is a heuristic, and ensures that there are no changes to the following directories: 1) /var/lib/rpm 2) /var/lib/dpkg 3) /bin 4) /sbin 5) /lib 6) /lib64 7) /usr/bin 8) /usr/sbin 9) /usr/lib 10) /usr/lib64
+Result Type|normative
+Suggested Remediation|Ensure that Container applications do not modify the Container Base Image.  In particular, ensure that the following directories are not modified: 1) /var/lib/rpm 2) /var/lib/dpkg 3) /bin 4) /sbin 5) /lib 6) /lib64 7) /usr/bin 8) /usr/sbin 9) /usr/lib 10) /usr/lib64 Ensure that all required binaries are built directly into the container image, and are not installed post startup.
+### http://test-network-function.com/testcases/container/container-best-practices
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/container/container-best-practices tests several aspects of CNF best practices, including: 1. The Pod does not have access to Host Node Networking. 2. The Pod does not have access to Host Node Ports. 3. The Pod cannot access Host Node IPC space. 4. The Pod cannot access Host Node PID space. 5. The Pod is not granted NET_ADMIN SCC. 6. The Pod is not granted SYS_ADMIN SCC. 7. The Pod does not run as root. 8. The Pod does not allow privileged escalation. 
+Result Type|normative
+Suggested Remediation|Ensure that each Pod in the CNF abides by the suggested best practices listed in the test description.  In some rare cases, not all best practices can be followed.  For example, some CNFs may be required to run as root.  Such exceptions should be handled on a case-by-case basis, and should provide a proper justification as to why the best practice(s) cannot be followed.
+### http://test-network-function.com/testcases/generic/hugepages-not-manually-manipulated
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/generic/hugepages-not-manually-manipulated checks to see that HugePage settings have been configured through MachineConfig, and not manually on the underlying Node.  This test case applies only to Nodes that are configured with the "worker" MachineConfigSet.  First, the "worker" MachineConfig is polled, and the Hugepage settings are extracted.  Next, the underlying Nodes are polled for configured HugePages through inspection of /proc/meminfo.  The results are compared, and the test passes only if they are the same.
+Result Type|normative
+Suggested Remediation|HugePage settings should be configured either directly through the MachineConfigOperator or indirectly using the PeformanceAddonOperator.  This ensures that OpenShift is aware of the special MachineConfig requirements, and can provision your CNF on a Node that is part of the corresponding MachineConfigSet.  Avoid making changes directly to an underlying Node, and let OpenShift handle the heavy lifting of configuring advanced settings.
+### http://test-network-function.com/testcases/operator/operator-best-practices
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/operator/operator-best-practices Ensures that CNF Operators abide by best practices.  The following is tested: 1. The Operator CSV reports "Installed" status. 2. The Operator is installed using through an Operator subscription catalog.
+Result Type|normative
+Suggested Remediation|Ensure that your Operator abides by the Operator Best Practices mentioned in the description.
+### http://test-network-function.com/testcases/generic/pod-cluster-role-bindings-best-practices
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/generic/pod-cluster-role-bindings-best-practices tests that a Pod does not specify ClusterRoleBindings.
+Result Type|normative
+Suggested Remediation|In most cases, Pod's should not have ClusterRoleBindings.  The suggested remediation is to remove the need for ClusterRoleBindings, if possible.
+### http://test-network-function.com/testcases/generic/pod-role-bindings-best-practices
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/generic/pod-role-bindings-best-practices ensures that a CNF does not utilize RoleBinding(s) in a non-CNF Namespace.
+Result Type|normative
+Suggested Remediation|Ensure the CNF is not configured to use RoleBinding(s) in a non-CNF Namespace.
+### http://test-network-function.com/testcases/generic/services-do-not-use-nodeports
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/generic/services-do-not-use-nodeports tests that each CNF Service does not utilize NodePort(s).
+Result Type|normative
+Suggested Remediation|Ensure Services are not configured to not use NodePort(s).
 ### http://test-network-function.com/testcases/generic/non-tainted-node-kernel
 
 Property|Description
@@ -150,85 +134,50 @@ Version|v1.0.0
 Description|http://test-network-function.com/testcases/generic/non-tainted-node-kernel ensures that the Node(s) hosting CNFs do not utilize tainted kernels. This test case is especially important to support Highly Available CNFs, since when a CNF is re-instantiated on a backup Node, that Node's kernel may not have the same hacks.'
 Result Type|normative
 Suggested Remediation|Test failure indicates that the underlying Node's' kernel is tainted.  Ensure that you have not altered underlying Node(s) kernels in order to run the CNF.
+### http://test-network-function.com/testcases/generic/pod-node-selector-node-affinity-best-practices
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/generic/pod-node-selector-node-affinity-best-practices ensures that CNF Pods do not specify nodeSelector or nodeAffinity.  In most cases, Pods should allow for instantiation on any underlying Node.
+Result Type|informative
+Suggested Remediation|In most cases, Pod's should not specify their host Nodes through nodeSelector or nodeAffinity.  However, there are cases in which CNFs require specialized hardware specific to a particular class of Node.  As such, this test is purely informative,  and will not prevent a CNF from being certified.  However, one should have an appropriate justification as to why nodeSelector and/or nodeAffinity is utilized by a CNF.
+### http://test-network-function.com/testcases/generic/pod-deployment-best-practices
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/generic/pod-deployment-best-practices tests that CNF Pod(s) are deployed as part of either DaemonSet(s) or a ReplicaSet(s).
+Result Type|normative
+Suggested Remediation|Deploy the CNF using DaemonSet or ReplicaSet.
+### http://test-network-function.com/testcases/generic/unaltered-startup-boot-params
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/generic/unaltered-startup-boot-params tests that boot parameters are set through the MachineConfigOperator, and not set manually on the Node.
+Result Type|normative
+Suggested Remediation|Ensure that boot parameters are set directly through the MachineConfigOperator, or indirectly through the PerfromanceAddonOperator.  Boot parameters should not be changed directly through the Node, as OpenShift should manage the changes for you.
+
 
 ## Test Case Building Blocks Catalog
 
 A number of Test Case Building Blocks, or `tnf.Test`s, are included out of the box.  This is a summary of the available implementations:
-### http://test-network-function.com/tests/owners
+### http://test-network-function.com/tests/nodes
 Property|Description
 ---|---
 Version|v1.0.0
-Description|A generic test used to test pod owners
-Result Type|normative
-Intrusive|false
-Modifications Persist After Test|false
-Runtime Binaries Required|`cat`
-
-### http://test-network-function.com/tests/nodemcname
-Property|Description
----|---
-Version|v1.0.0
-Description|A generic test used to get node's /proc/cmdline
-Result Type|normative
-Intrusive|false
-Modifications Persist After Test|false
-Runtime Binaries Required|`cat`
-
-### http://test-network-function.com/tests/nodemcname
-Property|Description
----|---
-Version|v1.0.0
-Description|A generic test used to get node's next boot kernel args
-Result Type|normative
-Intrusive|false
-Modifications Persist After Test|false
-Runtime Binaries Required|`ls`, `sort`, `head`, `cut`, `oc`
-
-### http://test-network-function.com/tests/hostname
-Property|Description
----|---
-Version|v1.0.0
-Description|A generic test used to check the hostname of a target machine/container.
-Result Type|normative
-Intrusive|false
-Modifications Persist After Test|false
-Runtime Binaries Required|`hostname`
-
-### http://test-network-function.com/tests/container/pod
-Property|Description
----|---
-Version|v1.0.0
-Description|A container-specific test suite used to verify various aspects of the underlying container.
-Result Type|normative
-Intrusive|false
-Modifications Persist After Test|false
-Runtime Binaries Required|`jq`, `oc`
-
-### http://test-network-function.com/tests/gracePeriod
-Property|Description
----|---
-Version|v1.0.0
-Description|A generic test used to extract the CNF pod's terminationGracePeriod.
-Result Type|normative
-Intrusive|false
-Modifications Persist After Test|false
-Runtime Binaries Required|`grep`, `cut`
-
-### http://test-network-function.com/tests/deployments
-Property|Description
----|---
-Version|v1.0.0
-Description|A generic test used to read namespace's deployments
-Result Type|normative
+Description|Polls the state of the OpenShift cluster nodes using "oc get nodes -o json".
+Result Type|
 Intrusive|false
 Modifications Persist After Test|false
 Runtime Binaries Required|`oc`
 
-### http://test-network-function.com/tests/nodemcname
+### http://test-network-function.com/tests/nodeport
 Property|Description
 ---|---
 Version|v1.0.0
-Description|A generic test used to get a node's current mc
+Description|A generic test used to test services of CNF pod's namespace.
 Result Type|normative
 Intrusive|false
 Modifications Persist After Test|false
@@ -239,40 +188,50 @@ Property|Description
 ---|---
 Version|v1.0.0
 Description|A generic test used to drain node from its deployment pods
-Result Type|
-Intrusive|false
-Modifications Persist After Test|false
+Result Type|normative
+Intrusive|true
+Modifications Persist After Test|true
 Runtime Binaries Required|`jq`, `echo`
 
-### http://test-network-function.com/tests/operator
+### http://test-network-function.com/tests/owners
 Property|Description
 ---|---
 Version|v1.0.0
-Description|An operator-specific test used to exercise the behavior of a given operator.  In the current offering, we check if the operator ClusterServiceVersion (CSV) is installed properly.  A CSV is a YAML manifest created from Operator metadata that assists the Operator Lifecycle Manager (OLM) in running the Operator.
+Description|A generic test used to test pod owners
 Result Type|normative
 Intrusive|false
 Modifications Persist After Test|false
-Runtime Binaries Required|`jq`, `oc`
+Runtime Binaries Required|`cat`
 
-### http://test-network-function.com/tests/generic/cnf_fs_diff
+### http://test-network-function.com/tests/hugepages
 Property|Description
 ---|---
 Version|v1.0.0
-Description|A test used to check if there were no installation during container runtime
+Description|A generic test used to read cluster's hugepages configuration
 Result Type|normative
 Intrusive|false
 Modifications Persist After Test|false
-Runtime Binaries Required|`grep`, `cut`
+Runtime Binaries Required|`grep`, `cut`, `oc`, `grep`
 
-### http://test-network-function.com/tests/nodehugepages
+### http://test-network-function.com/tests/deploymentsnodes
 Property|Description
 ---|---
 Version|v1.0.0
-Description|A generic test used to verify a node's hugepages configuration
+Description|A generic test used to read node names of pods owned by deployments in namespace
 Result Type|normative
 Intrusive|false
 Modifications Persist After Test|false
 Runtime Binaries Required|`oc`, `grep`
+
+### http://test-network-function.com/tests/node/uncordon
+Property|Description
+---|---
+Version|v1.0.0
+Description|A generic test used to uncordon a node
+Result Type|normative
+Intrusive|true
+Modifications Persist After Test|true
+Runtime Binaries Required|`oc`
 
 ### http://test-network-function.com/tests/generic/containerId
 Property|Description
@@ -284,17 +243,47 @@ Intrusive|false
 Modifications Persist After Test|false
 Runtime Binaries Required|`cat`
 
-### http://test-network-function.com/tests/nodenames
+### http://test-network-function.com/tests/nodetainted
 Property|Description
 ---|---
 Version|v1.0.0
-Description|A generic test used to get node names
+Description|A generic test used to test whether node is tainted
+Result Type|normative
+Intrusive|false
+Modifications Persist After Test|false
+Runtime Binaries Required|`oc`, `cat`, `echo`
+
+### http://test-network-function.com/tests/grubKernelCmdlineArgs
+Property|Description
+---|---
+Version|v1.0.0
+Description|A generic test used to get node's next boot kernel args
+Result Type|normative
+Intrusive|false
+Modifications Persist After Test|false
+Runtime Binaries Required|`ls`, `sort`, `head`, `cut`, `oc`
+
+### http://test-network-function.com/tests/sysctlConfigFilesList
+Property|Description
+---|---
+Version|v1.0.0
+Description|A generic test used to get node's list of sysctl config files
+Result Type|normative
+Intrusive|false
+Modifications Persist After Test|false
+Runtime Binaries Required|`cat`
+
+### http://test-network-function.com/tests/clusterrolebinding
+Property|Description
+---|---
+Version|v1.0.0
+Description|A generic test used to test ClusterRoleBindings of CNF pod's ServiceAccount.
 Result Type|normative
 Intrusive|false
 Modifications Persist After Test|false
 Runtime Binaries Required|`oc`
 
-### http://test-network-function.com/tests/nodemcname
+### http://test-network-function.com/tests/mckernelarguments
 Property|Description
 ---|---
 Version|v1.0.0
@@ -314,25 +303,55 @@ Intrusive|false
 Modifications Persist After Test|false
 Runtime Binaries Required|`cat`
 
-### http://test-network-function.com/tests/nodehugepages
+### http://test-network-function.com/tests/gracePeriod
 Property|Description
 ---|---
 Version|v1.0.0
-Description|A generic test used to verify a pod's nodeSelector and nodeAffinity configuration
+Description|A generic test used to extract the CNF pod's terminationGracePeriod.
 Result Type|normative
 Intrusive|false
 Modifications Persist After Test|false
-Runtime Binaries Required|`oc`, `grep`
+Runtime Binaries Required|`grep`, `cut`
 
-### http://test-network-function.com/tests/deploymentsnodes
+### http://test-network-function.com/tests/readRemoteFile
 Property|Description
 ---|---
 Version|v1.0.0
-Description|A generic test used to read node names of pods owned by deployments in namespace
+Description|A generic test used to read a specified file at a specified node
 Result Type|normative
 Intrusive|false
 Modifications Persist After Test|false
-Runtime Binaries Required|`oc`, `grep`
+Runtime Binaries Required|`echo`
+
+### http://test-network-function.com/tests/hostname
+Property|Description
+---|---
+Version|v1.0.0
+Description|A generic test used to check the hostname of a target machine/container.
+Result Type|normative
+Intrusive|false
+Modifications Persist After Test|false
+Runtime Binaries Required|`hostname`
+
+### http://test-network-function.com/tests/ping
+Property|Description
+---|---
+Version|v1.0.0
+Description|A generic test used to test ICMP connectivity from a source machine/container to a target destination.
+Result Type|normative
+Intrusive|false
+Modifications Persist After Test|false
+Runtime Binaries Required|`ping`
+
+### http://test-network-function.com/tests/container/pod
+Property|Description
+---|---
+Version|v1.0.0
+Description|A container-specific test suite used to verify various aspects of the underlying container.
+Result Type|normative
+Intrusive|false
+Modifications Persist After Test|false
+Runtime Binaries Required|`jq`, `oc`
 
 ### http://test-network-function.com/tests/serviceaccount
 Property|Description
@@ -354,35 +373,55 @@ Intrusive|false
 Modifications Persist After Test|false
 Runtime Binaries Required|`cat`, `oc`
 
-### http://test-network-function.com/tests/nodetainted
+### http://test-network-function.com/tests/operator/check-subscription
 Property|Description
 ---|---
 Version|v1.0.0
-Description|A generic test used to test whether node is tainted
-Result Type|normative
-Intrusive|false
-Modifications Persist After Test|false
-Runtime Binaries Required|`oc`, `cat`, `echo`
-
-### http://test-network-function.com/tests/hugepages
-Property|Description
----|---
-Version|v1.0.0
-Description|A generic test used to read cluster's hugepages configuration
-Result Type|normative
-Intrusive|false
-Modifications Persist After Test|false
-Runtime Binaries Required|`grep`, `cut`, `oc`, `grep`
-
-### http://test-network-function.com/tests/podnodename
-Property|Description
----|---
-Version|v1.0.0
-Description|A generic test used to get a pod's node
+Description|A test used to check the subscription of a given operator
 Result Type|normative
 Intrusive|false
 Modifications Persist After Test|false
 Runtime Binaries Required|`oc`
+
+### http://test-network-function.com/tests/generic/cnf_fs_diff
+Property|Description
+---|---
+Version|v1.0.0
+Description|A test used to check if there were no installation during container runtime
+Result Type|normative
+Intrusive|false
+Modifications Persist After Test|false
+Runtime Binaries Required|`grep`, `cut`
+
+### http://test-network-function.com/tests/nodenames
+Property|Description
+---|---
+Version|v1.0.0
+Description|A generic test used to get node names
+Result Type|normative
+Intrusive|false
+Modifications Persist After Test|false
+Runtime Binaries Required|`oc`
+
+### http://test-network-function.com/tests/deployments
+Property|Description
+---|---
+Version|v1.0.0
+Description|A generic test used to read namespace's deployments
+Result Type|normative
+Intrusive|false
+Modifications Persist After Test|false
+Runtime Binaries Required|`oc`
+
+### http://test-network-function.com/tests/nodehugepages
+Property|Description
+---|---
+Version|v1.0.0
+Description|A generic test used to verify a pod's nodeSelector and nodeAffinity configuration
+Result Type|normative
+Intrusive|false
+Modifications Persist After Test|false
+Runtime Binaries Required|`oc`, `grep`
 
 ### http://test-network-function.com/tests/ipaddr
 Property|Description
@@ -394,43 +433,53 @@ Intrusive|false
 Modifications Persist After Test|false
 Runtime Binaries Required|`ip`
 
-### http://test-network-function.com/tests/nodes
+### http://test-network-function.com/tests/operator
 Property|Description
 ---|---
 Version|v1.0.0
-Description|Polls the state of the OpenShift cluster nodes using "oc get nodes -o json".
-Result Type|
-Intrusive|false
-Modifications Persist After Test|false
-Runtime Binaries Required|`oc`
-
-### http://test-network-function.com/tests/ping
-Property|Description
----|---
-Version|v1.0.0
-Description|A generic test used to test ICMP connectivity from a source machine/container to a target destination.
+Description|An operator-specific test used to exercise the behavior of a given operator.  In the current offering, we check if the operator ClusterServiceVersion (CSV) is installed properly.  A CSV is a YAML manifest created from Operator metadata that assists the Operator Lifecycle Manager (OLM) in running the Operator.
 Result Type|normative
 Intrusive|false
 Modifications Persist After Test|false
-Runtime Binaries Required|`ping`
+Runtime Binaries Required|`jq`, `oc`
 
-### http://test-network-function.com/tests/clusterrolebinding
+### http://test-network-function.com/tests/nodehugepages
 Property|Description
 ---|---
 Version|v1.0.0
-Description|A generic test used to test ClusterRoleBindings of CNF pod's ServiceAccount.
-Result Type|normative
-Intrusive|false
-Modifications Persist After Test|false
-Runtime Binaries Required|`oc`
-
-### http://test-network-function.com/tests/nodeport
-Property|Description
----|---
-Version|v1.0.0
-Description|A generic test used to test services of CNF pod's namespace.
+Description|A generic test used to verify a node's hugepages configuration
 Result Type|normative
 Intrusive|false
 Modifications Persist After Test|false
 Runtime Binaries Required|`oc`, `grep`
+
+### http://test-network-function.com/tests/podnodename
+Property|Description
+---|---
+Version|v1.0.0
+Description|A generic test used to get a pod's node
+Result Type|normative
+Intrusive|false
+Modifications Persist After Test|false
+Runtime Binaries Required|`oc`
+
+### http://test-network-function.com/tests/nodemcname
+Property|Description
+---|---
+Version|v1.0.0
+Description|A generic test used to get a node's current mc
+Result Type|normative
+Intrusive|false
+Modifications Persist After Test|false
+Runtime Binaries Required|`oc`, `grep`
+
+### http://test-network-function.com/tests/currentKernelCmdlineArgs
+Property|Description
+---|---
+Version|v1.0.0
+Description|A generic test used to get node's /proc/cmdline
+Result Type|normative
+Intrusive|false
+Modifications Persist After Test|false
+Runtime Binaries Required|`cat`
 

--- a/pkg/tnf/handlers/checksubscription/check-subscription.json
+++ b/pkg/tnf/handlers/checksubscription/check-subscription.json
@@ -1,0 +1,27 @@
+{
+  "identifier": {
+    "url": "http://test-network-function.com/tests/operator/check-subscription",
+    "version": "v1.0.0"
+  },
+  "description": "This test checks the subscription for a given operator, verifying that the operator was installed using OLM.",
+  "testResult": 0,
+  "testTimeout": 10000000000,
+  "reelFirstStep": {
+    "execute": "oc get subscription {{.SUBSCRIPTION_NAME}} -n {{.SUBSCRIPTION_NAMESPACE}} -o json | jq -r '.metadata.name'\n",
+    "expect": [
+      "(?m)Error from server.*",
+      "{{.SUBSCRIPTION_NAME}}"
+    ],
+    "timeout": 10000000000
+  },
+  "resultContexts": [
+    {
+      "pattern": "(?m)Error from server.*",
+      "defaultResult": 2
+    },
+    {
+      "pattern": "{{.SUBSCRIPTION_NAME}}",
+      "defaultResult": 1
+    }
+  ]
+}

--- a/pkg/tnf/handlers/checksubscription/checksubscription_test.go
+++ b/pkg/tnf/handlers/checksubscription/checksubscription_test.go
@@ -1,0 +1,136 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package checksubscription_test
+
+import (
+	"fmt"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/test-network-function/pkg/tnf"
+	"github.com/test-network-function/test-network-function/pkg/tnf/handlers/generic"
+	"github.com/test-network-function/test-network-function/pkg/tnf/identifier"
+	"github.com/test-network-function/test-network-function/pkg/tnf/reel"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+const (
+	testTimeoutDuration = time.Second * 10
+)
+
+var (
+	genericTestSchemaFile     = path.Join("schemas", "generic-test.schema.json")
+	checkSubFilename          = "check-subscription.json"
+	expectedFailPattern       = "(?m)Error from server.*"
+	expectedPassPattern       = testSubscriptionName
+	pathRelativeToRoot        = path.Join("..", "..", "..", "..")
+	pathToTestSchemaFile      = path.Join(pathRelativeToRoot, genericTestSchemaFile)
+	testSubscriptionName      = "testSubName123"
+	testSubscriptionNamespace = "testSubNamespace123"
+)
+
+func createTest() (*tnf.Tester, []reel.Handler, *gojsonschema.Result, error) {
+	values := make(map[string]interface{})
+	values["SUBSCRIPTION_NAME"] = testSubscriptionName
+	values["SUBSCRIPTION_NAMESPACE"] = testSubscriptionNamespace
+	return generic.NewGenericFromMap(checkSubFilename, pathToTestSchemaFile, values)
+}
+
+func TestNodes_Args(t *testing.T) {
+	test, handlers, jsonParseResult, err := createTest()
+
+	assert.Nil(t, err)
+	assert.True(t, jsonParseResult.Valid())
+	assert.NotNil(t, handlers)
+
+	assert.Nil(t, (*test).Args())
+}
+
+func TestNodes_GetIdentifier(t *testing.T) {
+	test, handlers, jsonParseResult, err := createTest()
+
+	assert.Nil(t, err)
+	assert.True(t, jsonParseResult.Valid())
+	assert.NotNil(t, handlers)
+
+	assert.Equal(t, identifier.CheckSubscriptionURLIdentifier, (*test).GetIdentifier())
+}
+
+func TestNodes_ReelFirst(t *testing.T) {
+	_, handlers, jsonParseResult, err := createTest()
+
+	assert.Nil(t, err)
+	assert.True(t, jsonParseResult.Valid())
+	assert.NotNil(t, handlers)
+
+	assert.Equal(t, 1, len(handlers))
+	handler := handlers[0]
+	step := handler.ReelFirst()
+	expectedReelFirstExecute := fmt.Sprintf("oc get subscription %s -n %s -o json | jq -r '.metadata.name'\n", testSubscriptionName, testSubscriptionNamespace)
+	assert.Equal(t, expectedReelFirstExecute, step.Execute)
+	assert.Contains(t, step.Expect, expectedPassPattern, expectedFailPattern)
+	assert.Equal(t, testTimeoutDuration, step.Timeout)
+}
+
+func TestNodes_ReelEOF(t *testing.T) {
+	_, handlers, jsonParseResult, err := createTest()
+
+	assert.Nil(t, err)
+	assert.True(t, jsonParseResult.Valid())
+	assert.NotNil(t, handlers)
+
+	assert.Equal(t, 1, len(handlers))
+	handler := handlers[0]
+	// just ensure there isn't a panic
+	handler.ReelEOF()
+}
+
+func TestNodes_ReelTimeout(t *testing.T) {
+	_, handlers, jsonParseResult, err := createTest()
+
+	assert.Nil(t, err)
+	assert.True(t, jsonParseResult.Valid())
+	assert.NotNil(t, handlers)
+
+	assert.Equal(t, 1, len(handlers))
+	handler := handlers[0]
+	assert.Nil(t, handler.ReelTimeout())
+}
+
+// Also tests GetNodes() and Result()
+func TestNodes_ReelMatch(t *testing.T) {
+	tester, handlers, jsonParseResult, err := createTest()
+
+	assert.Nil(t, err)
+	assert.True(t, jsonParseResult.Valid())
+	assert.NotNil(t, handlers)
+
+	assert.Equal(t, 1, len(handlers))
+	handler := handlers[0]
+
+	// Positive Test
+	step := handler.ReelMatch(expectedPassPattern, "", testSubscriptionName)
+	assert.Nil(t, step)
+	assert.Equal(t, tnf.SUCCESS, (*tester).Result())
+
+	// Negative Test
+	step = handler.ReelMatch(expectedFailPattern, "", "Error from server")
+	assert.Nil(t, step)
+	assert.Equal(t, tnf.FAILURE, (*tester).Result())
+}

--- a/pkg/tnf/handlers/checksubscription/doc.go
+++ b/pkg/tnf/handlers/checksubscription/doc.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2021 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+// Package checksubscription provides a Test that checks the subscription for a given operator.  This verifies that the
+// operator was installed using OLM.
+package checksubscription

--- a/pkg/tnf/identifier/identifiers.go
+++ b/pkg/tnf/identifier/identifiers.go
@@ -50,6 +50,7 @@ const (
 	sysctlConfigFilesListIdentifierURL    = "http://test-network-function.com/tests/sysctlConfigFilesList"
 	readRemoteFileIdentifierURL           = "http://test-network-function.com/tests/readRemoteFile"
 	uncordonNodeIdentifierURL             = "http://test-network-function.com/tests/node/uncordon"
+	checkSubscriptionIdentifierURL        = "http://test-network-function.com/tests/operator/check-subscription"
 
 	versionOne = "v1.0.0"
 )
@@ -489,6 +490,18 @@ var Catalog = map[string]TestCatalogEntry{
 			dependencies.OcBinaryName,
 		},
 	},
+	checkSubscriptionIdentifierURL: {
+		Identifier:  CheckSubscriptionURLIdentifier,
+		Description: "A test used to check the subscription of a given operator",
+		Type:        Normative,
+		IntrusionSettings: IntrusionSettings{
+			ModifiesSystem:           false,
+			ModificationIsPersistent: false,
+		},
+		BinaryDependencies: []string{
+			dependencies.OcBinaryName,
+		},
+	},
 }
 
 // HostnameIdentifier is the Identifier used to represent the generic hostname test case.
@@ -674,5 +687,11 @@ var ReadRemoteFileURLIdentifier = Identifier{
 // UncordonNodeURLIdentifier is the Identifier used to represent a test that uncordons a node.
 var UncordonNodeURLIdentifier = Identifier{
 	URL:             uncordonNodeIdentifierURL,
+	SemanticVersion: versionOne,
+}
+
+// CheckSubscriptionURLIdentifier is the Identifier used to represent a test that checks the subscription of an operator.
+var CheckSubscriptionURLIdentifier = Identifier{
+	URL:             checkSubscriptionIdentifierURL,
 	SemanticVersion: versionOne,
 }

--- a/pkg/tnf/testcases/base.go
+++ b/pkg/tnf/testcases/base.go
@@ -151,25 +151,25 @@ var OperatorTestTemplateFileMap = map[string]string{
 type RegExType string
 
 const (
-	// AllowEmpty - Allows the result to match empty string
+	// AllowEmpty Allows the result to match empty string
 	AllowEmpty RegExType = "ALLOW_EMPTY"
-	// AllowAll - Allows the result to match non empty string
+	// AllowAll Allows the result to match non empty string
 	AllowAll RegExType = "allowAll"
-	// EmptyNullFalse - Allows the result to match either empty,null or false string
+	// EmptyNullFalse Allows the result to match either empty,null or false string
 	EmptyNullFalse RegExType = "EMPTY_NULL_FALSE"
-	// NullFalse - Allows the result to match either null or false string
+	// NullFalse Allows the result to match either null or false string
 	NullFalse RegExType = "NULL_FALSE"
-	// True - Allows the result to match `true` string
+	// True Allows the result to match `true` string
 	True RegExType = "TRUE"
-	// Null - Allows the result to match `null` string
+	// Null Allows the result to match `null` string
 	Null RegExType = "NULL"
-	// Zero - Allows the result to match 0 number
+	// Zero Allows the result to match 0 number
 	Zero RegExType = "ZERO"
-	// NonZero - Allows the result to match non 0 number
+	// NonZero Allows the result to match non 0 number
 	NonZero RegExType = "NON_ZERO"
-	// Error - Allows the result to match error string
+	// Error Allows the result to match error string
 	Error RegExType = "ERROR"
-	// Digit - Allows the result to match any number
+	// Digit Allows the result to match any number
 	Digit RegExType = "DIGIT"
 )
 

--- a/pkg/tnf/testcases/base_test.go
+++ b/pkg/tnf/testcases/base_test.go
@@ -135,13 +135,12 @@ func TestBaseTestCase_CNFExpectedStatusFn(t *testing.T) {
 func TestConfiguredTest_Operator_RenderTestCaseSpec(t *testing.T) {
 	var c = testcases.ConfiguredTest{}
 	c.Name = "OPERATOR_STATUS"
-	c.Tests = []string{"CSV_INSTALLED", "SUBSCRIPTION_INSTALLED", "CSV_SCC"}
+	c.Tests = []string{"CSV_INSTALLED", "CSV_SCC"}
 	b, err := c.RenderTestCaseSpec(testcases.Operator, testcases.OperatorStatus)
 	assert.Nil(t, err)
 	assert.NotNil(t, b)
 	assert.Equal(t, "CSV_INSTALLED", b.TestCase[0].Name)
-	assert.Equal(t, "SUBSCRIPTION_INSTALLED", b.TestCase[1].Name)
-	assert.Equal(t, "CSV_SCC", b.TestCase[2].Name)
+	assert.Equal(t, "CSV_SCC", b.TestCase[1].Name)
 
 	c.Name = "PRIVILEGED_POD"
 	c.Tests = []string{"HOST_NETWORK_CHECK"}

--- a/pkg/tnf/testcases/data/operator/operator.go
+++ b/pkg/tnf/testcases/data/operator/operator.go
@@ -30,16 +30,6 @@ var OperatorJSON = string(`{
       ]
     },
     {
-      "name": "SUBSCRIPTION_INSTALLED",
-      "skiptest": true,
-      "command": "oc get subscription %s -n %s -ojson | jq -r '.spec.name'",
-      "action": "allow",
-      "resulttype": "string",
-      "expectedstatus": [
-        "etcd"
-      ]
-    },
-    {
       "name": "CSV_SCC",
       "skiptest": true,
       "command": "oc get csv %s -n %s -o json | jq -r 'if .spec.install.spec.clusterPermissions == null then null else . end ` +

--- a/pkg/tnf/testcases/files/operator/operatorstatus.yml
+++ b/pkg/tnf/testcases/files/operator/operatorstatus.yml
@@ -7,14 +7,6 @@ testcase:
     expectedType: "string"
     expectedstatus:
       - "Succeeded"
-  - name: "SUBSCRIPTION_INSTALLED"
-    skiptest: false
-    command: "oc get subscription %s -n %s -ojson | jq -r '.spec.name'"
-    action: "allow"
-    resulttype: "string"
-    expectedType: "string"
-    expectedstatus:
-      - "etcd"
   - name: "CSV_SCC"
     skiptest: false
     command: "oc get csv %s -n %s -o json | jq -r 'if .spec.install.spec.clusterPermissions == null then null else . end | if . == null then \"EMPTY\" else .spec.install.spec.clusterPermissions[].rules[].resourceNames end | if length == 0 then \"EMPTY\" else . end'"

--- a/test-network-function/identifiers/identifiers.go
+++ b/test-network-function/identifiers/identifiers.go
@@ -107,6 +107,11 @@ var (
 		Url:     formTestURL(operatorSuite, "operator-is-certified"),
 		Version: versionOne,
 	}
+	// TestOperatorIsInstalledViaOLMIdentifier tests that an Operator is installed via OLM.
+	TestOperatorIsInstalledViaOLMIdentifier = claim.Identifier{
+		Url:     formTestURL(operatorSuite, "operator-is-installed-via-olm"),
+		Version: versionOne,
+	}
 	// TestPodNodeSelectorAndAffinityBestPractices is the test ensuring nodeSelector and nodeAffinity are not used by a
 	// Pod.
 	TestPodNodeSelectorAndAffinityBestPractices = claim.Identifier{
@@ -281,6 +286,14 @@ the same hacks.'`),
 			`tests whether CNF Operators have passed the Red Hat Operator Certification Program (OCP).`),
 	},
 
+	TestOperatorIsInstalledViaOLMIdentifier: {
+		Identifier:  TestOperatorIsInstalledViaOLMIdentifier,
+		Type:        normativeResult,
+		Remediation: `Ensure that your Operator is installed via OLM.`,
+		Description: formDescription(TestOperatorIsInstalledViaOLMIdentifier,
+			`tests whether a CNF Operator is installed via OLM.`),
+	},
+
 	TestPodNodeSelectorAndAffinityBestPractices: {
 		Identifier: TestPodNodeSelectorAndAffinityBestPractices,
 		Type:       informativeResult,
@@ -308,16 +321,6 @@ ClusterRoleBindings, if possible.`,
 		Remediation: `Deploy the CNF using DaemonSet or ReplicaSet.`,
 		Description: formDescription(TestPodDeploymentBestPracticesIdentifier,
 			`tests that CNF Pod(s) are deployed as part of either DaemonSet(s) or a ReplicaSet(s).`),
-	},
-
-	TestPodRecreationIdentifier: {
-		Identifier: TestPodRecreationIdentifier,
-		Type:       normativeResult,
-		Remediation: `Ensure that CNF Pod(s) utilize a configuration that supports High Availability.  Additionally, ensure that there are
-available Nodes in the OpenShift cluster that can be utilized in the event that a host Node fails.`,
-		Description: `tests that a CNF is configured to support High Availability.  First, this test cordons and drains a Node that hosts
-the CNF Pod.  Next, the test ensures that OpenShift can re-instantiate the Pod on another Node, and that the actual
-replica count matches the desired replica count.`,
 	},
 
 	TestPodRoleBindingsBestPracticesIdentifier: {

--- a/test-network-function/operator/suite.go
+++ b/test-network-function/operator/suite.go
@@ -18,8 +18,11 @@ package operator
 
 import (
 	"fmt"
+	"path"
 	"strings"
 	"time"
+
+	"github.com/test-network-function/test-network-function/pkg/tnf/handlers/generic"
 
 	"github.com/test-network-function/test-network-function/test-network-function/identifiers"
 	"github.com/test-network-function/test-network-function/test-network-function/results"
@@ -53,6 +56,21 @@ var (
 	defaultTimeout = time.Duration(defaultTimeoutSeconds) * time.Second
 	context        *interactive.Context
 	err            error
+
+	// checkSubscriptionTestPath is the file location of the uncordon.json test case relative to the project root.
+	checkSubscriptionTestPath = path.Join("pkg", "tnf", "handlers", "checksubscription", "check-subscription.json")
+
+	// pathRelativeToRoot is used to calculate relative filepaths for the `test-network-function` executable entrypoint.
+	pathRelativeToRoot = path.Join("..")
+
+	// relativeNodesTestPath is the relative path to the nodes.json test case.
+	relativeNodesTestPath = path.Join(pathRelativeToRoot, checkSubscriptionTestPath)
+
+	// relativeSchemaPath is the relative path to the generic-test.schema.json JSON schema.
+	relativeSchemaPath = path.Join(pathRelativeToRoot, schemaPath)
+
+	// schemaPath is the path to the generic-test.schema.json JSON schema relative to the project root.
+	schemaPath = path.Join("schemas", "generic-test.schema.json")
 )
 
 var _ = ginkgo.Describe(testSpecName, func() {
@@ -71,8 +89,46 @@ var _ = ginkgo.Describe(testSpecName, func() {
 		ginkgo.Context("Runs test on operators", func() {
 			itRunsTestsOnOperator()
 		})
+		testOperatorsAreInstalledViaOLM()
 	}
 })
+
+// testOperatorsAreInstalledViaOLM ensures all configured operators have a proper OLM subscription.
+func testOperatorsAreInstalledViaOLM() {
+	_, operatorsInTest := getConfig()
+	for _, operatorInTest := range operatorsInTest {
+		ginkgo.Context("an operator is installed", func() {
+			ginkgo.When("subscriptions are polled", func() {
+				ginkgo.It(fmt.Sprintf("%s in namespace %s Should have a valid subscription", operatorInTest.SubscriptionName, operatorInTest.Namespace), func() {
+					defer results.RecordResult(identifiers.TestOperatorIsInstalledViaOLMIdentifier)
+					testOperatorIsInstalledViaOLM(operatorInTest.SubscriptionName, operatorInTest.Namespace)
+				})
+			})
+		})
+	}
+}
+
+// testOperatorIsInstalledViaOLM tests that an operator is installed via OLM.
+func testOperatorIsInstalledViaOLM(subscriptionName, subscriptionNamespace string) {
+	values := make(map[string]interface{})
+	values["SUBSCRIPTION_NAME"] = subscriptionName
+	values["SUBSCRIPTION_NAMESPACE"] = subscriptionNamespace
+	test, handlers, result, err := generic.NewGenericFromMap(relativeNodesTestPath, relativeSchemaPath, values)
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(result).ToNot(gomega.BeNil())
+	gomega.Expect(result.Valid()).To(gomega.BeTrue())
+	gomega.Expect(handlers).ToNot(gomega.BeNil())
+	gomega.Expect(len(handlers)).To(gomega.Equal(1))
+	gomega.Expect(test).ToNot(gomega.BeNil())
+
+	tester, err := tnf.NewTest(context.GetExpecter(), *test, handlers, context.GetErrorChannel())
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(tester).ToNot(gomega.BeNil())
+
+	testResult, err := tester.Run()
+	gomega.Expect(err).To(gomega.BeNil())
+	gomega.Expect(testResult).To(gomega.Equal(tnf.SUCCESS))
+}
 
 func getConfig() ([]configsections.CertifiedOperatorRequestInfo, []configsections.Operator) {
 	conf := config.GetConfigInstance()


### PR DESCRIPTION
Hitherto, the operator subscription is tested against a non-templated
test case input file.  The existing framework does not have the innate
ability to render the file contents based on a template, making it an
unsuitable candidate for a test which requires specific, templated output.
Since test cases ultimately are fed into the tool using a Go string,
templating this code seemed like the wrong solution.

This change rips the "CHECK_SUBSCRIPTION" test out of the existing operator
testing framework.  That framework is difficult to maneuver, and this change
aligns with utilizing the JSON test framework instead.  Why was this approach
chosen?  Here are some of the reasons:

1) Standardize on JSON Test Template framework.
2) Disaggregate the reference to the "operator-is-installed-via-olm" from the
   existing "operator-best-practices" test case.  This provides further
   granularity so that this test case can pass/fail independently of the other
   operator best practices.
3) Unit testing is crafted towards the specific use case, instead of testing
   pseudo-template rendering.  In this case, we can use actual input/output
   that the Handler would encounter.
4) The code is easier to read.

Finally, CATALOG.md is regenerated to reflect the changes.  This involved
eliminating the "pod-is-recreated" test case from the catalog, which was
removed in an earlier PR.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>