### PR TITLE
Invoke auto discovery for the diagnostic suite

### DIFF
--- a/test-network-function/diagnostic/suite.go
+++ b/test-network-function/diagnostic/suite.go
@@ -67,6 +67,12 @@ var (
 
 var _ = ginkgo.Describe(common.DiagnosticTestKey, func() {
 	if testcases.IsInFocus(ginkgoconfig.GinkgoConfig.FocusStrings, common.DiagnosticTestKey) {
+		env := config.GetTestEnvironment()
+		ginkgo.BeforeEach(func() {
+			env.LoadAndRefresh()
+			gomega.Expect(len(env.PodsUnderTest)).ToNot(gomega.Equal(0))
+			gomega.Expect(len(env.ContainersUnderTest)).ToNot(gomega.Equal(0))
+		})
 		ginkgo.When("a cluster is set up and installed with OpenShift", func() {
 
 			ginkgo.By("should report OCP version")


### PR DESCRIPTION
This suite used to be special as it does not rely on auto discovery. Recent change to extend the scope of auto discovery to nodes made this suite dependent on auto discovery as well.