### PR TITLE
Removing naked returns

### DIFF
--- a/pkg/config/autodiscover/autodiscover.go
+++ b/pkg/config/autodiscover/autodiscover.go
@@ -45,8 +45,8 @@ var (
 )
 
 // PerformAutoDiscovery checks the environment variable to see if autodiscovery should be performed
-func PerformAutoDiscovery() (doAuto bool) {
-	doAuto, _ = strconv.ParseBool(os.Getenv(disableAutodiscoverEnvVar))
+func PerformAutoDiscovery() bool {
+	doAuto, _ := strconv.ParseBool(os.Getenv(disableAutodiscoverEnvVar))
 	return !doAuto
 }
 
@@ -86,11 +86,13 @@ var executeOcGetAllCommand = func(resourceType, labelQuery string) string {
 }
 
 // getContainersByLabel builds `config.Container`s from containers in pods matching a label.
-func getContainersByLabel(label configsections.Label) (containers []configsections.ContainerConfig, err error) {
+// Returns slice of ContainerConfig, error.
+func getContainersByLabel(label configsections.Label) ([]configsections.ContainerConfig, error) {
 	pods, err := GetPodsByLabel(label)
 	if err != nil {
 		return nil, err
 	}
+	containers := []configsections.ContainerConfig{}
 	for i := range pods.Items {
 		containers = append(containers, buildContainersFromPodResource(pods.Items[i])...)
 	}
@@ -98,11 +100,13 @@ func getContainersByLabel(label configsections.Label) (containers []configsectio
 }
 
 // getContainerIdentifiersByLabel builds `config.ContainerIdentifier`s from containers in pods matching a label.
-func getContainerIdentifiersByLabel(label configsections.Label) (containerIDs []configsections.ContainerIdentifier, err error) {
+// Returns slice of ContainerIdentifier, error.
+func getContainerIdentifiersByLabel(label configsections.Label) ([]configsections.ContainerIdentifier, error) {
 	containers, err := getContainersByLabel(label)
 	if err != nil {
 		return nil, err
 	}
+	containerIDs := []configsections.ContainerIdentifier{}
 	for _, c := range containers {
 		containerIDs = append(containerIDs, c.ContainerIdentifier)
 	}
@@ -110,7 +114,9 @@ func getContainerIdentifiersByLabel(label configsections.Label) (containerIDs []
 }
 
 // buildContainersFromPodResource builds `configsections.Container`s from a `PodResource`
-func buildContainersFromPodResource(pr *PodResource) (containers []configsections.ContainerConfig) {
+// Returns slice of ContainerConfig
+func buildContainersFromPodResource(pr *PodResource) []configsections.ContainerConfig {
+	containers := []configsections.ContainerConfig{}
 	for _, containerResource := range pr.Spec.Containers {
 		var err error
 		var container configsections.ContainerConfig

--- a/pkg/config/autodiscover/autodiscover_targets.go
+++ b/pkg/config/autodiscover/autodiscover_targets.go
@@ -218,12 +218,13 @@ func buildOperatorFromCSVResource(csv *CSVResource) (op configsections.Operator)
 }
 
 // getConfiguredOperatorTests loads the `configuredTestFile` used by the `operator` specs and extracts
-// the names of test groups from it.
-func getConfiguredOperatorTests() (opTests []string) {
+// the names of test groups from it.  Returns slice of strings.
+func getConfiguredOperatorTests() []string {
+	var opTests []string
 	configuredTests, err := testcases.LoadConfiguredTestFile(testcases.ConfiguredTestFile)
 	if err != nil {
 		log.Errorf("failed to load %s, continuing with no tests", testcases.ConfiguredTestFile)
-		return []string{}
+		return opTests
 	}
 	for _, configuredTest := range configuredTests.OperatorTest {
 		opTests = append(opTests, configuredTest.Name)

--- a/pkg/config/autodiscover/autodiscover_test.go
+++ b/pkg/config/autodiscover/autodiscover_test.go
@@ -92,7 +92,7 @@ func TestGetContainersByLabel(t *testing.T) {
 			name:           "",
 			value:          "", // no value
 			filename:       "testdata/testpods_empty.json",
-			expectedOutput: []configsections.ContainerConfig(nil),
+			expectedOutput: []configsections.ContainerConfig{},
 		},
 	}
 	origCommand := executeOcGetAllCommand
@@ -164,7 +164,7 @@ func TestGetContainerIdentifiersByLabel(t *testing.T) {
 			name:           "",
 			value:          "", // no value
 			filename:       "testdata/testpods_empty.json",
-			expectedOutput: []configsections.ContainerIdentifier(nil),
+			expectedOutput: []configsections.ContainerIdentifier{},
 		},
 	}
 

--- a/pkg/config/autodiscover/csv_info.go
+++ b/pkg/config/autodiscover/csv_info.go
@@ -43,23 +43,23 @@ type CSVResource struct {
 	} `json:"metadata"`
 }
 
-func (csv *CSVResource) hasAnnotation(annotationKey string) (present bool) {
-	_, present = csv.Metadata.Annotations[annotationKey]
-	return
+func (csv *CSVResource) hasAnnotation(annotationKey string) bool {
+	_, present := csv.Metadata.Annotations[annotationKey]
+	return present
 }
 
 // GetAnnotationValue will get the value stored in the given annotation and
 // Unmarshal it into the given var `v`.
-func (csv *CSVResource) GetAnnotationValue(annotationKey string, v interface{}) (err error) {
+func (csv *CSVResource) GetAnnotationValue(annotationKey string, v interface{}) error {
 	if !csv.hasAnnotation(annotationKey) {
 		return fmt.Errorf("failed to find annotation '%s' on CSV '%s/%s'", annotationKey, csv.Metadata.Namespace, csv.Metadata.Name)
 	}
 	val := csv.Metadata.Annotations[annotationKey]
-	err = jsonUnmarshal([]byte(val), v)
+	err := jsonUnmarshal([]byte(val), v)
 	if err != nil {
 		return csv.annotationUnmarshalError(annotationKey, err)
 	}
-	return
+	return err
 }
 
 func (csv *CSVResource) annotationUnmarshalError(annotationKey string, err error) error {

--- a/pkg/config/configsections/container.go
+++ b/pkg/config/configsections/container.go
@@ -39,8 +39,8 @@ type ContainerConfig struct {
 	MultusIPAddressesPerNet map[string][]string `yaml:"multusIpAddressesPerNet" json:"multusIpAddressesPerNet"`
 }
 
-func (cid *ContainerIdentifier) String() (output string) {
-	output = fmt.Sprintf("node:%s ns:%s podName:%s containerName:%s containerUID:%s containerRuntime:%s",
+func (cid *ContainerIdentifier) String() string {
+	return fmt.Sprintf("node:%s ns:%s podName:%s containerName:%s containerUID:%s containerRuntime:%s",
 		cid.NodeName,
 		cid.Namespace,
 		cid.PodName,
@@ -48,5 +48,4 @@ func (cid *ContainerIdentifier) String() (output string) {
 		cid.ContainerUID,
 		cid.ContainerRuntime,
 	)
-	return
 }

--- a/test-network-function/accesscontrol/suite.go
+++ b/test-network-function/accesscontrol/suite.go
@@ -216,8 +216,8 @@ func getCrsNamespaces(crdName, crdKind string) (map[string]string, error) {
 	return crNamespaces, nil
 }
 
-func testCrsNamespaces(crNames, configNamespaces []string) (invalidCrs map[string][]string) {
-	invalidCrs = map[string][]string{}
+func testCrsNamespaces(crNames, configNamespaces []string) map[string][]string {
+	invalidCrs := map[string][]string{}
 	for _, crdName := range crNames {
 		getCrPluralNameCommand := fmt.Sprintf(ocGetCrPluralNameFormat, crdName)
 		crdPluralName := utils.ExecuteCommandAndValidate(getCrPluralNameCommand, common.DefaultTimeout, common.GetContext(), func() {

--- a/test-network-function/networking/suite.go
+++ b/test-network-function/networking/suite.go
@@ -62,26 +62,26 @@ type containerIP struct {
 	containerIdentifier *configsections.ContainerIdentifier
 }
 
-func (testContext netTestContext) String() (output string) {
-	output = fmt.Sprintf("From initiating container: %s\n", testContext.testerSource.String())
+func (testContext netTestContext) String() string {
+	output := fmt.Sprintf("From initiating container: %s\n", testContext.testerSource.String())
 	if len(testContext.destTargets) == 0 {
 		output = "--> No target containers to test for this network" //nolint:goconst // this is only one time
 	}
 	for _, target := range testContext.destTargets {
 		output += fmt.Sprintf("--> To target container: %s\n", target.String())
 	}
-	return
+	return output
 }
 
-func (cip *containerIP) String() (output string) {
-	output = fmt.Sprintf("%s ( %s )",
+func (cip *containerIP) String() string {
+	return fmt.Sprintf("%s ( %s )",
 		cip.ip,
 		cip.containerIdentifier.String(),
 	)
-	return
 }
 
-func printNetTestContextMap(netsUnderTest map[string]netTestContext) (output string) {
+func printNetTestContextMap(netsUnderTest map[string]netTestContext) string {
+	var output string
 	if len(netsUnderTest) == 0 {
 		output = "No networks to test.\n" //nolint:goconst // this is only one time
 	}
@@ -89,7 +89,7 @@ func printNetTestContextMap(netsUnderTest map[string]netTestContext) (output str
 		output += fmt.Sprintf("***Test for Network attachment: %s\n", netName)
 		output += fmt.Sprintf("%s\n", netUnderTest.String())
 	}
-	return
+	return output
 }
 
 //


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/CNFCERT-249

Naked returns are less explicit and less readable and to be consistent across our code we should probably stop using them.

