### PR TITLE
Fix test identifiers for list-cni-plugins and nodes-hw-info TCs (was under generic instead of diagnostic)

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -30,6 +30,22 @@ Version|v1.0.0
 Description|http://test-network-function.com/testcases/diagnostic/extract-node-information extracts informational information about the cluster.
 Result Type|informative
 Suggested Remediation|
+### http://test-network-function.com/testcases/diagnostic/list-cni-plugins
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/diagnostic/list-cni-plugins lists CNI plugins
+Result Type|normative
+Suggested Remediation|
+### http://test-network-function.com/testcases/diagnostic/nodes-hw-info
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/diagnostic/nodes-hw-info list nodes HW info
+Result Type|normative
+Suggested Remediation|
 ### http://test-network-function.com/testcases/generic/hugepages-not-manually-manipulated
 
 Property|Description
@@ -46,14 +62,6 @@ Version|v1.0.0
 Description|http://test-network-function.com/testcases/generic/icmpv4-connectivity checks that each CNF Container is able to communicate via ICMPv4 on the Default OpenShift network.  This test case requires the Deployment of the [CNF Certification Test Partner](https://github.com/test-network-function/cnf-certification-test-partner/blob/main/test-partner/partner.yaml). The test ensures that all CNF containers respond to ICMPv4 requests from the Partner Pod, and vice-versa. 
 Result Type|normative
 Suggested Remediation|Ensure that the CNF is able to communicate via the Default OpenShift network.  In some rare cases, CNFs may require routing table changes in order to communicate over the Default network.  In other cases, if the Container base image does not provide the "ip" or "ping" binaries, this test may not be applicable.  For instructions on how to exclude a particular container from ICMPv4 connectivity tests, consult: [README.md](https://github.com/test-network-function/test-network-function#issue-161-some-containers-under-test-do-nto-contain-ping-or-ip-binary-utilities).
-### http://test-network-function.com/testcases/generic/list-cni-plugins
-
-Property|Description
----|---
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/generic/list-cni-plugins lists CNI plugins
-Result Type|normative
-Suggested Remediation|
 ### http://test-network-function.com/testcases/generic/namespace-best-practices
 
 Property|Description
@@ -62,14 +70,6 @@ Version|v1.0.0
 Description|http://test-network-function.com/testcases/generic/namespace-best-practices tests that CNFs utilize a CNF-specific namespace, and that the namespace does not start with "openshift-". OpenShift may host a variety of CNF and software applications, and multi-tenancy of such applications is supported through namespaces.  As such, each CNF should be a good neighbor, and utilize an appropriate, unique namespace.
 Result Type|normative
 Suggested Remediation|Ensure that your CNF utilizes a CNF-specific namespace.  Additionally, the CNF-specific namespace should not start with "openshift-", except in rare cases.
-### http://test-network-function.com/testcases/generic/nodes-hw-info
-
-Property|Description
----|---
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/generic/nodes-hw-info list nodes HW info
-Result Type|normative
-Suggested Remediation|
 ### http://test-network-function.com/testcases/generic/non-default-grace-period
 
 Property|Description

--- a/test-network-function/identifiers/identifiers.go
+++ b/test-network-function/identifiers/identifiers.go
@@ -72,6 +72,16 @@ var (
 		Url:     formTestURL(diagnosticSuite, "extract-node-information"),
 		Version: versionOne,
 	}
+	// TestListCniPluginsIdentifier retrieves list of CNI plugins.
+	TestListCniPluginsIdentifier = claim.Identifier{
+		Url:     formTestURL(diagnosticSuite, "list-cni-plugins"),
+		Version: versionOne,
+	}
+	// TestNodesHwInfoIdentifier retrieves nodes HW info.
+	TestNodesHwInfoIdentifier = claim.Identifier{
+		Url:     formTestURL(diagnosticSuite, "nodes-hw-info"),
+		Version: versionOne,
+	}
 	// TestHugepagesNotManuallyManipulated represents the test identifier testing hugepages have not been manipulated.
 	TestHugepagesNotManuallyManipulated = claim.Identifier{
 		Url:     formGenericTestURL("hugepages-not-manually-manipulated"),
@@ -163,16 +173,6 @@ var (
 	// TestUnalteredStartupBootParamsIdentifier ensures startup boot params are not altered.
 	TestUnalteredStartupBootParamsIdentifier = claim.Identifier{
 		Url:     formGenericTestURL("unaltered-startup-boot-params"),
-		Version: versionOne,
-	}
-	// TestListCniPluginsIdentifier retrieves list of CNI plugins.
-	TestListCniPluginsIdentifier = claim.Identifier{
-		Url:     formGenericTestURL("list-cni-plugins"),
-		Version: versionOne,
-	}
-	// TestNodesHwInfoIdentifier retrieves nodes HW info.
-	TestNodesHwInfoIdentifier = claim.Identifier{
-		Url:     formGenericTestURL("nodes-hw-info"),
 		Version: versionOne,
 	}
 	// TestLoggingIdentifier ensures stderr/stdout are used


### PR DESCRIPTION
Improvement in the categorization of the test cases: "list-cni-plugins" and "nodes-hw-info" moved from "generic" TS to "diagnostic".
This commit changes the identifiers.go file only, but the automatically rebuilt file catalog.mds needs to be commited as well to reflect the change.