### PR TITLE
Insert claim.json file in results HTML page

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -153,7 +153,8 @@ jobs:
           path: |
             test-network-function/*.xml
             test-network-function/claim.json
-            script/results.html
+            test-network-function/claimjson.js
+            test-network-function/results.html
 
       # Perform smoke tests using a TNF container.
 
@@ -190,7 +191,8 @@ jobs:
           path: |
             ${{ env.TNF_OUTPUT_DIR }}/*.xml
             ${{ env.TNF_OUTPUT_DIR }}/claim.json
-            script/results.html
+            ${{ env.TNF_OUTPUT_DIR }}/claimjson.js
+            ${{ env.TNF_OUTPUT_DIR }}/results.html
 
       # Push the new unstable TNF image to Quay.io.
       - name: (if on main and upstream) Authenticate against Quay.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,8 @@ RUN make install-tools && \
 #  Extract what's needed to run at a seperate location
 RUN mkdir ${TNF_BIN_DIR} && \
 	cp run-cnf-suites.sh ${TNF_DIR} && \
+    mkdir ${TNF_DIR}/script && \
+    cp script/results.html ${TNF_DIR}/script && \
 	# copy all JSON files to allow tests to run
 	cp --parents `find -name \*.json*` ${TNF_DIR} && \
   # copy all go template files to allow tests to run

--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -20,6 +20,7 @@ usage_error() {
 
 FOCUS=""
 SKIP=""
+BASEDIR=$(dirname $(realpath $0))
 # Parge args beginning with "-"
 while [[ $1 == -* ]]; do
 	case "$1" in
@@ -46,6 +47,17 @@ while [[ $1 == -* ]]; do
 done
 # specify Junit report file name.
 GINKGO_ARGS="-junit $OUTPUT_LOC -claimloc $OUTPUT_LOC --ginkgo.junit-report $OUTPUT_LOC/cnf-certification-tests_junit.xml -ginkgo.v -test.v"
+
+# Make sure the HTML output is copied to the output directory,
+# even in case of a test failure
+function html_output() {
+    if [ -f ${OUTPUT_LOC}/claim.json ]; then
+        echo -n "var initialjson=" > ${OUTPUT_LOC}/claimjson.js
+        cat ${OUTPUT_LOC}/claim.json >>  ${OUTPUT_LOC}/claimjson.js
+    fi
+    cp ${BASEDIR}/script/results.html ${OUTPUT_LOC}
+}
+trap html_output EXIT
 
 
 # If no focus is set then display usage and quit with a non-zero exit code.

--- a/script/results.html
+++ b/script/results.html
@@ -229,8 +229,17 @@
             $(text).appendTo($(element))    
         }
     </script>
-
+    <!-- This will load the initial JSON file, if present. It may fail. -->
+    <script src="./claimjson.js"></script>
     <script>
+        // Load initial json, if available
+        if (typeof initialjson !== 'undefined') {
+            fillConfig(initialjson.claim.configurations, '#config-table')
+            fillConfig(initialjson.claim.nodes, '#nodes-table')
+            fillMetadata(initialjson.claim.metadata, '#metadata-table')
+            fillVersions(initialjson.claim.versions, '#versions-table')
+            fillResults(initialjson.claim.results, '#results-table')
+        }
         const inputElement = document.getElementById("formFile");
         inputElement.addEventListener("change", handleFiles, false);
         function handleFiles() {


### PR DESCRIPTION
To simplify log viewing, we want to have the CI job insert the
claim.json file automatically inside the results.html page. This cannot
be done by dynamically loading it due to CORS restrictions, but we can
convert the JSON file into a javascript file, then load it from the HTML
page.