### PR TITLE
Fix for image failing to build due do gomega requiring golang 1.16 in 3.0.0

### DIFF
--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: checkout the latest for the script directory in the main branch
         run: |
-          git checkout origin/test-david -- Dockerfile
+          git checkout origin/main -- Dockerfile
           
       - name: Build the `test-network-function` image
         run: |

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -106,6 +106,10 @@ jobs:
         with:
           ref: ${{ env.TNF_VERSION }}
 
+      - name: checkout the latest for the script directory in the main branch
+        run: |
+          git checkout origin/test-david -- Dockerfile
+          
       - name: Build the `test-network-function` image
         run: |
           docker build --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ ARG GIT_PARTNER_CHECKOUT_TARGET=$TNF_PARTNER_VERSION
 # Clone the TNF source repository and checkout the target branch/tag/commit
 RUN git clone --no-single-branch --depth=1 ${TNF_SRC_URL} ${TNF_SRC_DIR}
 RUN git -C ${TNF_SRC_DIR} fetch origin ${GIT_CHECKOUT_TARGET}
+RUN git -C ${TNF_SRC_DIR} fetch origin main
 RUN git -C ${TNF_SRC_DIR} checkout ${GIT_CHECKOUT_TARGET}
+RUN git -C ${TNF_SRC_DIR} checkout origin/main -- Makefile
 
 # Clone the partner source repository and checkout the target branch/tag/commit
 RUN git clone --no-single-branch --depth=1 ${TNF_PARTNER_SRC_URL} ${TNF_PARTNER_SRC_DIR}


### PR DESCRIPTION
Fix image build in previous versions.
Seems like gomega is requiring go 1.16 now...: the build script failed in 3.0.0 when building gomega.
To resolve this issue and similar ones in the future:
- even when building older branch always checkout the latest build scripts and Makefile
- checkout the latest dockerfile
- When modifying the Makefile, github workflow, Dockerfile, consider that it will be used bu all release so it has to be backward compatible.