### PR TITLE
Fixed NON_ZERO regex

### DIFF
--- a/pkg/tnf/testcases/base.go
+++ b/pkg/tnf/testcases/base.go
@@ -166,7 +166,7 @@ const (
 	// Zero Allows the result to match 0 number
 	Zero RegExType = "ZERO"
 	// NonZero Allows the result to match non 0 number
-	NonZero RegExType = "NON_ZERO"
+	NonZeroNumber RegExType = "NON_ZERO_NUMBER"
 	// Error Allows the result to match error string
 	Error RegExType = "ERROR"
 	// Digit Allows the result to match any number
@@ -182,7 +182,7 @@ var outRegExp = map[RegExType]string{
 	True:           `^\b(true)\b$`,
 	Null:           `^\b(null)\b$`,
 	Zero:           `0`,
-	NonZero:        `^(0*([1-9]\d*)|null)$`,
+	NonZeroNumber:  `^(0*([1-9]\d*)|null)$`,
 	Error:          "error",
 	Digit:          `\d`,
 }

--- a/pkg/tnf/testcases/base.go
+++ b/pkg/tnf/testcases/base.go
@@ -182,7 +182,7 @@ var outRegExp = map[RegExType]string{
 	True:           `^\b(true)\b$`,
 	Null:           `^\b(null)\b$`,
 	Zero:           `0`,
-	NonZero:        `^(\d([^0]+)|null)$`,
+	NonZero:        `^(0*([1-9]\d*)|null)$`,
 	Error:          "error",
 	Digit:          `\d`,
 }

--- a/pkg/tnf/testcases/base.go
+++ b/pkg/tnf/testcases/base.go
@@ -165,7 +165,7 @@ const (
 	Null RegExType = "NULL"
 	// Zero Allows the result to match 0 number
 	Zero RegExType = "ZERO"
-	// NonZero Allows the result to match non 0 number
+	// NonZeroNumber Allows the result to match non 0 number
 	NonZeroNumber RegExType = "NON_ZERO_NUMBER"
 	// Error Allows the result to match error string
 	Error RegExType = "ERROR"

--- a/pkg/tnf/testcases/data/cnf/privilegedpod.go
+++ b/pkg/tnf/testcases/data/cnf/privilegedpod.go
@@ -89,7 +89,7 @@ var PrivilegedPodJSON = string(`{
       "resulttype": "string",
       "action": "allow",
       "expectedstatus": [
-        "NON_ZERO"
+        "NON_ZERO_NUMBER"
       ]
     },
     {


### PR DESCRIPTION
The ROOT_CHECK of the access-control TS failed with some valid uid
combinations like:

- 1000640000 --> reported by Ramón Pérez <raperez@redhat.com>
- 1001       --> classic uid used linux/kuberentes examples.
- 001