### PR TITLE
Update Go to 1.17.4

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.3
+          go-version: 1.17.4
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.3
+          go-version: 1.17.4
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.3
+          go-version: 1.17.4
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -105,7 +105,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.3
+          go-version: 1.17.4
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN yum install -y gcc git jq make wget
 
 # Install Go binary
 ENV GO_DL_URL="https://golang.org/dl"
-ENV GO_BIN_TAR="go1.17.3.linux-amd64.tar.gz"
+ENV GO_BIN_TAR="go1.17.4.linux-amd64.tar.gz"
 ENV GO_BIN_URL_x86_64=${GO_DL_URL}/${GO_BIN_TAR}
 ENV GOPATH="/root/go"
 RUN if [[ "$(uname -m)" -eq "x86_64" ]] ; then \


### PR DESCRIPTION
https://go.dev/doc/devel/release

`go1.17.4 (released 2021-12-02) includes fixes to the compiler, linker, runtime, and the go/types, net/http, and time packages.`