### PR TITLE
Switch to go install

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Rebuild mocks
-        run: go get github.com/golang/mock/mockgen && make mocks
+        run: go install github.com/golang/mock/mockgen && make mocks
 
       - name: Run Tests
         run: make test

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Rebuild mocks
-        run: go get github.com/golang/mock/mockgen && make mocks
+        run: go install github.com/golang/mock/mockgen && make mocks
 
       # TODO: golangci-lint team recommends using a GitHub Action to perform golangci-lint responsibilities.  However
       # there does not appear to be a way to honor our existing .golangci.yml.  For now, mimic developer behavior.
@@ -66,7 +66,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Rebuild mocks
-        run: go get github.com/golang/mock/mockgen && make mocks
+        run: go install github.com/golang/mock/mockgen && make mocks
 
       - name: Run Tests
         run: make test
@@ -90,10 +90,10 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Execute `make mocks`
-        run: go get github.com/golang/mock/mockgen && make mocks
+        run: go install github.com/golang/mock/mockgen && make mocks
 
       - name: Install ginkgo
-        run: go get -u github.com/onsi/ginkgo/ginkgo
+        run: go install github.com/onsi/ginkgo/ginkgo
 
       - name: Execute `make build`
         run: make build

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,6 @@ update-deps:
 
 # Install build tools and other required software.
 install-tools:
-	go get github.com/onsi/ginkgo/ginkgo
-	go get github.com/onsi/gomega/...
-	go get github.com/golang/mock/mockgen
+	go install github.com/onsi/ginkgo/ginkgo
+	go install github.com/onsi/gomega/...
+	go install github.com/golang/mock/mockgen


### PR DESCRIPTION
As part of the switch to Go 1.16 [here](#366), `go get` to install external deps is deprecated.

Error message when using `go get`:
```
go get github.com/onsi/ginkgo/ginkgo
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```