### PR TITLE
add default timeout to send command in spawned shell

### DIFF
--- a/cmd/generic/cmd/jsontest.go
+++ b/cmd/generic/cmd/jsontest.go
@@ -251,7 +251,7 @@ func runOcCmd(_ *cobra.Command, args []string) {
 	// oc shell creation.
 	goExpectSpawner := interactive.NewGoExpectSpawner()
 	var spawnContext interactive.Spawner = goExpectSpawner
-	oc, ch, err := interactive.SpawnOc(&spawnContext, pod, container, namespace, (*tester).Timeout(), interactive.Verbose(true))
+	oc, ch, err := interactive.SpawnOc(&spawnContext, pod, container, namespace, (*tester).Timeout(), interactive.Verbose(true), interactive.SendTimeout((*tester).Timeout()))
 	if err != nil {
 		fatalError("could not create the oc expecter", err, testExpecterCreationFailedExitCode)
 	}

--- a/cmd/generic/cmd/jsontest.go
+++ b/cmd/generic/cmd/jsontest.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 
 	expect "github.com/google/goexpect"
 	"github.com/google/goterm/term"
@@ -224,7 +225,7 @@ func runSSHCmd(_ *cobra.Command, args []string) {
 	// SSH shell creation.
 	goExpectSpawner := interactive.NewGoExpectSpawner()
 	var spawnContext interactive.Spawner = goExpectSpawner
-	context, err := interactive.SpawnSSH(&spawnContext, user, host, (*tester).Timeout(), interactive.Verbose(true))
+	context, err := interactive.SpawnSSH(&spawnContext, user, host, (*tester).Timeout(), interactive.Verbose(true), interactive.SendTimeout(10*time.Second))
 	if err != nil {
 		fatalError("could not create the ssh expecter", err, testExpecterCreationFailedExitCode)
 	}

--- a/cmd/generic/cmd/jsontest.go
+++ b/cmd/generic/cmd/jsontest.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"time"
 
 	expect "github.com/google/goexpect"
 	"github.com/google/goterm/term"
@@ -225,7 +224,7 @@ func runSSHCmd(_ *cobra.Command, args []string) {
 	// SSH shell creation.
 	goExpectSpawner := interactive.NewGoExpectSpawner()
 	var spawnContext interactive.Spawner = goExpectSpawner
-	context, err := interactive.SpawnSSH(&spawnContext, user, host, (*tester).Timeout(), interactive.Verbose(true), interactive.SendTimeout(10*time.Second))
+	context, err := interactive.SpawnSSH(&spawnContext, user, host, (*tester).Timeout(), interactive.Verbose(true), interactive.SendTimeout((*tester).Timeout()))
 	if err != nil {
 		fatalError("could not create the ssh expecter", err, testExpecterCreationFailedExitCode)
 	}

--- a/cmd/ssh/main.go
+++ b/cmd/ssh/main.go
@@ -52,7 +52,7 @@ func parseArgs() (*interactive.Context, string, time.Duration, error) {
 	timeoutDuration := time.Duration(*timeout) * time.Second
 	goExpectSpawner := interactive.NewGoExpectSpawner()
 	var spawner interactive.Spawner = goExpectSpawner
-	context, err := interactive.SpawnSSH(&spawner, args[0], args[1], timeoutDuration, interactive.Verbose(true))
+	context, err := interactive.SpawnSSH(&spawner, args[0], args[1], timeoutDuration, interactive.Verbose(true), interactive.SendTimeout(10*time.Second))
 	return context, args[2], timeoutDuration, err
 }
 

--- a/cmd/ssh/main.go
+++ b/cmd/ssh/main.go
@@ -52,7 +52,7 @@ func parseArgs() (*interactive.Context, string, time.Duration, error) {
 	timeoutDuration := time.Duration(*timeout) * time.Second
 	goExpectSpawner := interactive.NewGoExpectSpawner()
 	var spawner interactive.Spawner = goExpectSpawner
-	context, err := interactive.SpawnSSH(&spawner, args[0], args[1], timeoutDuration, interactive.Verbose(true), interactive.SendTimeout(10*time.Second))
+	context, err := interactive.SpawnSSH(&spawner, args[0], args[1], timeoutDuration, interactive.Verbose(true), interactive.SendTimeout(timeoutDuration))
 	return context, args[2], timeoutDuration, err
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -198,7 +198,7 @@ func (env *TestEnvironment) doAutodiscover() {
 func (env *TestEnvironment) createContainers(containerDefinitions []configsections.ContainerConfig) map[configsections.ContainerIdentifier]*Container {
 	createdContainers := make(map[configsections.ContainerIdentifier]*Container)
 	for _, c := range containerDefinitions {
-		oc := getOcSession(c.PodName, c.ContainerName, c.Namespace, DefaultTimeout, interactive.Verbose(true))
+		oc := getOcSession(c.PodName, c.ContainerName, c.Namespace, DefaultTimeout, interactive.Verbose(true), interactive.SendTimeout(DefaultTimeout))
 		var defaultIPAddress = "UNKNOWN"
 		if _, ok := env.ContainersToExcludeFromConnectivityTests[c.ContainerIdentifier]; !ok {
 			defaultIPAddress = getContainerDefaultNetworkIPAddress(oc, c.DefaultNetworkDevice)

--- a/pkg/tnf/interactive/spawner.go
+++ b/pkg/tnf/interactive/spawner.go
@@ -146,6 +146,11 @@ type GoExpectSpawner struct {
 	verboseWriterIsSet bool
 	// verboseWriter is an alternate destination for verbose logs.
 	verboseWriter io.Writer
+
+	// sendTimeoutIsSet tracks whether the Send command timeout is set.
+	sendTimeoutIsSet bool
+	// sendTimeout is the timeout of send command
+	sendTimeout time.Duration
 }
 
 // Option is a function pointer to enable lightweight optionals for GoExpectSpawner.
@@ -188,6 +193,16 @@ func VerboseWriter(verboseWriter io.Writer) Option {
 		prev := g.verboseWriter
 		g.verboseWriter = verboseWriter
 		return VerboseWriter(prev)
+	}
+}
+
+// SendTimeout sets the timeout of send command
+func SendTimeout(timeout time.Duration) Option {
+	return func(g *GoExpectSpawner) Option {
+		g.sendTimeoutIsSet = true
+		prev := g.sendTimeout
+		g.sendTimeout = timeout
+		return SendTimeout(prev)
 	}
 }
 

--- a/pkg/tnf/interactive/spawner.go
+++ b/pkg/tnf/interactive/spawner.go
@@ -243,6 +243,10 @@ func (g *GoExpectSpawner) GetGoExpectOptions() []expect.Option {
 		opts = append(opts, expect.VerboseWriter(g.verboseWriter))
 	}
 
+	if g.sendTimeoutIsSet {
+		opts = append(opts, expect.SendTimeout(g.sendTimeout))
+	}
+
 	return opts
 }
 

--- a/test-network-function/common/env.go
+++ b/test-network-function/common/env.go
@@ -44,7 +44,7 @@ var DefaultTimeout = time.Duration(defaultTimeoutSeconds) * time.Second
 
 // GetContext spawns a new shell session and returns its context
 func GetContext() *interactive.Context {
-	context, err := interactive.SpawnShell(interactive.CreateGoExpectSpawner(), DefaultTimeout, interactive.Verbose(true), interactive.SendTimeout(DefaultTimeout*time.Second))
+	context, err := interactive.SpawnShell(interactive.CreateGoExpectSpawner(), DefaultTimeout, interactive.Verbose(true), interactive.SendTimeout(DefaultTimeout))
 	gomega.Expect(err).To(gomega.BeNil())
 	gomega.Expect(context).ToNot(gomega.BeNil())
 	gomega.Expect(context.GetExpecter()).ToNot(gomega.BeNil())

--- a/test-network-function/common/env.go
+++ b/test-network-function/common/env.go
@@ -44,7 +44,7 @@ var DefaultTimeout = time.Duration(defaultTimeoutSeconds) * time.Second
 
 // GetContext spawns a new shell session and returns its context
 func GetContext() *interactive.Context {
-	context, err := interactive.SpawnShell(interactive.CreateGoExpectSpawner(), DefaultTimeout, interactive.Verbose(true))
+	context, err := interactive.SpawnShell(interactive.CreateGoExpectSpawner(), DefaultTimeout, interactive.Verbose(true), interactive.SendTimeout(DefaultTimeout*time.Second))
 	gomega.Expect(err).To(gomega.BeNil())
 	gomega.Expect(context).ToNot(gomega.BeNil())
 	gomega.Expect(context.GetExpecter()).ToNot(gomega.BeNil())


### PR DESCRIPTION
This aims to add timeout to "Send" function in goexpect library, by default, the library does not use any timeout. 
By looking in the code of the goexpect,  it's printing the log after "sending" the command, so if there's any issue in the "send" we will not see the log. This seems like the issue we were seeing this morning where the process hangs. 