### PR TITLE
Fix access-control HOST_PORT_CHECK tc.

### DIFF
--- a/pkg/tnf/testcases/data/cnf/privilegedpod.go
+++ b/pkg/tnf/testcases/data/cnf/privilegedpod.go
@@ -33,7 +33,7 @@ var PrivilegedPodJSON = string(`{
       "name": "HOST_PORT_CHECK",
       "skiptest": true,
       "loop": 1,
-      "command": "oc get pod %s -n %s -o json  | jq -r '.spec.containers[%d].ports[].hostPort'",
+      "command": "oc get pod %s -n %s -o json | jq -r '.spec.containers[%d] | select(.ports) | .ports[].hostPort'",
       "action": "allow",
       "expectedstatus": [
         "NULL_FALSE"

--- a/pkg/tnf/testcases/data/cnf/privilegedpod.go
+++ b/pkg/tnf/testcases/data/cnf/privilegedpod.go
@@ -33,7 +33,7 @@ var PrivilegedPodJSON = string(`{
       "name": "HOST_PORT_CHECK",
       "skiptest": true,
       "loop": 1,
-      "command": "oc get pod %s -n %s -o json  | jq -r '.spec.containers[%d].ports.hostPort'",
+      "command": "oc get pod %s -n %s -o json  | jq -r '.spec.containers[%d].ports[].hostPort'",
       "action": "allow",
       "expectedstatus": [
         "NULL_FALSE"


### PR DESCRIPTION
When containers have ports declared, the previous jq query failed
to get them with this error:
jq: error (at <stdin>:1330): Cannot index array with string "hostPort"

That's because of the query is not accessing correctly to the ports
array, so the TC would fail either its ports are hostPort or
containerPort ones.