### PR TITLE
Fix jq hostPort lookup

### DIFF
--- a/pkg/tnf/testcases/data/cnf/privilegedpod.go
+++ b/pkg/tnf/testcases/data/cnf/privilegedpod.go
@@ -33,10 +33,10 @@ var PrivilegedPodJSON = string(`{
       "name": "HOST_PORT_CHECK",
       "skiptest": true,
       "loop": 1,
-      "command": "oc get pod %s -n %s -o json  | jq -r '.spec.containers[%d].ports.hostPort'",
+      "command": "oc get pod %s -n %s -o json | jq -r '.spec.containers[%d] | select(.ports) | .ports[].hostPort'",
       "action": "allow",
       "expectedstatus": [
-        "NULL_FALSE"
+        "^(<no value>)*$"
       ]
     },
     {

--- a/pkg/tnf/testcases/files/cnf/privilegedpod.yml
+++ b/pkg/tnf/testcases/files/cnf/privilegedpod.yml
@@ -10,11 +10,11 @@ testcase:
   - name: HOST_PORT_CHECK
     skiptest: true
     loop: 0
-    command: "oc get pod  %s  -n %s -o json  | jq -r '.spec.containers[%d].ports.hostPort'"
+    command: "oc get pod %s -n %s -o json | jq -r '.spec.containers[%d] | select(.ports) | .ports[].hostPort'"
     action: allow
     expectedType: "regex"
     expectedstatus:
-      - NULL_FALSE
+      - "^(<no value>)*$"
   - name: HOST_PATH_CHECK
     skiptest: true
     loop: 0


### PR DESCRIPTION
Previously, this `jq` command was failing to find the hostPort references because `ports` is an array.

Marked WIP until I can test thoroughly.