### PR TITLE
Add GOPROXY support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@
 # development. This includes running configured linters and executing unit tests
 
 GO_PACKAGES=$(shell go list ./... | grep -v vendor)
+GOPROXY:=https://proxy.golang.org,direct
+export
 
 .PHONY:	build \
 	mocks \


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/CNFCERT-192

Taking advantage of the `proxy.golang.org` to help us with cached dependencies.

Interesting reads:
- https://jfrog.com/blog/why-goproxy-matters-and-which-to-pick/
- https://arslan.io/2019/08/02/why-you-should-use-a-go-module-proxy/

Marking WIP for now.