### PR TITLE
Close/Kill shell sessions on oc.Close()

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -245,6 +245,9 @@ func (env *TestEnvironment) ResetOc() {
 		cut.Oc.Close()
 		cut.Oc = nil
 	}
+
+	// Wait to allow "done" signals to propagate.
+	time.Sleep(time.Second * 1)
 }
 
 func (env *TestEnvironment) doAutodiscover() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -245,9 +245,6 @@ func (env *TestEnvironment) ResetOc() {
 		cut.Oc.Close()
 		cut.Oc = nil
 	}
-
-	// Wait to allow "done" signals to propagate.
-	time.Sleep(time.Second * 1)
 }
 
 func (env *TestEnvironment) doAutodiscover() {

--- a/pkg/tnf/interactive/spawner.go
+++ b/pkg/tnf/interactive/spawner.go
@@ -55,7 +55,7 @@ type SpawnFunc interface {
 	// Start consult exec.Cmd.Start.
 	Start() error
 
-	// Close calls the exec.Cmd.Kill to stop de program
+	// Close calls the exec.Cmd.Kill to stop the process (shell).
 	Close() error
 
 	// StdinPipe consult exec.Cmd.StdinPipe


### PR DESCRIPTION
- Kills the underlying shell session when oc.Close() is called.
~~- Wait 1 sec at the end of env.ResetOc() functions to allow channels to
  propagate the "done" signals. This is needed to avoid race conditions
with the "oc adm drain" command, which can be executed first, evicting
the pods whose shell sessions' expecters haven't processed the "done"
signal yet.~~
- Minor refactor in the stdout/stderr mirror pipes to detect EOF as
  normal way to return.