### PR TITLE
Fix URL for node selector identifier

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -560,7 +560,7 @@ Intrusive|false
 Modifications Persist After Test|false
 Runtime Binaries Required|`oc`
 
-### http://test-network-function.com/tests/nodehugepages
+### http://test-network-function.com/tests/nodeselector
 Property|Description
 ---|---
 Version|v1.0.0

--- a/pkg/tnf/identifier/identifiers.go
+++ b/pkg/tnf/identifier/identifiers.go
@@ -790,7 +790,7 @@ var OwnersIdentifier = Identifier{
 
 // NodeSelectorIdentifier is the Identifier used to represent the generic NodeSelector test.
 var NodeSelectorIdentifier = Identifier{
-	URL:             nodehugepagesIdentifierURL,
+	URL:             nodeselectorIdentifierURL,
 	SemanticVersion: versionOne,
 }
 


### PR DESCRIPTION
It was pointing to the nodehugepagesIdentifierURL, instead of the
nodeselector IdentifierURL.