### PR TITLE
Spawner Check function implementation.

### DIFF
--- a/pkg/tnf/interactive/spawner.go
+++ b/pkg/tnf/interactive/spawner.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	expect "github.com/google/goexpect"
@@ -60,6 +61,12 @@ type SpawnFunc interface {
 
 	// Wait consult exec.Cmd.Wait
 	Wait() error
+
+	// IsRunning returns true if the shell hasn't exited yet.
+	IsRunning() bool
+
+	// Args returns the command and arguments used to spawn the shell.
+	Args() []string
 }
 
 // ExecSpawnFunc is an implementation of SpawnFunc using exec.Cmd.
@@ -78,6 +85,16 @@ func (e *ExecSpawnFunc) Command(name string, arg ...string) *SpawnFunc {
 // Wait wraps exec.Cmd.Wait.
 func (e *ExecSpawnFunc) Wait() error {
 	return e.cmd.Wait()
+}
+
+// IsRunning returns true if e.Cmd.ProcessState is nil, false otherwise
+func (e *ExecSpawnFunc) IsRunning() bool {
+	return e.cmd.ProcessState == nil
+}
+
+// Args wraps e.Cmd.Args
+func (e *ExecSpawnFunc) Args() []string {
+	return e.cmd.Args
 }
 
 // Start wraps exec.Cmd.Start.
@@ -296,7 +313,13 @@ func (g *GoExpectSpawner) spawnGeneric(spawnFunc *SpawnFunc, stdinPipe io.WriteC
 		Close: func() error {
 			return nil
 		},
-		Check: func() bool { return true },
+		Check: func() bool {
+			if !(*spawnFunc).IsRunning() {
+				log.Error("Unable to spawn shell. Cmd: " + strings.Join((*spawnFunc).Args(), " "))
+				return false
+			}
+			return true
+		},
 	}, timeout, opts...)
 	// coax out the typing
 	var expecter expect.Expecter = gexpecter


### PR DESCRIPTION
Calls to (*expecter).Send() will fail if the shell process has already
exited.