### PR TITLE
Show git commit ID before running the TS.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,11 +100,13 @@ RUN yum remove -y gcc git wget && \
 # TODO run as non-root
 FROM scratch
 ARG TNF_PARTNER_DIR=/usr/tnf-partner
+ARG TNF_VERSION
 COPY --from=build / /
 ENV TNF_CONFIGURATION_PATH=/usr/tnf/config/tnf_config.yml
 ENV KUBECONFIG=/usr/tnf/kubeconfig/config
 ENV TNF_PARTNER_SRC_DIR=$TNF_PARTNER_DIR/src
 ENV PATH="/usr/local/oc/bin:${PATH}"
+ENV TNF_VERSION=$TNF_VERSION
 WORKDIR /usr/tnf
 ENV SHELL=/bin/bash
 CMD ["./run-cnf-suites.sh", "-o", "claim", "-f", "diagnostic"]

--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -68,6 +68,8 @@ else
 	make -C $TNF_PARTNER_SRC_DIR install-partner-pods
 fi
 
+TNF_VERSION=${TNF_VERSION:-"unknown"}
+echo "TNF version: $TNF_VERSION"
 echo "Running with focus '$FOCUS'"
 echo "Running with skip  '$SKIP'"
 echo "Report will be output to '$OUTPUT_LOC'"


### PR DESCRIPTION
Dockerfile updated to set a new envar inside the container image
pointing to the TNF repo commit id/sha/tag that was checked out
to be included in the image. This id/tag will be displayed
by the run-cnf-suites.sh before launching the test suites.

In case the script run-cnf-suites.sh is launched locally, outside of the
tnf container, it will show "unknown".