### PR TITLE
Go 1.17.3 update

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.2
+          go-version: 1.17.3
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.2
+          go-version: 1.17.3
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.2
+          go-version: 1.17.3
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -104,7 +104,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.2
+          go-version: 1.17.3
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN yum install -y gcc git jq make wget
 
 # Install Go binary
 ENV GO_DL_URL="https://golang.org/dl"
-ENV GO_BIN_TAR="go1.17.2.linux-amd64.tar.gz"
+ENV GO_BIN_TAR="go1.17.3.linux-amd64.tar.gz"
 ENV GO_BIN_URL_x86_64=${GO_DL_URL}/${GO_BIN_TAR}
 ENV GOPATH="/root/go"
 RUN if [[ "$(uname -m)" -eq "x86_64" ]] ; then \


### PR DESCRIPTION
Go 1.17.3 is now [available](https://twitter.com/golang/status/1456314310330880004).

Includes security fixes to archive/zip and debug/macho (CVE-2021-41772, CVE-2021-41771).