### PR TITLE
CATALOG: Restore Cluster CSI info TC.

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -78,6 +78,15 @@ Description|http://test-network-function.com/testcases/affiliated-certification/
 Result Type|normative
 Suggested Remediation|Ensure that your Operator has passed Red Hat's Operator Certification Program (OCP).
 Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2.12 and Section 6.3.3
+### http://test-network-function.com/testcases/diagnostic/cluster-csi-info
+
+Property|Description
+---|---
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/diagnostic/cluster-csi-info extracts CSI driver information in the cluster.
+Result Type|informative
+Suggested Remediation|
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.3.6
 ### http://test-network-function.com/testcases/diagnostic/clusterversion
 
 Property|Description

--- a/test-network-function/diagnostic/suite.go
+++ b/test-network-function/diagnostic/suite.go
@@ -76,7 +76,7 @@ var _ = ginkgo.Describe(common.DiagnosticTestKey, func() {
 			gomega.Expect(len(env.ContainersUnderTest)).ToNot(gomega.Equal(0))
 		})
 		ginkgo.ReportAfterEach(results.RecordResult)
-		testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestclusterVersionIdentifier)
+		testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestClusterVersionIdentifier)
 		ginkgo.It(testID, func() {
 			testOcpVersion()
 		})

--- a/test-network-function/identifiers/identifiers.go
+++ b/test-network-function/identifiers/identifiers.go
@@ -223,8 +223,8 @@ var (
 		Url:     formTestURL(common.DiagnosticTestKey, "cluster-csi-info"),
 		Version: versionOne,
 	}
-	// TestclusterVersionIdentifier list Cluster CSIdriver Identifier retrieves Third Party CSI driver info.
-	TestclusterVersionIdentifier = claim.Identifier{
+	// TestClusterVersionIdentifier list Cluster CSIdriver Identifier retrieves Third Party CSI driver info.
+	TestClusterVersionIdentifier = claim.Identifier{
 		Url:     formTestURL(common.DiagnosticTestKey, "clusterversion"),
 		Version: versionOne,
 	}
@@ -597,10 +597,10 @@ the changes for you.`,
 			`extracts CSI driver information in the cluster.`),
 		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.3.6",
 	},
-	TestClusterCsiInfoIdentifier: {
-		Identifier: TestclusterVersionIdentifier,
+	TestClusterVersionIdentifier: {
+		Identifier: TestClusterVersionIdentifier,
 		Type:       informativeResult,
-		Description: formDescription(TestclusterVersionIdentifier,
+		Description: formDescription(TestClusterVersionIdentifier,
 			`Extracts OCP versions from the cluster.`),
 		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.3.6",
 	},


### PR DESCRIPTION
The identifier "TestClusterVersionIdentifier" was used twice as key for
the CATALOG entry.