### PR TITLE
Ensure drained nodes are uncordoned if test times out

### DIFF
--- a/test-network-function/lifecycle/suite.go
+++ b/test-network-function/lifecycle/suite.go
@@ -316,12 +316,7 @@ func testNodeDrain(env *config.TestEnvironment, nodeName string) {
 		waitForAllDeploymentsReady(ns, scalingTimeout, scalingPollingPeriod)
 	}
 	// If we got this far, all deployments are ready after draining the node
-	msg := fmt.Sprintf("Node drain for %s succeeded\n", nodeName)
-	log.Info(msg)
-	_, err := ginkgo.GinkgoWriter.Write([]byte(msg))
-	if err != nil {
-		log.Errorf("Ginkgo writer could not write because: %s", err)
-	}
+	tnf.ClaimFilePrintf("Node drain for %s succeeded\n", nodeName)
 }
 
 func testPodsRecreation(env *config.TestEnvironment) {

--- a/test-network-function/lifecycle/suite.go
+++ b/test-network-function/lifecycle/suite.go
@@ -401,6 +401,7 @@ func drainNode(node string) {
 	gomega.Expect(err).To(gomega.BeNil())
 	result, err := test.Run()
 	if err != nil || result == tnf.ERROR {
+		uncordonNode(node) // Try to undo the node drain
 		log.Fatalf("Test skipped because of draining node failure - platform issue")
 	}
 }

--- a/test-network-function/lifecycle/suite.go
+++ b/test-network-function/lifecycle/suite.go
@@ -316,7 +316,7 @@ func testNodeDrain(env *config.TestEnvironment, nodeName string) {
 		waitForAllDeploymentsReady(ns, scalingTimeout, scalingPollingPeriod)
 	}
 	// If we got this far, all deployments are ready after draining the node
-	tnf.ClaimFilePrintf("Node drain for %s succeeded\n", nodeName)
+	tnf.ClaimFilePrintf("Node drain for %s succeeded", nodeName)
 }
 
 func testPodsRecreation(env *config.TestEnvironment) {

--- a/test-network-function/lifecycle/suite.go
+++ b/test-network-function/lifecycle/suite.go
@@ -124,7 +124,7 @@ func waitForAllDeploymentsReady(namespace string, timeout, pollingPeriod time.Du
 	var notReadyDeployments []string
 
 	for elapsed < timeout {
-		_, notReadyDeployments := getDeployments(namespace)
+		_, notReadyDeployments = getDeployments(namespace)
 		log.Debugf("Waiting for deployments to get ready, remaining: %d deployments", len(notReadyDeployments))
 		if len(notReadyDeployments) == 0 {
 			break
@@ -408,7 +408,6 @@ func getDeployments(namespace string) (deployments dp.DeploymentMap, notReadyDep
 	return deployments, notReadyDeployments
 }
 
-//nolint:deadcode // to be used in Javier's change
 func collectNodeAndPendingPodInfo(ns string) {
 	context := common.GetContext()
 
@@ -429,7 +428,10 @@ func drainNode(node string) {
 	tester := dd.NewDeploymentsDrain(drainTimeout, node)
 	test, err := tnf.NewTest(context.GetExpecter(), tester, []reel.Handler{tester}, context.GetErrorChannel())
 	gomega.Expect(err).To(gomega.BeNil())
-	test.Run()
+	result, err := test.Run()
+	if err != nil || result == tnf.ERROR {
+		log.Fatalf("Test skipped because of draining node failure - platform issue")
+	}
 }
 
 func uncordonNode(node string) {

--- a/test-network-function/lifecycle/suite.go
+++ b/test-network-function/lifecycle/suite.go
@@ -301,6 +301,7 @@ func shutdownTest(podNamespace, podName string) {
 }
 
 func testNodeDrain(env *config.TestEnvironment, nodeName string) {
+	ginkgo.By(fmt.Sprintf("Testing node drain for %s\n", nodeName))
 	// drain node
 	drainNode(nodeName)
 	// Ensure the node is uncordoned before exiting the function,
@@ -313,6 +314,13 @@ func testNodeDrain(env *config.TestEnvironment, nodeName string) {
 	}()
 	for _, ns := range env.NameSpacesUnderTest {
 		waitForAllDeploymentsReady(ns, scalingTimeout, scalingPollingPeriod)
+	}
+	// If we got this far, all deployments are ready after draining the node
+	msg := fmt.Sprintf("Node drain for %s succeeded\n", nodeName)
+	log.Info(msg)
+	_, err := ginkgo.GinkgoWriter.Write([]byte(msg))
+	if err != nil {
+		log.Errorf("Ginkgo writer could not write because: %s", err)
 	}
 }
 

--- a/test-network-function/lifecycle/suite.go
+++ b/test-network-function/lifecycle/suite.go
@@ -301,7 +301,6 @@ func shutdownTest(podNamespace, podName string) {
 }
 
 func testNodeDrain(env *config.TestEnvironment, nodeName string) {
-
 	// drain node
 	drainNode(nodeName)
 	// Ensure the node is uncordoned before exiting the function,


### PR DESCRIPTION
In the pod recreation test, when deployments are not restarted in time
after a node is drained, that node would remain drained forever and
never be uncordoned.

We can defer the node uncordon operation, so it will always be executed.
If the node was successfully uncordoned, a second uncordon will become a
no-op.

We also remove some unneeded checks after the call to uncordonNode(),
since they are already performed by waitForAllDeploymentsReady(), and
move the final waitForAllDeploymentsReady() check outside of the loop,
so we only do it once.