### PR TITLE
Skipping certification tests when test input not present

### DIFF
--- a/test-network-function/certification/suite.go
+++ b/test-network-function/certification/suite.go
@@ -23,6 +23,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/test-network-function/test-network-function/internal/api"
 	configpkg "github.com/test-network-function/test-network-function/pkg/config"
+	"github.com/test-network-function/test-network-function/pkg/tnf"
 	"github.com/test-network-function/test-network-function/pkg/tnf/testcases"
 	"github.com/test-network-function/test-network-function/test-network-function/common"
 	"github.com/test-network-function/test-network-function/test-network-function/identifiers"
@@ -60,11 +61,21 @@ func testContainerCertificationStatus() {
 		env := configpkg.GetTestEnvironment()
 		cnfsToQuery := env.Config.CertifiedContainerInfo
 
+		if len(cnfsToQuery) == 0 {
+			ginkgo.Skip("No containers to check configured in tnf_config.yml")
+		}
+
 		ginkgo.By(fmt.Sprintf("Getting certification status. Number of containers to check: %d", len(cnfsToQuery)))
 
 		if len(cnfsToQuery) > 0 {
 			certAPIClient = api.NewHTTPClient()
+			allCnfToQueryEmpty := true
 			for _, cnf := range cnfsToQuery {
+				if cnf.Name == "" || cnf.Repository == "" {
+					tnf.ClaimFilePrintf(" cnf name = \"%s\" or repository = \"%s\" is missing, skipping this cnf to query", cnf.Name, cnf.Repository)
+					continue
+				}
+				allCnfToQueryEmpty = false
 				cnf := cnf // pin
 				// Care: this test takes some time to run, failures at later points while before this has finished may be reported as a failure here. Read the failure reason carefully.
 				ginkgo.By(fmt.Sprintf("container %s/%s should eventually be verified as certified", cnf.Repository, cnf.Name))
@@ -72,6 +83,9 @@ func testContainerCertificationStatus() {
 					isCertified := certAPIClient.IsContainerCertified(cnf.Repository, cnf.Name)
 					return isCertified
 				}, eventuallyTimeoutSeconds, interval).Should(gomega.BeTrue())
+			}
+			if allCnfToQueryEmpty {
+				ginkgo.Skip("No containers to check because either cnf name or repository is empty for all cnfs in tnf_config.yml")
 			}
 		}
 	})
@@ -81,10 +95,21 @@ func testOperatorCertificationStatus() {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestOperatorIsCertifiedIdentifier)
 	ginkgo.It(testID, func() {
 		operatorsToQuery := configpkg.GetTestEnvironment().Config.CertifiedOperatorInfo
+
+		if len(operatorsToQuery) == 0 {
+			ginkgo.Skip("No operators to check configured in tnf_config.yml")
+		}
+
 		ginkgo.By(fmt.Sprintf("Verify operator as certified. Number of operators to check: %d", len(operatorsToQuery)))
 		if len(operatorsToQuery) > 0 {
 			certAPIClient := api.NewHTTPClient()
+			allOperatorsToQueryEmpty := true
 			for _, certified := range operatorsToQuery {
+				if certified.Name == "" || certified.Organization == "" {
+					tnf.ClaimFilePrintf(" operator name = \"%s\" or organization = \"%s\" is missing, skipping this cnf to query", certified.Name, certified.Organization)
+					continue
+				}
+				allOperatorsToQueryEmpty = false
 				ginkgo.By(fmt.Sprintf("should eventually be verified as certified (operator %s/%s)", certified.Organization, certified.Name))
 				// Care: this test takes some time to run, failures at later points while before this has finished may be reported as a failure here. Read the failure reason carefully.
 				certified := certified // pin
@@ -92,6 +117,9 @@ func testOperatorCertificationStatus() {
 					isCertified := certAPIClient.IsOperatorCertified(certified.Organization, certified.Name)
 					return isCertified
 				}, eventuallyTimeoutSeconds, interval).Should(gomega.BeTrue())
+			}
+			if allOperatorsToQueryEmpty {
+				ginkgo.Skip("No operators to check because either operator name or organization is empty for all operators in tnf_config.yml")
 			}
 		}
 	})

--- a/test-network-function/certification/suite.go
+++ b/test-network-function/certification/suite.go
@@ -59,33 +59,33 @@ func testContainerCertificationStatus() {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestContainerIsCertifiedIdentifier)
 	ginkgo.It(testID, func() {
 		env := configpkg.GetTestEnvironment()
-		cnfsToQuery := env.Config.CertifiedContainerInfo
+		containersToQuery := env.Config.CertifiedContainerInfo
 
-		if len(cnfsToQuery) == 0 {
+		if len(containersToQuery) == 0 {
 			ginkgo.Skip("No containers to check configured in tnf_config.yml")
 		}
 
-		ginkgo.By(fmt.Sprintf("Getting certification status. Number of containers to check: %d", len(cnfsToQuery)))
+		ginkgo.By(fmt.Sprintf("Getting certification status. Number of containers to check: %d", len(containersToQuery)))
 
-		if len(cnfsToQuery) > 0 {
+		if len(containersToQuery) > 0 {
 			certAPIClient = api.NewHTTPClient()
-			allCnfToQueryEmpty := true
-			for _, cnf := range cnfsToQuery {
-				if cnf.Name == "" || cnf.Repository == "" {
-					tnf.ClaimFilePrintf(" cnf name = \"%s\" or repository = \"%s\" is missing, skipping this cnf to query", cnf.Name, cnf.Repository)
+			allContainersToQueryEmpty := true
+			for _, c := range containersToQuery {
+				if c.Name == "" || c.Repository == "" {
+					tnf.ClaimFilePrintf("Container name = \"%s\" or repository = \"%s\" is missing, skipping this container to query", c.Name, c.Repository)
 					continue
 				}
-				allCnfToQueryEmpty = false
-				cnf := cnf // pin
+				allContainersToQueryEmpty = false
+				c := c // pin
 				// Care: this test takes some time to run, failures at later points while before this has finished may be reported as a failure here. Read the failure reason carefully.
-				ginkgo.By(fmt.Sprintf("container %s/%s should eventually be verified as certified", cnf.Repository, cnf.Name))
+				ginkgo.By(fmt.Sprintf("Container %s/%s should eventually be verified as certified", c.Repository, c.Name))
 				gomega.Eventually(func() bool {
-					isCertified := certAPIClient.IsContainerCertified(cnf.Repository, cnf.Name)
+					isCertified := certAPIClient.IsContainerCertified(c.Repository, c.Name)
 					return isCertified
 				}, eventuallyTimeoutSeconds, interval).Should(gomega.BeTrue())
 			}
-			if allCnfToQueryEmpty {
-				ginkgo.Skip("No containers to check because either cnf name or repository is empty for all cnfs in tnf_config.yml")
+			if allContainersToQueryEmpty {
+				ginkgo.Skip("No containers to check because either container name or repository is empty for all containers in tnf_config.yml")
 			}
 		}
 	})
@@ -106,11 +106,11 @@ func testOperatorCertificationStatus() {
 			allOperatorsToQueryEmpty := true
 			for _, certified := range operatorsToQuery {
 				if certified.Name == "" || certified.Organization == "" {
-					tnf.ClaimFilePrintf(" operator name = \"%s\" or organization = \"%s\" is missing, skipping this cnf to query", certified.Name, certified.Organization)
+					tnf.ClaimFilePrintf("Operator name = \"%s\" or organization = \"%s\" is missing, skipping this operator to query", certified.Name, certified.Organization)
 					continue
 				}
 				allOperatorsToQueryEmpty = false
-				ginkgo.By(fmt.Sprintf("should eventually be verified as certified (operator %s/%s)", certified.Organization, certified.Name))
+				ginkgo.By(fmt.Sprintf("Should eventually be verified as certified (operator %s/%s)", certified.Organization, certified.Name))
 				// Care: this test takes some time to run, failures at later points while before this has finished may be reported as a failure here. Read the failure reason carefully.
 				certified := certified // pin
 				gomega.Eventually(func() bool {


### PR DESCRIPTION
Added logic to skip certification tests when test input is not available:
- if there is no operator or cnf to check -> skip the test
- if the tnf_config.yml contains missing test input info as shown below, this particular certification check is not performed (in either the cnf or operator tests):
    - operator definitions with empty names or organization
    - or cnf definitions with empty names or repositories 

- If input for all cnfs checks is incomplete, the CNF check test is skipped 
- If input for all operator checks is incomplete, the operator check test is skipped 