### PR TITLE
Restore CRDs autodiscovery.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -274,6 +274,7 @@ func (env *TestEnvironment) doAutodiscover() {
 	env.TestOrchestrator = env.PartnerContainers[env.Config.Partner.TestOrchestratorID]
 	env.DeploymentsUnderTest = env.Config.DeploymentsUnderTest
 	env.OperatorsUnderTest = env.Config.Operators
+	env.CrdNames = autodiscover.FindTestCrdNames(env.Config.CrdFilters)
 
 	env.discoverNodes()
 	log.Infof("Test Configuration: %+v", *env)


### PR DESCRIPTION
The CRD autodiscovery was removed by mistake in this commit:
03b5d5c464d40279ab8bcb09ad20ab72014a056f (PR:
https://github.com/test-network-function/test-network-function/pull/395)