### PR TITLE
Fix for HostPath test 

### DIFF
--- a/pkg/tnf/testcases/data/cnf/privilegedpod.go
+++ b/pkg/tnf/testcases/data/cnf/privilegedpod.go
@@ -43,10 +43,10 @@ var PrivilegedPodJSON = string(`{
       "name": "HOST_PATH_CHECK",
       "skiptest": true,
        "loop": 0,
-      "command": "oc get pod  %s  -n %s -o json  | jq -r '.spec.hostpath.path'",
+      "command": "oc get pods %s -n %s -o go-template='{{ range .spec.volumes}}{{.hostPath.path}}{{end}}'",
       "action": "allow",
       "expectedstatus": [
-        "NULL_FALSE"
+        "^(<no value>)*$"
       ]
     },
     {


### PR DESCRIPTION
Using Go template to to look for hostpath volumes. If <no value> is reported one or more times, the test passes. Otherwise the test fails.