### PR TITLE
TNF handler generation tool improvements.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -606,11 +606,14 @@ oc get pod %s -n %s -o go-template='{{len .spec.containers}}{{"\n"}}'
 
 ## Adding new handler
 
-To facilitate adding new handlers, the developers can leverage existing infrastructure to generate repetitive code.
-As an example, to generate handler with name Xyz, the command generate handler Xyz can be used(we need to run this command 
-in the folder "cmd/tnf/" and we run the command directly here).
+To facilitate adding new handlers, the "tnf" utility has been created to help developers to avoid generating repetitive code.
+As an example, to generate a new handler with named MyHandler, the command "tnf generate handler MyHandler" can be used.
 The generated code has a template and creates the necessary headers.
-The result is folder "new handler" located in /pkg/tnf/handlers/"new handler" that includes 3 files by handler template.
+The result is folder "myhandler" located in /pkg/tnf/handlers/myhandler that includes 3 files by handler template.
+The command relays on golang templates located in ./pkg/tnf/handlers/handler_template, so in case the "tnf" utility is executed outside the test-network-function root folder, the user can export the environment variable TNF_HANDLERS_SRC pointing to an existing "handlers" relative/absolute folder path.
+```shell-script
+ export TNF_HANDLERS_SRC=other/path/pkg/tnf/handlers
+```
 
 ## Adding information to claim file
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -606,7 +606,7 @@ oc get pod %s -n %s -o go-template='{{len .spec.containers}}{{"\n"}}'
 
 ## Adding new handler
 
-To facilitate adding new handlers, the "tnf" utility has been created to help developers to avoid writing repetitive code. The tnf tool [source code is here](https://github.com/test-network-function/test-network-function/tree/main/cmd/tnf) and can be built with the following command:
+To facilitate adding new handlers, the "tnf" utility has been created to help developers to avoid writing repetitive code. The tnf tool [source code is here](cmd/tnf) and can be built with the following command:
 ```shell-script
 make build-tnf-tool
 ```
@@ -618,7 +618,7 @@ To generate a new handler named MyHandler, use the options "generate handler" as
 
 The generated code has a template and creates the necessary headers.
 The result is folder "myhandler" located in /pkg/tnf/handlers/myhandler that includes 3 files by handler template.
-The command relays on golang templates located in ./pkg/tnf/handlers/handler_template, so in case the "tnf" utility is executed outside the test-network-function root folder, the user can export the environment variable TNF_HANDLERS_SRC pointing to an existing "handlers" relative/absolute folder path.
+The command relays on golang templates located in [pkg/tnf/handlers/handler_template](pkg/tnf/handlers/handler_template), so in case the "tnf" utility is executed outside the test-network-function root folder, the user can export the environment variable TNF_HANDLERS_SRC pointing to an existing "handlers" relative/absolute folder path.
 ```shell-script
  export TNF_HANDLERS_SRC=other/path/pkg/tnf/handlers
 ```

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -606,8 +606,16 @@ oc get pod %s -n %s -o go-template='{{len .spec.containers}}{{"\n"}}'
 
 ## Adding new handler
 
-To facilitate adding new handlers, the "tnf" utility has been created to help developers to avoid generating repetitive code.
-As an example, to generate a new handler with named MyHandler, the command "tnf generate handler MyHandler" can be used.
+To facilitate adding new handlers, the "tnf" utility has been created to help developers to avoid writing repetitive code. The tnf tool [source code is here](https://github.com/test-network-function/test-network-function/tree/main/cmd/tnf) and can be built with the following command:
+```shell-script
+make build-tnf-tool
+```
+
+To generate a new handler named MyHandler, use the options "generate handler" as in the next example:
+```shell-script
+./tnf generate handler MyHandler
+```
+
 The generated code has a template and creates the necessary headers.
 The result is folder "myhandler" located in /pkg/tnf/handlers/myhandler that includes 3 files by handler template.
 The command relays on golang templates located in ./pkg/tnf/handlers/handler_template, so in case the "tnf" utility is executed outside the test-network-function root folder, the user can export the environment variable TNF_HANDLERS_SRC pointing to an existing "handlers" relative/absolute folder path.

--- a/cmd/tnf/main.go
+++ b/cmd/tnf/main.go
@@ -68,25 +68,22 @@ func getHandlersDirectory() (string, error) {
 }
 
 func generateHandlerFilesFromTemplates(handlerTemplatesDirectory, newHandlerDirectory string, myhandler myHandler) error {
-	templateFilePath := path.Join(handlerTemplatesDirectory, "doc.tmpl")
-	renderedFileName := docFileName
-
-	if err := createfile(templateFilePath, renderedFileName, myhandler, newHandlerDirectory); err != nil {
-		return err
+	type fileToRender struct {
+		templatePath     string
+		renderedFileName string
 	}
 
-	templateFilePath = path.Join(handlerTemplatesDirectory, "handler_test.tmpl")
-	renderedFileName = myhandler.LowerHandlername + "_test.go"
-
-	if err := createfile(templateFilePath, renderedFileName, myhandler, newHandlerDirectory); err != nil {
-		return err
+	filesToRender := []fileToRender{
+		{templatePath: path.Join(handlerTemplatesDirectory, "doc.tmpl"), renderedFileName: docFileName},
+		{templatePath: path.Join(handlerTemplatesDirectory, "handler_test.tmpl"), renderedFileName: myhandler.LowerHandlername + "_test.go"},
+		{templatePath: path.Join(handlerTemplatesDirectory, "handler.tmpl"), renderedFileName: myhandler.LowerHandlername + ".go"},
 	}
 
-	templateFilePath = path.Join(handlerTemplatesDirectory, "handler.tmpl")
-	renderedFileName = myhandler.LowerHandlername + ".go"
-
-	if err := createfile(templateFilePath, renderedFileName, myhandler, newHandlerDirectory); err != nil {
-		return err
+	for _, renderedFileName := range filesToRender {
+		if err := createfile(renderedFileName.templatePath, renderedFileName.renderedFileName, myhandler, newHandlerDirectory); err != nil {
+			log.Errorf("Unable to create rendered file %s on %s", renderedFileName, newHandlerDirectory)
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/tnf/handlers/handler_template/handler.tmpl
+++ b/pkg/tnf/handlers/handler_template/handler.tmpl
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/test-network-function/test-network-function/pkg/tnf"
+	"github.com/test-network-function/test-network-function/pkg/tnf/identifier"
 	"github.com/test-network-function/test-network-function/pkg/tnf/reel"
 )
 
@@ -51,8 +52,9 @@ func (h *{{ .UpperHandlername }}) Args() []string {
 }
 
 // GetIdentifier returns the tnf.Test specific identifier.
-func (h *{{ .UpperHandlername }}) GetIdentifier() {
+func (h *{{ .UpperHandlername }}) GetIdentifier() identifier.Identifier {
 	// Return the {{ .UpperHandlername }} handler identifier.
+	return identifier.Identifier{}
 }
 
 // Timeout returns the timeout for the test.

--- a/pkg/tnf/handlers/handler_template/handler.tmpl
+++ b/pkg/tnf/handlers/handler_template/handler.tmpl
@@ -23,7 +23,7 @@ import (
 	"github.com/test-network-function/test-network-function/pkg/tnf/reel"
 )
 
-// {{ .UpperHandlername }} provides a {{ .UpperHandlername }} test implemented using command line tool {{ .UpperHandlername }}.
+// {{ .UpperHandlername }} is the reel handler struct.
 type {{ .UpperHandlername }} struct {
 	result  int
 	timeout time.Duration
@@ -35,17 +35,27 @@ const (
 // adding special variables
 )
 
-// Args function
+// New{{ .UpperHandlername }} returns a new {{ .UpperHandlername }} handler struct.
+// TODO: Add needed parameters to this function and initialize the handler properly.
+func New{{ .UpperHandlername }}(timeout time.Duration) *{{ .UpperHandlername }} {
+	return &{{ .UpperHandlername }}{
+		timeout: timeout,
+		result:  tnf.ERROR,
+		args:    []string{}, // TODO: Add proper execution command.
+	}
+}
+
+// Args returns the initial execution/send command strings for handler {{ .UpperHandlername }}.
 func (h *{{ .UpperHandlername }}) Args() []string {
 	return h.args
 }
 
 // GetIdentifier returns the tnf.Test specific identifier.
 func (h *{{ .UpperHandlername }}) GetIdentifier() {
-	// Create identifier {{ .UpperHandlername }}Identifier.	
+	// Return the {{ .UpperHandlername }} handler identifier.
 }
 
-// Timeout return the timeout for the test.
+// Timeout returns the timeout for the test.
 func (h *{{ .UpperHandlername }}) Timeout() time.Duration {
 	return h.timeout
 }
@@ -55,28 +65,28 @@ func (h *{{ .UpperHandlername }}) Result() int {
 	return h.result
 }
 
-// ReelFirst returns a step which expects an {{ .UpperHandlername }} summary for the given device.
+// ReelFirst returns a reel step for handler {{ .UpperHandlername }}.
 func (h *{{ .UpperHandlername }}) ReelFirst() *reel.Step {
 	return &reel.Step{
-		Expect: []string{""}, // TODO : pass the list of possible regex in here
+		Expect:  []string{}, // TODO : pass the list of possible regex in here
 		Timeout: h.timeout,
 	}
 }
 
 // ReelMatch parses the {{ .UpperHandlername }} output and set the test result on match.
 func (h *{{ .UpperHandlername }}) ReelMatch(_, _, match string) *reel.Step {
+	// TODO : add the matching logic here and return an appropriate tnf result.
 	h.result = tnf.ERROR
 	return nil
-	// TODO : add the matching logic in here
 }
 
-// ReelTimeout does nothing, {{ .UpperHandlername }} requires no explicit intervention for a timeout.
+// ReelTimeout function for {{ .UpperHandlername }} will be called by the reel FSM when a expect timeout occurs.
 func (h *{{ .UpperHandlername }}) ReelTimeout() *reel.Step {
+	// TODO : Add code here in case a timeout reaction is needed.
 	return nil
-	// TODO : fill the stub
 }
 
-// ReelEOF does nothing, {{ .UpperHandlername }} requires no explicit intervention for EOF.
+// ReelEOF function for {{ .UpperHandlername }} will be called by the reel FSM when a EOF is read.
 func (h *{{ .UpperHandlername }}) ReelEOF() {
-	// TODO : fill the stub
+	// TODO : Add code here in case a EOF reaction is needed.
 }

--- a/pkg/tnf/handlers/handler_template/handler_test.tmpl
+++ b/pkg/tnf/handlers/handler_template/handler_test.tmpl
@@ -24,37 +24,37 @@ const (
 // adding special variable
 )
 
-// {{ .UpperHandlername }}_Args()
+// Test_New{{ .UpperHandlername }} is the unit test for New{{ .UpperHandlername }}().
+func Test_New{{ .UpperHandlername }}(t *testing.T) {
+	// Todo: Write test.
+}
+
+// Test_{{ .UpperHandlername }}_Args is the unit test for {{ .UpperHandlername }}_Args().
 func Test{{ .UpperHandlername }}_Args(t *testing.T) {
-	// Todo: Write test for function {{ .UpperHandlername }}_Args.
+	// Todo: Write test.
 }
 
-// {{ .UpperHandlername }}_GetIdentifier
+// Test_{{ .UpperHandlername }}_GetIdentifier is the unit test for {{ .UpperHandlername }}_GetIdentifier().
 func Test{{ .UpperHandlername }}_GetIdentifier(t *testing.T) {
-	// Todo : write test for function {{ .UpperHandlername }}_GetIdentifier.
+	// Todo: Write test.
 }
 
-// {{ .UpperHandlername }}_ReelFirst
+// Test_{{ .UpperHandlername }}_ReelFirst is the unit test for {{ .UpperHandlername }}_ReelFirst().
 func Test{{ .UpperHandlername }}_ReelFirst(t *testing.T) {
-	// Todo : write test for function {{ .UpperHandlername }}_ReelFirst.
+	// Todo: Write test.
 }
 
-// {{ .UpperHandlername }}_ReelEof
-func Test{{ .UpperHandlername }}_ReelEof(t *testing.T) {
-	// Todo : write test for function {{ .UpperHandlername }}_ReelEof.
+// Test_{{ .UpperHandlername }}_ReelEOF is the unit test for {{ .UpperHandlername }}_ReelEOF().
+func Test{{ .UpperHandlername }}_ReelEOF(t *testing.T) {
+	// Todo: Write test.
 }
 
-// {{ .UpperHandlername }}_ReelTimeout
+// Test_{{ .UpperHandlername }}_ReelTimeout is the unit test for {{ .UpperHandlername }}}_ReelTimeout().
 func Test{{ .UpperHandlername }}_ReelTimeout(t *testing.T) {
-	// Todo : write test for function {{ .UpperHandlername }}_ReelTimeout.
+	// Todo: Write test.
 }
 
-// {{ .UpperHandlername }}_ReelMatch
+// Test_{{ .UpperHandlername }}_ReelMatch is the unit test for {{ .UpperHandlername }}_ReelMatch().
 func Test{{ .UpperHandlername }}_ReelMatch(t *testing.T) {
-	// Todo : write test for function {{ .UpperHandlername }}_ReelMatch.
-}
-
-// New{{ .UpperHandlername }}
-func TestNew{{ .UpperHandlername }}(t *testing.T) {
-	// Todo : write test for function TestNew{{ .UpperHandlername }}.
+	// Todo: Write test.
 }


### PR DESCRIPTION
Fixed so the tnf tool can be launched anywhere. If no envar
TNF_HANDLER_SRC detected, the tool assumes you're in the repo root
folder so the handlers folder should be at ./pkg/tnf/handlers.

+ Minor refactors.