### PR TITLE
Add unit test coverage gate

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -93,6 +93,22 @@ jobs:
         env:
           SHELL: /bin/bash
 
+      - name: Quality Gate - Test coverage shall be above threshold
+        env:
+          TESTCOVERAGE_THRESHOLD: 60
+        run: |
+          echo "Quality Gate: checking test coverage is above threshold ..."
+          echo "Threshold             : $TESTCOVERAGE_THRESHOLD %"
+          totalCoverage=`go tool cover -func=cover.out | grep total | grep -Eo '[0-9]+\.[0-9]+'`
+          echo "Current test coverage : $totalCoverage %"
+          if (( $(echo "$totalCoverage $TESTCOVERAGE_THRESHOLD" | awk '{print ($1 > $2)}') )); then
+              echo "OK"
+          else
+              echo "Current test coverage is below threshold. Please add more unit tests or adjust threshold to a lower value."
+              echo "Failed"
+              exit 1
+          fi
+
   smoke-tests:
     name: Run Smoke Tests
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ validation_junit.xml
 jsontest-cli
 gradetool
 test-out.json
+cover.out
 
 # Explicitly don't track mocks.  mocks should be built on request.
 pkg/tnf/mocks/mock_tester.go

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ lint:
 # Build and run unit tests
 test: mocks
 	go build ${COMMON_GO_ARGS} ./...
-	go test -coverprofile=cover.out `go list ./... | grep -v "github.com/test-network-function/test-network-function/test-network-function" | grep -v mock`
+	go test -coverprofile=cover.out -covermode count `go list ./... | grep -v "github.com/test-network-function/test-network-function/test-network-function" | grep -v mock`
+	go tool cover -func cover.out
 
 # generate the test catalog in JSON
 build-catalog-json: build-tnf-tool

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 	clean \
 	lint \
 	test \
+	coverage-html \
 	build-cnf-tests \
 	run-cnf-tests \
 	run-generic-cnf-tests \
@@ -79,6 +80,9 @@ test: mocks
 	go build ${COMMON_GO_ARGS} ./...
 	go test -coverprofile=cover.out -covermode count `go list ./... | grep -v "github.com/test-network-function/test-network-function/test-network-function" | grep -v mock`
 	go tool cover -func cover.out
+
+coverage-html: test
+	go tool cover -html cover.out
 
 # generate the test catalog in JSON
 build-catalog-json: build-tnf-tool


### PR DESCRIPTION
Setting a minimum unit test threshold of 60%.  Our current testing coverage is 67%.  We can bump the threshold up later as the coverage improves.

Tutorial: https://medium.com/citihub/how-to-set-up-a-test-coverage-threshold-in-go-and-github-167f69b940dc

As a bonus, I added `make coverage-html` to output a browser based coverage report.