### PR TITLE
Add unit tests wrapping exec commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@
 # Tasks provide shortcuts to common operations that occur frequently during
 # development. This includes running configured linters and executing unit tests
 
+GO_PACKAGES=$(shell go list ./... | grep -v vendor)
+
 .PHONY:	build \
 	mocks \
 	clean \
@@ -33,7 +35,8 @@
 	run-container-tests \
 	clean-mocks \
 	update-deps \
-	install-tools
+	install-tools \
+	vet
 
 # Get default value of $GOBIN if not explicitly set
 ifeq (,$(shell go env GOBIN))
@@ -146,3 +149,6 @@ install-tools:
 	go install github.com/onsi/ginkgo/ginkgo
 	go install github.com/onsi/gomega/...
 	go install github.com/golang/mock/mockgen
+
+vet:
+	go vet ${GO_PACKAGES}

--- a/pkg/config/autodiscover/csv_info.go
+++ b/pkg/config/autodiscover/csv_info.go
@@ -17,7 +17,6 @@
 package autodiscover
 
 import (
-	"encoding/json"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
@@ -56,7 +55,7 @@ func (csv *CSVResource) GetAnnotationValue(annotationKey string, v interface{}) 
 		return fmt.Errorf("failed to find annotation '%s' on CSV '%s/%s'", annotationKey, csv.Metadata.Namespace, csv.Metadata.Name)
 	}
 	val := csv.Metadata.Annotations[annotationKey]
-	err = json.Unmarshal([]byte(val), v)
+	err = jsonUnmarshal([]byte(val), v)
 	if err != nil {
 		return csv.annotationUnmarshalError(annotationKey, err)
 	}
@@ -73,7 +72,7 @@ func (csv *CSVResource) annotationUnmarshalError(annotationKey string, err error
 func GetCSVsByLabel(labelName, labelValue, namespace string) (*CSVList, error) {
 	cmd := makeGetCommand(resourceTypeCSV, buildLabelQuery(configsections.Label{Prefix: tnfLabelPrefix, Name: labelName, Value: labelValue}), namespace)
 
-	out, err := cmd.Output()
+	out, err := execCommandOutput(cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +80,7 @@ func GetCSVsByLabel(labelName, labelValue, namespace string) (*CSVList, error) {
 	log.Debug("Command: ", cmd)
 	log.Debug(string(out))
 	var csvList CSVList
-	err = json.Unmarshal(out, &csvList)
+	err = jsonUnmarshal(out, &csvList)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/autodiscover/csv_info_test.go
+++ b/pkg/config/autodiscover/csv_info_test.go
@@ -17,7 +17,6 @@
 package autodiscover
 
 import (
-	"encoding/json"
 	"log"
 	"os"
 	"path"
@@ -39,7 +38,7 @@ func loadCSVResource(filePath string) (csv CSVResource) {
 	if err != nil {
 		log.Fatalf("error (%s) loading CSVResource %s for testing", err, filePath)
 	}
-	err = json.Unmarshal(contents, &csv)
+	err = jsonUnmarshal(contents, &csv)
 	if err != nil {
 		log.Fatalf("error (%s) loading CSVResource %s for testing", err, filePath)
 	}

--- a/pkg/config/autodiscover/deployment_info.go
+++ b/pkg/config/autodiscover/deployment_info.go
@@ -28,6 +28,13 @@ const (
 	resourceTypeDeployment = "deployment"
 )
 
+var (
+	jsonUnmarshal     = json.Unmarshal
+	execCommandOutput = func(cmd *exec.Cmd) ([]byte, error) {
+		return cmd.Output()
+	}
+)
+
 // DeploymentList holds the data from an `oc get deployments -o json` command
 type DeploymentList struct {
 	Items []DeploymentResource `json:"items"`
@@ -75,13 +82,13 @@ func GetTargetDeploymentsByNamespace(namespace string, targetLabel configsection
 
 	cmd := exec.Command("bash", "-c", ocCmd)
 
-	out, err := cmd.Output()
+	out, err := execCommandOutput(cmd)
 	if err != nil {
 		return nil, err
 	}
 
 	var deploymentList DeploymentList
-	err = json.Unmarshal(out, &deploymentList.Items)
+	err = jsonUnmarshal(out, &deploymentList.Items)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/autodiscover/deployment_info_test.go
+++ b/pkg/config/autodiscover/deployment_info_test.go
@@ -18,20 +18,25 @@ package autodiscover
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"os"
+	"os/exec"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/test-network-function/pkg/config/configsections"
 )
 
 const (
 	testDeploymentFile = "testdeployment.json"
+	testJQFile         = "testdeploy.json"
 )
 
 var (
 	testDeploymentFilePath = path.Join(filePath, testDeploymentFile)
+	testJQFilePath         = path.Join(filePath, testJQFile)
 )
 
 func loadDeployment(filePath string) (deployment DeploymentResource) {
@@ -39,7 +44,7 @@ func loadDeployment(filePath string) (deployment DeploymentResource) {
 	if err != nil {
 		log.Fatalf("error (%s) loading DeploymentResource %s for testing", err, filePath)
 	}
-	err = json.Unmarshal(contents, &deployment)
+	err = jsonUnmarshal(contents, &deployment)
 	if err != nil {
 		log.Fatalf("error (%s) unmarshalling DeploymentResource %s for testing", err, filePath)
 	}
@@ -56,4 +61,78 @@ func TestPodGetAnnotationValue1(t *testing.T) {
 	labels := deployment.GetLabels()
 	assert.Equal(t, 1, len(labels))
 	assert.Equal(t, "test", labels["app"])
+}
+
+//nolint:funlen
+func TestGetTargetDeploymentByNamespace(t *testing.T) {
+	testCases := []struct {
+		badExec          bool
+		execErr          error
+		badJSONUnmarshal bool
+		jsonErr          error
+	}{
+		{ // no failures
+			badExec:          false,
+			badJSONUnmarshal: false,
+		},
+		{ // failure to exec
+			badExec:          true,
+			execErr:          errors.New("this is an error"),
+			badJSONUnmarshal: false,
+			jsonErr:          nil,
+		},
+		{ // failure to jsonUnmarshal
+			badExec:          false,
+			execErr:          nil,
+			badJSONUnmarshal: true,
+			jsonErr:          errors.New("this is an error"),
+		},
+	}
+
+	origExecFunc := execCommandOutput
+
+	for _, tc := range testCases {
+		// Setup the mock functions
+		if tc.badExec {
+			execCommandOutput = func(cmd *exec.Cmd) ([]byte, error) {
+				return nil, tc.execErr
+			}
+		} else {
+			execCommandOutput = func(cmd *exec.Cmd) ([]byte, error) {
+				contents, err := os.ReadFile(testJQFilePath)
+				assert.Nil(t, err)
+				return contents, nil
+			}
+		}
+		if tc.badJSONUnmarshal {
+			jsonUnmarshal = func(data []byte, v interface{}) error {
+				return tc.jsonErr
+			}
+		} else {
+			// use the "real" function
+			jsonUnmarshal = json.Unmarshal
+		}
+
+		// Run the function and compare the list output
+		list, err := GetTargetDeploymentsByNamespace("test", configsections.Label{
+			Prefix: "prefix1",
+			Name:   "name1",
+			Value:  "value1",
+		})
+		if !tc.badExec && !tc.badJSONUnmarshal {
+			assert.NotNil(t, list)
+			assert.Equal(t, "my-test1", list.Items[0].Metadata.Name)
+		}
+
+		// Assert the errors and cleanup
+		if tc.badExec {
+			assert.NotNil(t, err)
+			execCommandOutput = origExecFunc
+		}
+
+		if tc.badJSONUnmarshal {
+			assert.NotNil(t, err)
+			jsonUnmarshal = json.Unmarshal
+		}
+	}
 }

--- a/pkg/config/autodiscover/pod_info_test.go
+++ b/pkg/config/autodiscover/pod_info_test.go
@@ -17,7 +17,6 @@
 package autodiscover
 
 import (
-	"encoding/json"
 	"log"
 	"os"
 	"path"
@@ -42,7 +41,7 @@ func loadPodResource(filePath string) (pod PodResource) {
 	if err != nil {
 		log.Fatalf("error (%s) loading PodResource %s for testing", err, filePath)
 	}
-	err = json.Unmarshal(contents, &pod)
+	err = jsonUnmarshal(contents, &pod)
 	if err != nil {
 		log.Fatalf("error (%s) loading PodResource %s for testing", err, filePath)
 	}

--- a/pkg/config/autodiscover/testdata/testdeploy.json
+++ b/pkg/config/autodiscover/testdata/testdeploy.json
@@ -1,0 +1,184 @@
+[{
+	"apiVersion": "apps/v1",
+	"kind": "Deployment",
+	"metadata": {
+		"annotations": {
+			"deployment.kubernetes.io/revision": "1"
+		},
+		"creationTimestamp": "2021-10-11T15:22:41Z",
+		"generation": 1,
+		"labels": {
+			"app": "my-test1"
+		},
+		"managedFields": [{
+				"apiVersion": "apps/v1",
+				"fieldsType": "FieldsV1",
+				"fieldsV1": {
+					"f:metadata": {
+						"f:labels": {
+							".": {},
+							"f:app": {}
+						}
+					},
+					"f:spec": {
+						"f:progressDeadlineSeconds": {},
+						"f:replicas": {},
+						"f:revisionHistoryLimit": {},
+						"f:selector": {},
+						"f:strategy": {
+							"f:rollingUpdate": {
+								".": {},
+								"f:maxSurge": {},
+								"f:maxUnavailable": {}
+							},
+							"f:type": {}
+						},
+						"f:template": {
+							"f:metadata": {
+								"f:labels": {
+									".": {},
+									"f:app": {},
+									"f:prefix1/name1": {}
+								}
+							},
+							"f:spec": {
+								"f:containers": {
+									"k:{\"name\":\"nginx\"}": {
+										".": {},
+										"f:image": {},
+										"f:imagePullPolicy": {},
+										"f:name": {},
+										"f:resources": {},
+										"f:terminationMessagePath": {},
+										"f:terminationMessagePolicy": {}
+									}
+								},
+								"f:dnsPolicy": {},
+								"f:restartPolicy": {},
+								"f:schedulerName": {},
+								"f:securityContext": {},
+								"f:terminationGracePeriodSeconds": {}
+							}
+						}
+					}
+				},
+				"manager": "oc",
+				"operation": "Update",
+				"time": "2021-10-11T15:22:41Z"
+			},
+			{
+				"apiVersion": "apps/v1",
+				"fieldsType": "FieldsV1",
+				"fieldsV1": {
+					"f:metadata": {
+						"f:annotations": {
+							".": {},
+							"f:deployment.kubernetes.io/revision": {}
+						}
+					},
+					"f:status": {
+						"f:availableReplicas": {},
+						"f:conditions": {
+							".": {},
+							"k:{\"type\":\"Available\"}": {
+								".": {},
+								"f:lastTransitionTime": {},
+								"f:lastUpdateTime": {},
+								"f:message": {},
+								"f:reason": {},
+								"f:status": {},
+								"f:type": {}
+							},
+							"k:{\"type\":\"Progressing\"}": {
+								".": {},
+								"f:lastTransitionTime": {},
+								"f:lastUpdateTime": {},
+								"f:message": {},
+								"f:reason": {},
+								"f:status": {},
+								"f:type": {}
+							}
+						},
+						"f:observedGeneration": {},
+						"f:readyReplicas": {},
+						"f:replicas": {},
+						"f:updatedReplicas": {}
+					}
+				},
+				"manager": "kube-controller-manager",
+				"operation": "Update",
+				"subresource": "status",
+				"time": "2021-10-11T15:22:44Z"
+			}
+		],
+		"name": "my-test1",
+		"namespace": "test",
+		"resourceVersion": "15460",
+		"uid": "bc6b1ac5-ee45-47a1-bc41-1258e0cf30a3"
+	},
+	"spec": {
+		"progressDeadlineSeconds": 600,
+		"replicas": 1,
+		"revisionHistoryLimit": 10,
+		"selector": {
+			"matchLabels": {
+				"app": "my-test1"
+			}
+		},
+		"strategy": {
+			"rollingUpdate": {
+				"maxSurge": "25%",
+				"maxUnavailable": "25%"
+			},
+			"type": "RollingUpdate"
+		},
+		"template": {
+			"metadata": {
+				"creationTimestamp": null,
+				"labels": {
+					"app": "my-test1",
+					"prefix1/name1": "value1"
+				}
+			},
+			"spec": {
+				"containers": [{
+					"image": "nginx",
+					"imagePullPolicy": "Always",
+					"name": "nginx",
+					"resources": {},
+					"terminationMessagePath": "/dev/termination-log",
+					"terminationMessagePolicy": "File"
+				}],
+				"dnsPolicy": "ClusterFirst",
+				"restartPolicy": "Always",
+				"schedulerName": "default-scheduler",
+				"securityContext": {},
+				"terminationGracePeriodSeconds": 30
+			}
+		}
+	},
+	"status": {
+		"availableReplicas": 1,
+		"conditions": [{
+				"lastTransitionTime": "2021-10-11T15:22:44Z",
+				"lastUpdateTime": "2021-10-11T15:22:44Z",
+				"message": "Deployment has minimum availability.",
+				"reason": "MinimumReplicasAvailable",
+				"status": "True",
+				"type": "Available"
+			},
+			{
+				"lastTransitionTime": "2021-10-11T15:22:41Z",
+				"lastUpdateTime": "2021-10-11T15:22:44Z",
+				"message": "ReplicaSet \"my-test1-57dbcf59f6\" has successfully progressed.",
+				"reason": "NewReplicaSetAvailable",
+				"status": "True",
+				"type": "Progressing"
+			}
+		],
+		"observedGeneration": 1,
+		"readyReplicas": 1,
+		"replicas": 1,
+		"updatedReplicas": 1
+	}
+}]


### PR DESCRIPTION
Changes:
- Added `vet` path to the Makefile.
- Added unit tests wrapping the `GetTargetDeploymentByNamespace` function that uses both the `exec.Command.Output` and the `json.Unmarshal` functions.  This only affects the `autodiscover` package but this same "example" for testing those functions could be used in other packages in the code.