### PR TITLE
Use go template for hostPort check

### DIFF
--- a/pkg/tnf/testcases/data/cnf/privilegedpod.go
+++ b/pkg/tnf/testcases/data/cnf/privilegedpod.go
@@ -33,7 +33,7 @@ var PrivilegedPodJSON = string(`{
       "name": "HOST_PORT_CHECK",
       "skiptest": true,
       "loop": 1,
-      "command": "oc get pod %s -n %s -o json | jq -r '.spec.containers[%d] | select(.ports) | .ports[].hostPort'",
+      "command": "oc get pod %s -n %s -o go-template='{{range (index .spec.containers %d).ports }}{{if .hostPort}}{{.hostPort}}{{end}}{{end}}'",
       "action": "allow",
       "expectedstatus": [
         "^(<no value>)*$"

--- a/pkg/tnf/testcases/data/cnf/privilegedpod.go
+++ b/pkg/tnf/testcases/data/cnf/privilegedpod.go
@@ -17,6 +17,7 @@
 package cnf
 
 // PrivilegedPodJSON test templates for privileged pods
+//nolint:lll
 var PrivilegedPodJSON = string(`{
   "testcase": [
     {
@@ -33,7 +34,7 @@ var PrivilegedPodJSON = string(`{
       "name": "HOST_PORT_CHECK",
       "skiptest": true,
       "loop": 1,
-      "command": "oc get pod %s -n %s -o go-template='{{range (index .spec.containers %d).ports }}{{if .hostPort}}{{.hostPort}}{{end}}{{end}}'",
+      "command": "oc get pod %s -n %s -o go-template='{{$putName := .metadata.name}}{{$cut := (index .spec.containers %d)}}{{range $cut.ports }}{{if .hostPort}}PUT {{$putName}} - CUT {{$cut.name}} has declared hostPort {{.hostPort}}{{\"\\n\"}}{{end}}{{end}}'",
       "action": "allow",
       "expectedstatus": [
         "^(<no value>)*$"

--- a/pkg/tnf/testcases/files/cnf/privilegedpod.yml
+++ b/pkg/tnf/testcases/files/cnf/privilegedpod.yml
@@ -10,7 +10,7 @@ testcase:
   - name: HOST_PORT_CHECK
     skiptest: true
     loop: 0
-    command: "oc get pod %s -n %s -o json | jq -r '.spec.containers[%d] | select(.ports) | .ports[].hostPort'"
+    command: "oc get pod %s -n %s -o go-template='{{range (index .spec.containers %d).ports }}{{if .hostPort}}{{.hostPort}}{{end}}{{end}}'"
     action: allow
     expectedType: "regex"
     expectedstatus:

--- a/pkg/tnf/testcases/files/cnf/privilegedpod.yml
+++ b/pkg/tnf/testcases/files/cnf/privilegedpod.yml
@@ -10,7 +10,7 @@ testcase:
   - name: HOST_PORT_CHECK
     skiptest: true
     loop: 0
-    command: "oc get pod %s -n %s -o go-template='{{range (index .spec.containers %d).ports }}{{if .hostPort}}{{.hostPort}}{{end}}{{end}}'"
+    command: "oc get pod %s -n %s -o go-template='{{$putName := .metadata.name}}{{$cut := (index .spec.containers %d)}}{{range $cut.ports }}{{if .hostPort}}PUT {{$putName}} - CUT {{$cut.name}} has declared hostPort {{.hostPort}}{{\"\\n\"}}{{end}}{{end}}'"
     action: allow
     expectedType: "regex"
     expectedstatus:


### PR DESCRIPTION
```
$ oc get pod busybox1 -o json | jq -r '.spec.containers[0] | select(.ports) | .ports[].hostPort'
null
```

We want to avoid the `null` so switching to go-template:
```
$ oc get pod busybox1 -o go-template='{{range (index .spec.containers 0).ports }}{{if .hostPort}}{{.hostPort}}{{end}}{{end}}'
```

Will review with @greyerof on Monday.