### PR TITLE
Add static HTML page to visualize claim.json

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -153,6 +153,7 @@ jobs:
           path: |
             test-network-function/*.xml
             test-network-function/claim.json
+            script/results.html
 
       # Perform smoke tests using a TNF container.
 
@@ -189,6 +190,7 @@ jobs:
           path: |
             ${{ env.TNF_OUTPUT_DIR }}/*.xml
             ${{ env.TNF_OUTPUT_DIR }}/claim.json
+            script/results.html
 
       # Push the new unstable TNF image to Quay.io.
       - name: (if on main and upstream) Authenticate against Quay.io

--- a/script/results.html
+++ b/script/results.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset=utf-8>
+    <title>TNF claim.json parser</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+  </head>
+  <body>
+    <nav class="navbar navbar-dark bg-dark">
+        <a class="navbar-brand" href="#">Test Network Function result parser</a>
+        <form class="form-inline">
+          <div class="mb-3">
+              <label for="formFile" class="form-label text-light">Upload claim.json file</label>
+              <input class="form-control" type="file" id="formFile">
+          </div>
+        </form>
+    </nav>
+
+    <ul class="nav nav-tabs">
+      <li class="nav-item">
+        <button class="nav-link active" id="config-tab" data-bs-toggle="tab" data-bs-target="#config" type="button" role="tab" aria-controls="config" aria-selected="true">Configuration</button>
+      </li>
+      <li class="nav-item">
+        <button class="nav-link" id="metadata-tab" data-bs-toggle="tab" data-bs-target="#metadata" type="button" role="tab" aria-controls="metadata" aria-selected="false">Metadata</button>
+      </li>
+      <li class="nav-item">
+        <button class="nav-link" id="nodes-tab" data-bs-toggle="tab" data-bs-target="#nodes" type="button" role="tab" aria-controls="nodes" aria-selected="false">Nodes</button>
+      </li>
+      <li class="nav-item">
+        <button class="nav-link" id="results-tab" data-bs-toggle="tab" data-bs-target="#results" type="button" role="tab" aria-controls="results" aria-selected="false">Results</button>
+      </li>
+      <li class="nav-item">
+        <button class="nav-link" id="versions-tab" data-bs-toggle="tab" data-bs-target="#versions" type="button" role="tab" aria-controls="versions" aria-selected="false">Versions</button>
+      </li>
+    </ul>
+
+    <div class="tab-content" id="myTabContent">
+      <div class="tab-pane fade show active" id="config" role="tabpanel" aria-labelledby="config-tab">
+        <table class="table table-hover table-bordered" id="config-table">
+        </table>
+      </div>
+      <div class="tab-pane fade" id="metadata" role="tabpanel" aria-labelledby="metadata-tab">
+        <table class="table table-hover table-bordered" id="metadata-table">
+        </table>
+      </div>
+      <div class="tab-pane fade" id="nodes" role="tabpanel" aria-labelledby="nodes-tab">
+        <table class="table table-hover table-bordered" id="nodes-table">
+        </table>
+      </div>
+      <div class="tab-pane fade" id="results" role="tabpanel" aria-labelledby="results-tab">
+        <table class="table table-hover table-bordered" id="results-table">
+        </table>
+      </div>
+      <div class="tab-pane fade" id="versions" role="tabpanel" aria-labelledby="versions-tab">
+        <table class="table table-hover table-bordered" id="versions-table">
+        </table>
+      </div>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/ansi_up@5.1.0/ansi_up.js" crossorigin="anonymous"></script>
+    <!-- We should extract the javascript code to a separate file, but if we include it here we can just use a single file HTMl, which is handy -->
+    <!--    <script src="./utils.js"></script> -->
+    <script>
+        function fillVersions(input, element) {
+            $(element).empty()
+
+            text ='<thead><tr><th scope="col">Component</th><th scope="col">Version</th></tr></thead><tbody>'
+            $(text).appendTo($(element))
+
+            for (const key in input) {
+              versionstext = '<tr><td><b>' + key + '</b></td><td>' + input[key] + '</td></tr>'
+              $(versionstext).appendTo($(element))
+            }
+
+            text ='</tbody>'
+            $(text).appendTo($(element))
+        }
+
+        function fillMetadata(input, element) {
+            $(element).empty()
+            text ='<tbody>'
+            $(text).appendTo($(element))
+
+            for (const key in input) {
+              text = '<tr><td><b>' + key + '</b></td><td>' + input[key] + '</td></tr>'
+              $(text).appendTo($(element))
+            }
+
+            text ='</tbody>'
+            $(text).appendTo($(element))
+        }
+
+        function innerFill(input) {
+            text = ''
+            // This utility function will return a table with the elements in input
+            if (typeof input  === 'string') {
+                text = input
+            } else if (Array.isArray(input)) {
+                text += '<table class="table table-light table-bordered">'
+                // Gather header from first item
+                text += '<thead><tr>'
+            
+                if (typeof input[0] === 'object' && input !== null) {
+                    for (const key2 in input[0]) {
+                      text += '<th scope="col">' + key2 + '</th>'
+                    }
+                }
+                text += '</tr></thead><tbody>'
+
+                for (const item of input) {
+                    text += '<tr>'
+                    if (typeof item === 'string') {
+                        text += '<td>' + item + '</td>'
+                    } else {
+                        for (const key2 in item) {
+                            text += '<td>' + innerFill(item[key2]) + '</td>'
+                        }
+                    }
+                    text += '</tr>'
+                }
+                text += '</tbody></table>'
+            } else if (typeof input === 'object' && input !== null) {
+                text += '<table class="table table-light table-bordered"><tbody>'
+                // Go down the rabbit hole
+                for (const key in input) {
+                    text += '<tr><td><b>' + key + '</b></td><td>'
+                    text += innerFill(input[key]) + '</td></tr>'
+                }
+                text += '</tbody></table>'
+            } else {
+                // What else could it be?
+                text = input
+            }
+            return text
+        }
+
+
+        function fillConfig(input, element) {
+            $(element).empty()
+            var text ='<tbody>'
+            $(text).appendTo($(element))
+
+            for (const key in input) {
+                text = '<tr><td><b>' + key + '</b></td><td>'
+                // Go down the rabbit hole
+                text += innerFill(input[key]) + '</td></tr>'
+                $(text).appendTo($(element))            
+            }
+
+            text ='</tbody>'
+            $(text).appendTo($(element))
+        }
+
+        function fillResults(input, element) {
+            $(element).empty()
+            // The results object is composed of multiple objects, 1 per test
+            // Inside the object we have an array of results
+            id = 1
+            var ansi_up = new AnsiUp;
+
+            tests_total = 0
+            tests_passed = 0
+            tests_skipped = 0
+            tests_failed = 0
+
+            // Compute number of passed/skipped/failed results
+            for (const key in input) {
+                for (const item of input[key]) {
+                    if (item.state == 'passed') {
+                        tests_total++
+                        tests_passed++
+                    } else if (item.state == 'skipped') {
+                        tests_total++
+                        tests_skipped++
+                    } else if (item.state == 'failed') {
+                        tests_total++
+                        tests_failed++
+                    }
+                }
+            }
+
+            // First we will have a left column in the table with the summarized results
+            text ='<thead><tr><th scope="col">Test summary</th><th scope="col">Test results</th></tr></thead><tbody>'
+            text += '<tr><td class="align-top"><b>Total:</b> ' + tests_total + '<br><b>Passed:</b> ' + tests_passed + '<br><b>Skipped:</b> ' + tests_skipped + '<br><b>Failed:</b> ' + tests_failed + '</td><td>'
+            text += '<div class="accordion" id="results-accordion">'
+
+            for (const key in input) {
+                // NOTE: we are assuming the test result is determined by the passed/failed state of the first item
+                status = input[key][0].state
+                if (status === "passed") {
+                    buttontype = 'bg-success text-white'
+                } else if (status === "skipped") {
+                    buttontype = 'bg-warning text-black'
+                } else {
+                    buttonntype = 'bg-danger text-white'
+                }   
+
+                itemid = 'collapse' + id
+                headingid = 'heading' + id
+                text += '<div class="accordion-item"><h2 class="accordion-header" id="' + headingid + '"><button class="accordion-button collapsed ' + buttontype + '" type="button" data-bs-toggle="collapse" data-bs-target="#' + itemid + '" aria-expanded="true" aria-controls="' + itemid +'">'
+                text += key + '</button></h2>'
+                // Now we should populate the item contents
+                text += '<div id="' + itemid + '" class="accordion-collapse collapse" aria-labelledby="' + headingid + '" data-bs-parent="' + element + '">'
+                text += '<div class="accordion-body">'
+                // Inside the accordion, 1 table with the following colummns
+                text += '<table class="table table-bordered table-fixed"><thead><tr>'
+                text += '<th scope="col" class="th-sm">Test ID</th>'
+                text += '<th scope="col" class="th-sm">Test Text</th>'
+                text += '<th scope="col" class="th-sm">Duration</th>'
+                text += '<th scope="col" class="th-sm">State</th>'
+                text += '<th scope="col" class="th-lg">Test output</th>'
+                text += '</tr></thead><tbody>'
+                // Note we are skipping some columns for now
+                // And 1 row per test
+                for (const item of input[key]) {
+                    text += '<tr><td>' + item.testID.url + '" version: ' + item.testID.version + '</td>'
+                    text += '<td>' + item.testText.replace(/\n/g, '<br>') + '</td>'
+                    text += '<td>' + item.duration + '</td>'
+                    text += '<td>' + item.state + '</td>'
+                    text += '<td>' + ansi_up.ansi_to_html(item.CapturedTestOutput).replace(/\n/g, '<br>') + '</td></tr>'
+                }
+                text += '</tbody></table>'
+                text += '</div></div></div>'
+                id = id + 1
+            }
+            text += '</div></td></tr></tbody>'
+            $(text).appendTo($(element))    
+        }
+    </script>
+
+    <script>
+        const inputElement = document.getElementById("formFile");
+        inputElement.addEventListener("change", handleFiles, false);
+        function handleFiles() {
+          const fileList = this.files; /* now you can work with the file list */
+            if (fileList.length) {
+                // We have a file to load
+                 let fileUploaded = new FileReader();
+                 fileUploaded.addEventListener("load", e => {
+                   json = JSON.parse(fileUploaded.result)
+                   //console.log(json)
+                   fillConfig(json.claim.configurations, '#config-table')
+                   fillConfig(json.claim.nodes, '#nodes-table')
+                   fillMetadata(json.claim.metadata, '#metadata-table')
+                   fillVersions(json.claim.versions, '#versions-table')
+                   fillResults(json.claim.results, '#results-table')
+                 });
+                 fileUploaded.readAsText(fileList[0]);
+            }
+        }
+    </script>
+  </body>
+</html>
+

--- a/script/results.html
+++ b/script/results.html
@@ -194,7 +194,7 @@
                 } else if (status === "skipped") {
                     buttontype = 'bg-warning text-black'
                 } else {
-                    buttonntype = 'bg-danger text-white'
+                    buttontype = 'bg-danger text-white'
                 }   
 
                 itemid = 'collapse' + id


### PR DESCRIPTION
As part of the CI process, we want to make it easier to check the
claim.json file after a test suite execution.

This commit adds a results.html file, which can parse a claim file and
show its output in a human-readable way.