### PR TITLE
remove 3.0.x branch(due to failure to build), add 3.1.x branch to matrix

### DIFF
--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        branch: [3.0.x]
+        branch: [3.1.x]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'


### PR DESCRIPTION
This is to start building tnf release images on the 3.1.x branch. Also removing the 3.0.x branch from the matrix list since it no longer builds due to ginkgo 1.16 requirement (will be fixed by implementing a new branch strategy)