### PR TITLE
Archive test run artifacts in GitHub Actions

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: make lint
         run: make lint
-        
+
       - name: make vet
         run: make vet
 
@@ -144,6 +144,16 @@ jobs:
 
       - name: 'Test: Run test suites'
         run: ./run-cnf-suites.sh --focus access-control lifecycle platform observablility networking affiliated-certification operator
+
+      - name: Upload smoke test results as an artifact
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: smoke-tests
+          path: |
+            test-network-function/*.xml
+            test-network-function/claim.json
+
       # Perform smoke tests using a TNF container.
 
       - name: Build the `test-network-function` image
@@ -170,7 +180,16 @@ jobs:
 
       - name: 'Test: Run generic test suite in a TNF container'
         run: ./run-tnf-container.sh ${{ env.TESTING_CMD_PARAMS }} -f access-control lifecycle platform observablility networking affiliated-certification operator
-        
+
+      - name: Upload container test results as an artifact
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: smoke-tests-container
+          path: |
+            ${{ env.TNF_OUTPUT_DIR }}/*.xml
+            ${{ env.TNF_OUTPUT_DIR }}/claim.json
+
       # Push the new unstable TNF image to Quay.io.
       - name: (if on main and upstream) Authenticate against Quay.io
         if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'test-network-function' }}


### PR DESCRIPTION
We want to store the test run artifacts for both the smoke and container
tests, so we can analyze them after a CI job.