### PR TITLE
Make the networking tests run once per pod instead of once per container

### DIFF
--- a/pkg/config/autodiscover/autodiscover.go
+++ b/pkg/config/autodiscover/autodiscover.go
@@ -85,7 +85,7 @@ var executeOcGetAllCommand = func(resourceType, labelQuery string) string {
 	return match
 }
 
-// getContainersByLabel builds `config.Container`s from containers in pods matching a label.
+// getContainersByLabel builds `configsections.Container`s from containers in pods matching a label.
 // Returns slice of ContainerConfig, error.
 func getContainersByLabel(label configsections.Label) ([]configsections.ContainerConfig, error) {
 	pods, err := GetPodsByLabel(label)

--- a/pkg/config/autodiscover/autodiscover.go
+++ b/pkg/config/autodiscover/autodiscover.go
@@ -87,14 +87,14 @@ var executeOcGetAllCommand = func(resourceType, labelQuery string) string {
 
 // getContainersByLabel builds `configsections.Container`s from containers in pods matching a label.
 // Returns slice of ContainerConfig, error.
-func getContainersByLabel(label configsections.Label) ([]configsections.ContainerConfig, error) {
+func getContainersByLabel(label configsections.Label) ([]configsections.Container, error) {
 	pods, err := GetPodsByLabel(label)
 	if err != nil {
 		return nil, err
 	}
-	containers := []configsections.ContainerConfig{}
+	containers := []configsections.Container{}
 	for i := range pods.Items {
-		containers = append(containers, buildContainersFromPodResource(pods.Items[i])...)
+		containers = append(containers, buildContainers(pods.Items[i])...)
 	}
 	return containers, nil
 }
@@ -113,13 +113,12 @@ func getContainerIdentifiersByLabel(label configsections.Label) ([]configsection
 	return containerIDs, nil
 }
 
-// buildContainersFromPodResource builds `configsections.Container`s from a `PodResource`
-// Returns slice of ContainerConfig
-func buildContainersFromPodResource(pr *PodResource) []configsections.ContainerConfig {
-	containers := []configsections.ContainerConfig{}
+// buildContainers builds a container list
+// Returns slice of Container
+func buildContainers(pr *PodResource) []configsections.Container {
+	containers := []configsections.Container{}
 	for _, containerResource := range pr.Spec.Containers {
-		var err error
-		var container configsections.ContainerConfig
+		var container configsections.Container
 		container.Namespace = pr.Metadata.Namespace
 		container.PodName = pr.Metadata.Name
 		container.ContainerName = containerResource.Name
@@ -135,16 +134,7 @@ func buildContainersFromPodResource(pr *PodResource) []configsections.ContainerC
 				}
 			}
 		}
-		container.DefaultNetworkDevice, err = pr.getDefaultNetworkDeviceFromAnnotations()
-		if err != nil {
-			log.Warnf("error encountered getting default network device: %s", err)
-		}
 
-		container.MultusIPAddressesPerNet, err = pr.getPodIPsPerNet()
-		if err != nil {
-			log.Warnf("error encountered getting multus IPs: %s", err)
-			err = nil
-		}
 		log.Debugf("added container: %s", container.String())
 		containers = append(containers, container)
 	}

--- a/pkg/config/autodiscover/autodiscover_debug.go
+++ b/pkg/config/autodiscover/autodiscover_debug.go
@@ -53,7 +53,7 @@ func FindDebugPods(tp *configsections.TestPartner) {
 		log.Panic("can't find debug pods, make sure daemonset debug is deployed properly")
 	}
 	for _, pod := range pods.Items {
-		tp.ContainersDebugList = append(tp.ContainersDebugList, buildContainersFromPodResource(pod)[0])
+		tp.ContainersDebugList = append(tp.ContainersDebugList, buildContainers(pod)[0])
 	}
 }
 

--- a/pkg/config/autodiscover/autodiscover_targets.go
+++ b/pkg/config/autodiscover/autodiscover_targets.go
@@ -177,8 +177,7 @@ func FindTestPodSetsByLabel(targetLabels []configsections.Label, target *configs
 // buildPodUnderTest builds a single `configsections.Pod` from a PodResource
 func buildPodUnderTest(pr *PodResource) (podUnderTest *configsections.Pod) {
 	var err error
-	var pod configsections.Pod
-	podUnderTest = &pod
+	podUnderTest := &configsections.Pod{}
 	podUnderTest.Namespace = pr.Metadata.Namespace
 	podUnderTest.Name = pr.Metadata.Name
 	podUnderTest.ServiceAccount = pr.Spec.ServiceAccount

--- a/pkg/config/autodiscover/autodiscover_targets.go
+++ b/pkg/config/autodiscover/autodiscover_targets.go
@@ -177,7 +177,7 @@ func FindTestPodSetsByLabel(targetLabels []configsections.Label, target *configs
 // buildPodUnderTest builds a single `configsections.Pod` from a PodResource
 func buildPodUnderTest(pr *PodResource) (podUnderTest *configsections.Pod) {
 	var err error
-	podUnderTest := &configsections.Pod{}
+	podUnderTest = &configsections.Pod{}
 	podUnderTest.Namespace = pr.Metadata.Namespace
 	podUnderTest.Name = pr.Metadata.Name
 	podUnderTest.ServiceAccount = pr.Spec.ServiceAccount

--- a/pkg/config/autodiscover/autodiscover_test.go
+++ b/pkg/config/autodiscover/autodiscover_test.go
@@ -62,7 +62,7 @@ func TestBuildLabelQuery(t *testing.T) {
 
 func TestGetContainersByLabel(t *testing.T) {
 	testCases := []struct {
-		expectedOutput []configsections.ContainerConfig
+		expectedOutput []configsections.Container
 		prefix         string
 		name           string
 		value          string
@@ -73,7 +73,7 @@ func TestGetContainersByLabel(t *testing.T) {
 			name:     "testname",
 			value:    "testvalue",
 			filename: "testdata/testpods_withlabel.json",
-			expectedOutput: []configsections.ContainerConfig{
+			expectedOutput: []configsections.Container{
 				{
 					ContainerIdentifier: configsections.ContainerIdentifier{
 						Namespace:        "kube-system",
@@ -83,7 +83,6 @@ func TestGetContainersByLabel(t *testing.T) {
 						ContainerUID:     "cf794b9e8c2448815b8b5a47b354c9bf9414a04f6fa567ac3b059851ed6757ab",
 						ContainerRuntime: "docker",
 					},
-					MultusIPAddressesPerNet: map[string][]string{},
 				},
 			},
 		},
@@ -92,7 +91,7 @@ func TestGetContainersByLabel(t *testing.T) {
 			name:           "",
 			value:          "", // no value
 			filename:       "testdata/testpods_empty.json",
-			expectedOutput: []configsections.ContainerConfig{},
+			expectedOutput: []configsections.Container{},
 		},
 	}
 	origCommand := executeOcGetAllCommand

--- a/pkg/config/autodiscover/container_test.go
+++ b/pkg/config/autodiscover/container_test.go
@@ -22,20 +22,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBuildContainersFromPodResource(t *testing.T) {
+func TestBuildContainers(t *testing.T) {
 	subjectPod := loadPodResource(testSubjectFilePath)
-	subjectContainers := buildContainersFromPodResource(&subjectPod)
+	subjectContainers := buildContainers(&subjectPod)
 	assert.Equal(t, 1, len(subjectContainers))
 
 	assert.Equal(t, "tnf", subjectContainers[0].Namespace)
 	assert.Equal(t, "I'mAPodName", subjectContainers[0].PodName)
 	assert.Equal(t, "I'mAContainer", subjectContainers[0].ContainerName)
-
-	// Check correct order of precedence for network devices
-	assert.Equal(t, "eth0", subjectContainers[0].DefaultNetworkDevice)
-
-	// test-network-function.com/multusips should be used for the test subject container.
-	assert.Equal(t, 2, len(subjectContainers[0].MultusIPAddressesPerNet))
-	assert.Equal(t, "3.3.3.3", subjectContainers[0].MultusIPAddressesPerNet["default/macvlan-conf1"][0])
-	assert.Equal(t, "4.4.4.4", subjectContainers[0].MultusIPAddressesPerNet["default/macvlan-conf2"][0])
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,9 +40,9 @@ const (
 )
 
 var (
-	expectersVerboseModeEnabled = false
 	// testEnvironment is the singleton instance of `TestEnvironment`, accessed through `GetTestEnvironment`
-	testEnvironment TestEnvironment
+	testEnvironment             TestEnvironment
+	expectersVerboseModeEnabled = false
 )
 
 // getConfigurationFilePathFromEnvironment returns the test configuration file.
@@ -54,36 +54,12 @@ func getConfigurationFilePathFromEnvironment() string {
 	return defaultConfigurationFilePath
 }
 
-// Container is a construct which follows the Container design pattern.  Essentially, a Container holds the
-// pertinent information to perform a test against or using an Operating System Container.  This includes facets such
-// as the reference to the interactive.Oc instance, the reference to the test configuration, and the default network
-// IP address.
-type Container struct {
-	configsections.ContainerConfig
-	oc                      *interactive.Oc
-	DefaultNetworkIPAddress string
-}
-
-func (c *Container) GetOc() *interactive.Oc {
-	if c.oc == nil {
-		c.oc = getOcSession(c.PodName, c.ContainerName, c.Namespace, DefaultTimeout, interactive.Verbose(expectersVerboseModeEnabled), interactive.SendTimeout(DefaultTimeout))
-	}
-	return c.oc
-}
-
-func (c *Container) CloseOc() {
-	if c.oc != nil {
-		c.oc.Close()
-		c.oc = nil
-	}
-}
-
 type NodeConfig struct {
 	// same Name as the one inside Node structure
 	Name string
 	Node configsections.Node
 	// pointer to the container of the debug pod running on the node
-	DebugContainer *Container
+	DebugContainer *configsections.Container
 	// podset indicates if the node has a podset,deployment/statefulset
 	podset bool
 	// debug indicates if the node should have a debug pod
@@ -108,41 +84,6 @@ func (n NodeConfig) HasDebugPod() bool {
 // DefaultTimeout for creating new interactive sessions (oc, ssh, tty)
 var DefaultTimeout = time.Duration(defaultTimeoutSeconds) * time.Second
 
-// Helper used to instantiate an OpenShift Client Session.
-func getOcSession(pod, container, namespace string, timeout time.Duration, options ...interactive.Option) *interactive.Oc {
-	// Spawn an interactive OC shell using a goroutine (needed to avoid cross expect.Expecter interaction).  Extract the
-	// Oc reference from the goroutine through a channel.  Performs basic sanity checking that the Oc session is set up
-	// correctly.
-	var containerOc *interactive.Oc
-	ocChan := make(chan *interactive.Oc)
-
-	goExpectSpawner := interactive.NewGoExpectSpawner()
-	var spawner interactive.Spawner = goExpectSpawner
-
-	go func() {
-		oc, outCh, err := interactive.SpawnOc(&spawner, pod, container, namespace, timeout, options...)
-		gomega.Expect(outCh).ToNot(gomega.BeNil())
-		gomega.Expect(err).To(gomega.BeNil())
-		// Set up a go routine which reads from the error channel
-		go func() {
-			log.Debugf("start watching the session with container %s/%s", oc.GetPodName(), oc.GetPodContainerName())
-			select {
-			case err := <-outCh:
-				log.Fatalf("OC session to container %s/%s is broken due to: %v, aborting the test run", oc.GetPodName(), oc.GetPodContainerName(), err)
-			case <-oc.GetDoneChannel():
-				log.Debugf("stop watching the session with container %s/%s", oc.GetPodName(), oc.GetPodContainerName())
-			}
-		}()
-		ocChan <- oc
-	}()
-
-	containerOc = <-ocChan
-
-	gomega.Expect(containerOc).ToNot(gomega.BeNil())
-
-	return containerOc
-}
-
 // Extract a container IP address for a particular device.  This is needed since container default network IP address
 // is served by dhcp, and thus is ephemeral.
 func getContainerDefaultNetworkIPAddress(initiatingPodNodeOc *interactive.Oc, nodeName, containerID, runtime, dev string) (string, error) {
@@ -160,10 +101,10 @@ func getContainerDefaultNetworkIPAddress(initiatingPodNodeOc *interactive.Oc, no
 
 // TestEnvironment includes the representation of the current state of the test targets and partners as well as the test configuration
 type TestEnvironment struct {
-	ContainersUnderTest  map[configsections.ContainerIdentifier]*Container
-	PartnerContainers    map[configsections.ContainerIdentifier]*Container
-	DebugContainers      map[configsections.ContainerIdentifier]*Container
-	PodsUnderTest        []configsections.Pod
+	ContainersUnderTest  map[configsections.ContainerIdentifier]*configsections.Container
+	PartnerContainers    map[configsections.ContainerIdentifier]*configsections.Container
+	DebugContainers      map[configsections.ContainerIdentifier]*configsections.Container
+	PodsUnderTest        []*configsections.Pod
 	DeploymentsUnderTest []configsections.PodSet
 	StateFulSetUnderTest []configsections.PodSet
 	OperatorsUnderTest   []configsections.Operator
@@ -388,15 +329,15 @@ func (env *TestEnvironment) discoverNodes() {
 
 // createContainers contains the general steps involved in creating "oc" sessions and other configuration. A map of the
 // aggregate information is returned. No IP is populated yet in this step
-func (env *TestEnvironment) createContainersNoIP(containerDefinitions []configsections.ContainerConfig) map[configsections.ContainerIdentifier]*Container {
-	createdContainers := make(map[configsections.ContainerIdentifier]*Container)
+func (env *TestEnvironment) createContainersNoIP(containerDefinitions []configsections.ContainerConfig) map[configsections.ContainerIdentifier]*configsections.Container {
+	createdContainers := make(map[configsections.ContainerIdentifier]*configsections.Container)
 	for _, c := range containerDefinitions {
-		oc := getOcSession(c.PodName, c.ContainerName, c.Namespace, DefaultTimeout, interactive.Verbose(expectersVerboseModeEnabled), interactive.SendTimeout(DefaultTimeout))
+		oc := configsections.GetOcSession(c.PodName, c.ContainerName, c.Namespace, DefaultTimeout, interactive.Verbose(expectersVerboseModeEnabled), interactive.SendTimeout(DefaultTimeout))
 		var defaultIPAddress = "UNKNOWN"
 
-		createdContainers[c.ContainerIdentifier] = &Container{
+		createdContainers[c.ContainerIdentifier] = &configsections.Container{
 			ContainerConfig:         c,
-			oc:                      oc,
+			Oc:                      oc,
 			DefaultNetworkIPAddress: defaultIPAddress,
 		}
 	}
@@ -405,20 +346,20 @@ func (env *TestEnvironment) createContainersNoIP(containerDefinitions []configse
 
 // createContainers contains the general steps involved in creating "oc" sessions and other configuration. A map of the
 // aggregate information is returned.
-func (env *TestEnvironment) createContainers(containerDefinitions []configsections.ContainerConfig) map[configsections.ContainerIdentifier]*Container {
+func (env *TestEnvironment) createContainers(containerDefinitions []configsections.ContainerConfig) map[configsections.ContainerIdentifier]*configsections.Container {
 	containers := env.createContainersNoIP(containerDefinitions)
 	env.recordContainersDefaultIP(containers)
 	return containers
 }
 
 // recordContainersDefaultIP default IP populated in container map
-func (env *TestEnvironment) recordContainersDefaultIP(containers map[configsections.ContainerIdentifier]*Container) {
+func (env *TestEnvironment) recordContainersDefaultIP(containers map[configsections.ContainerIdentifier]*configsections.Container) {
 	for id, c := range containers {
 		var defaultIPAddress = "UNKNOWN"
 		var err error
 		if _, ok := env.ContainersToExcludeFromConnectivityTests[c.ContainerIdentifier]; !ok {
 			if env.NodesUnderTest[c.NodeName].HasDebugPod() {
-				defaultIPAddress, err = getContainerDefaultNetworkIPAddress(env.NodesUnderTest[c.NodeName].DebugContainer.oc,
+				defaultIPAddress, err = getContainerDefaultNetworkIPAddress(env.NodesUnderTest[c.NodeName].DebugContainer.Oc,
 					c.NodeName,
 					c.ContainerUID,
 					c.ContainerRuntime,
@@ -434,6 +375,14 @@ func (env *TestEnvironment) recordContainersDefaultIP(containers map[configsecti
 			}
 		}
 		containers[id].DefaultNetworkIPAddress = defaultIPAddress
+	}
+	// Fill the default Ip address of the pod, by getting it from the container selected by us to run the networking tests
+	// Find the container based on the container identifier in the pod object. Get the Ip address from the container and update the pod
+	for key, pod := range env.PodsUnderTest {
+		if _, ok := containers[pod.ContainerConfig.ContainerIdentifier]; ok {
+			pod.DefaultNetworkIPAddress = containers[pod.ContainerConfig.ContainerIdentifier].DefaultNetworkIPAddress
+			env.PodsUnderTest[key] = pod
+		}
 	}
 }
 

--- a/pkg/config/configsections/common.go
+++ b/pkg/config/configsections/common.go
@@ -77,10 +77,10 @@ type TestTarget struct {
 	// StateFulSetUnderTest is the list of statefulset that contain pods under test.
 	StateFulSetUnderTest []PodSet `yaml:"stateFulSetUnderTest" json:"stateFulSetUnderTest"`
 	// PodsUnderTest is the list of the pods that needs to be tested. Each entry is a single pod to be tested.
-	PodsUnderTest []Pod `yaml:"podsUnderTest,omitempty" json:"podsUnderTest,omitempty"`
+	PodsUnderTest []*Pod `yaml:"podsUnderTest,omitempty" json:"podsUnderTest,omitempty"`
 	// NonValidPods contains a list of pods that share the same labels with Pods Under Test
 	// without belonging to namespaces under test
-	NonValidPods []Pod
+	NonValidPods []*Pod
 	// ContainerConfigList is the list of containers that needs to be tested.
 	ContainerConfigList []ContainerConfig `yaml:"containersUnderTest" json:"containersUnderTest"`
 	// ExcludeContainersFromConnectivityTests excludes specific containers from network connectivity tests.  This is particularly useful for containers that don't have ping available.

--- a/pkg/config/configsections/common.go
+++ b/pkg/config/configsections/common.go
@@ -67,7 +67,7 @@ type TestConfiguration struct {
 // TestPartner contains the helper containers that can be used to facilitate tests
 type TestPartner struct {
 	// DebugPods
-	ContainersDebugList []ContainerConfig `yaml:"debugContainers,omitempty" json:"debugContainers,omitempty"`
+	ContainersDebugList []Container `yaml:"debugContainers,omitempty" json:"debugContainers,omitempty"`
 }
 
 // TestTarget is a collection of resources under test
@@ -82,7 +82,7 @@ type TestTarget struct {
 	// without belonging to namespaces under test
 	NonValidPods []*Pod
 	// ContainerConfigList is the list of containers that needs to be tested.
-	ContainerConfigList []ContainerConfig `yaml:"containersUnderTest" json:"containersUnderTest"`
+	ContainerList []Container `yaml:"containersUnderTest" json:"containersUnderTest"`
 	// ExcludeContainersFromConnectivityTests excludes specific containers from network connectivity tests.  This is particularly useful for containers that don't have ping available.
 	ExcludeContainersFromConnectivityTests []ContainerIdentifier `yaml:"excludeContainersFromConnectivityTests" json:"excludeContainersFromConnectivityTests"`
 	// Operator is the list of operator objects that needs to be tested.

--- a/pkg/config/configsections/config_section_test.go
+++ b/pkg/config/configsections/config_section_test.go
@@ -111,7 +111,7 @@ func loadDeploymentsConfig() {
 }
 
 func loadPodConfig() {
-	test.PodsUnderTest = []Pod{
+	test.PodsUnderTest = []*Pod{
 		{
 			Name:      cnfName,
 			Namespace: testNameSpace,

--- a/pkg/config/configsections/container.go
+++ b/pkg/config/configsections/container.go
@@ -40,9 +40,8 @@ var (
 // as the reference to the interactive.Oc instance, the reference to the test configuration, and the default network
 // IP address.
 type Container struct {
-	ContainerConfig
-	Oc                      *interactive.Oc
-	DefaultNetworkIPAddress string `yaml:"defaultnetworkipaddress" json:"defaultnetworkipaddress"`
+	ContainerIdentifier
+	Oc *interactive.Oc
 }
 
 // Helper used to instantiate an OpenShift Client Session.
@@ -102,15 +101,6 @@ type ContainerIdentifier struct {
 	NodeName         string `yaml:"nodeName" json:"nodeName"`
 	ContainerUID     string `yaml:"containerUID" json:"containerUID"`
 	ContainerRuntime string `yaml:"containerRuntime" json:"containerRuntime"`
-}
-
-// ContainerConfig contains the payload of container facets.
-type ContainerConfig struct {
-	ContainerIdentifier `yaml:",inline"`
-	// OpenShift Default network interface name (i.e., eth0)
-	DefaultNetworkDevice string `yaml:"defaultNetworkDevice" json:"defaultNetworkDevice"`
-	// MultusIPAddressesPerNet are the overlay IPs.
-	MultusIPAddressesPerNet map[string][]string `yaml:"multusIpAddressesPerNet,omitempty" json:"multusIpAddressesPerNet,omitempty"`
 }
 
 func (cid *ContainerIdentifier) String() string {

--- a/pkg/config/configsections/pod.go
+++ b/pkg/config/configsections/pod.go
@@ -33,6 +33,14 @@ type Pod struct {
 	// Tests this is list of test that need to run against the Pod.
 	Tests []string `yaml:"tests" json:"tests"`
 
+	DefaultNetworkIPAddress string `yaml:"defaultnetworkipaddress" json:"defaultnetworkipaddress"`
+
+	// OpenShift Default network interface name (i.e., eth0)
+	DefaultNetworkDevice string `yaml:"defaultNetworkDevice" json:"defaultNetworkDevice"`
+
+	// MultusIPAddressesPerNet are the overlay IPs.
+	MultusIPAddressesPerNet map[string][]string `yaml:"multusIpAddressesPerNet,omitempty" json:"multusIpAddressesPerNet,omitempty"`
+
 	// Representation of the container in this pod used to run networing tests
-	Container `yaml:"containerfornettests" json:"containerfornettests"`
+	ContainerList []Container `yaml:"containerfornettests,omitempty" json:"containerfornettests,omitempty"`
 }

--- a/pkg/config/configsections/pod.go
+++ b/pkg/config/configsections/pod.go
@@ -32,4 +32,7 @@ type Pod struct {
 
 	// Tests this is list of test that need to run against the Pod.
 	Tests []string `yaml:"tests" json:"tests"`
+
+	// Representation of the container in this pod used to run networing tests
+	Container `yaml:"containerfornettests" json:"containerfornettests"`
 }

--- a/test-network-function/accesscontrol/suite.go
+++ b/test-network-function/accesscontrol/suite.go
@@ -309,7 +309,7 @@ func testServiceAccount(env *config.TestEnvironment) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestPodServiceAccountBestPracticesIdentifier)
 	ginkgo.It(testID, func() {
 		ginkgo.By("Should have a valid ServiceAccount name")
-		failedPods := []configsections.Pod{}
+		failedPods := []*configsections.Pod{}
 		for _, podUnderTest := range env.PodsUnderTest {
 			ginkgo.By(fmt.Sprintf("Testing service account for pod %s (ns: %s)", podUnderTest.Name, podUnderTest.Namespace))
 			if podUnderTest.ServiceAccount == "" {
@@ -387,7 +387,7 @@ func testAutomountService(env *config.TestEnvironment) {
 func testRoleBindings(env *config.TestEnvironment) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestPodRoleBindingsBestPracticesIdentifier)
 	ginkgo.It(testID, func() {
-		failedPods := []configsections.Pod{}
+		failedPods := []*configsections.Pod{}
 		ginkgo.By("Should not have RoleBinding in other namespaces")
 		for _, podUnderTest := range env.PodsUnderTest {
 			podName := podUnderTest.Name
@@ -421,7 +421,7 @@ func testClusterRoleBindings(env *config.TestEnvironment) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestPodClusterRoleBindingsBestPracticesIdentifier)
 	ginkgo.It(testID, func() {
 		ginkgo.By("Should not have ClusterRoleBindings")
-		failedPods := []configsections.Pod{}
+		failedPods := []*configsections.Pod{}
 		for _, podUnderTest := range env.PodsUnderTest {
 			podName := podUnderTest.Name
 			podNamespace := podUnderTest.Namespace

--- a/test-network-function/diagnostic/suite_test.go
+++ b/test-network-function/diagnostic/suite_test.go
@@ -40,7 +40,7 @@ func TestGetMasterAndWorkerNodeName(t *testing.T) {
 						Node: configsections.Node{
 							Labels: []string{configsections.MasterLabel},
 						},
-						DebugContainer: &config.Container{
+						DebugContainer: &configsections.Container{
 							ContainerConfig: configsections.ContainerConfig{
 								ContainerIdentifier: configsections.ContainerIdentifier{
 									PodName: "debugTest",
@@ -61,7 +61,7 @@ func TestGetMasterAndWorkerNodeName(t *testing.T) {
 						Node: configsections.Node{
 							Labels: []string{configsections.WorkerLabel},
 						},
-						DebugContainer: &config.Container{
+						DebugContainer: &configsections.Container{
 							ContainerConfig: configsections.ContainerConfig{
 								ContainerIdentifier: configsections.ContainerIdentifier{
 									PodName: "debugTest",
@@ -97,7 +97,7 @@ func TestGetMasterAndWorkerNodeName(t *testing.T) {
 						Node: configsections.Node{
 							Labels: []string{configsections.WorkerLabel},
 						},
-						DebugContainer: &config.Container{
+						DebugContainer: &configsections.Container{
 							ContainerConfig: configsections.ContainerConfig{
 								ContainerIdentifier: configsections.ContainerIdentifier{
 									PodName: "debugTest",
@@ -118,7 +118,7 @@ func TestGetMasterAndWorkerNodeName(t *testing.T) {
 						Node: configsections.Node{
 							Labels: []string{configsections.MasterLabel},
 						},
-						DebugContainer: &config.Container{
+						DebugContainer: &configsections.Container{
 							ContainerConfig: configsections.ContainerConfig{
 								ContainerIdentifier: configsections.ContainerIdentifier{
 									PodName: "debugTest",

--- a/test-network-function/diagnostic/suite_test.go
+++ b/test-network-function/diagnostic/suite_test.go
@@ -41,10 +41,8 @@ func TestGetMasterAndWorkerNodeName(t *testing.T) {
 							Labels: []string{configsections.MasterLabel},
 						},
 						DebugContainer: &configsections.Container{
-							ContainerConfig: configsections.ContainerConfig{
-								ContainerIdentifier: configsections.ContainerIdentifier{
-									PodName: "debugTest",
-								},
+							ContainerIdentifier: configsections.ContainerIdentifier{
+								PodName: "debugTest",
 							},
 						},
 					},
@@ -62,10 +60,8 @@ func TestGetMasterAndWorkerNodeName(t *testing.T) {
 							Labels: []string{configsections.WorkerLabel},
 						},
 						DebugContainer: &configsections.Container{
-							ContainerConfig: configsections.ContainerConfig{
-								ContainerIdentifier: configsections.ContainerIdentifier{
-									PodName: "debugTest",
-								},
+							ContainerIdentifier: configsections.ContainerIdentifier{
+								PodName: "debugTest",
 							},
 						},
 					},
@@ -98,10 +94,8 @@ func TestGetMasterAndWorkerNodeName(t *testing.T) {
 							Labels: []string{configsections.WorkerLabel},
 						},
 						DebugContainer: &configsections.Container{
-							ContainerConfig: configsections.ContainerConfig{
-								ContainerIdentifier: configsections.ContainerIdentifier{
-									PodName: "debugTest",
-								},
+							ContainerIdentifier: configsections.ContainerIdentifier{
+								PodName: "debugTest",
 							},
 						},
 					},
@@ -119,10 +113,8 @@ func TestGetMasterAndWorkerNodeName(t *testing.T) {
 							Labels: []string{configsections.MasterLabel},
 						},
 						DebugContainer: &configsections.Container{
-							ContainerConfig: configsections.ContainerConfig{
-								ContainerIdentifier: configsections.ContainerIdentifier{
-									PodName: "debugTest",
-								},
+							ContainerIdentifier: configsections.ContainerIdentifier{
+								PodName: "debugTest",
 							},
 						},
 					},

--- a/test-network-function/lifecycle/suite.go
+++ b/test-network-function/lifecycle/suite.go
@@ -180,7 +180,7 @@ func refreshReplicas(podset *configsections.PodSet, env *config.TestEnvironment)
 	}
 }
 
-func closeOcSessionsByPodset(containers map[configsections.ContainerIdentifier]*config.Container, podset *configsections.PodSet) {
+func closeOcSessionsByPodset(containers map[configsections.ContainerIdentifier]*configsections.Container, podset *configsections.PodSet) {
 	log.Debug("close session for", string(podset.Type), "=", podset.Name, " start")
 	defer log.Debug("close session for", string(podset.Type), "=", podset.Name, " done")
 	for cid, c := range containers {
@@ -319,7 +319,7 @@ func testGracePeriod(env *config.TestEnvironment) {
 func testShutdown(env *config.TestEnvironment) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestShudtownIdentifier)
 	ginkgo.It(testID, func() {
-		failedPods := []configsections.Pod{}
+		failedPods := []*configsections.Pod{}
 		ginkgo.By("Testing PUTs are configured with pre-stop lifecycle")
 		for _, podUnderTest := range env.PodsUnderTest {
 			podName := podUnderTest.Name
@@ -548,7 +548,7 @@ func testOwner(env *config.TestEnvironment) {
 	ginkgo.It(testID, func() {
 		ginkgo.By("Testing owners of CNF pod, should be replicas Set")
 		context := common.GetContext()
-		failedPods := []configsections.Pod{}
+		failedPods := []*configsections.Pod{}
 		for _, podUnderTest := range env.PodsUnderTest {
 			podName := podUnderTest.Name
 			podNamespace := podUnderTest.Namespace
@@ -576,7 +576,7 @@ func testImagePolicy(env *config.TestEnvironment) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestImagePullPolicyIdentifier)
 	ginkgo.It(testID, func() {
 		context := common.GetContext()
-		failedPods := []configsections.Pod{}
+		failedPods := []*configsections.Pod{}
 		for _, podUnderTest := range env.PodsUnderTest {
 			values := make(map[string]interface{})
 			ContainerCount := podUnderTest.ContainerCount

--- a/test-network-function/networking/suite.go
+++ b/test-network-function/networking/suite.go
@@ -178,13 +178,7 @@ func runNetworkingTests(netsUnderTest map[string]netTestContext, count int) map[
 			ginkgo.Skip(fmt.Sprintf("There are no containers to ping for network %s. A minimum of 2 containers is needed to run a ping test (a source and a destination) Skipping test", netName))
 		}
 		ginkgo.By(fmt.Sprintf("Ping tests on network %s. Number of target IPs: %d", netName, len(netUnderTest.destTargets)))
-		m := make(map[string]bool)
 		for _, aDestIP := range netUnderTest.destTargets {
-			podName := aDestIP.containerIdentifier.PodName
-			if _, ok := m[podName]; ok {
-				continue
-			}
-			m[podName] = true
 			ginkgo.By(fmt.Sprintf("a Ping is issued from %s(%s) %s to %s(%s) %s",
 				netUnderTest.testerSource.containerIdentifier.PodName,
 				netUnderTest.testerSource.containerIdentifier.ContainerName,
@@ -209,18 +203,18 @@ func testDefaultNetworkConnectivity(env *config.TestEnvironment, count int) {
 		testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv4ConnectivityIdentifier)
 		ginkgo.It(testID, func() {
 			netsUnderTest := make(map[string]netTestContext)
-			for _, cut := range env.ContainersUnderTest {
-				if _, ok := env.ContainersToExcludeFromConnectivityTests[cut.ContainerIdentifier]; ok {
-					tnf.ClaimFilePrintf("Skipping container %s because it is excluded from connectivity tests (default interface)", cut.PodName)
+			for _, pod := range env.PodsUnderTest {
+				if _, ok := env.ContainersToExcludeFromConnectivityTests[pod.ContainerIdentifier]; ok {
+					tnf.ClaimFilePrintf("Skipping container %s because it is excluded from connectivity tests (default interface)", pod.PodName)
 					continue
 				}
 				netKey := "default" //nolint:goconst // only used once
-				defaultIPAddress := []string{cut.DefaultNetworkIPAddress}
+				defaultIPAddress := []string{pod.DefaultNetworkIPAddress}
 				gomega.Expect(env).To(gomega.Not(gomega.BeNil()))
-				gomega.Expect(env.NodesUnderTest[cut.NodeName]).To(gomega.Not(gomega.BeNil()))
-				gomega.Expect(env.NodesUnderTest[cut.NodeName].DebugContainer.GetOc()).To(gomega.Not(gomega.BeNil()))
-				nodeOc := env.NodesUnderTest[cut.NodeName].DebugContainer.GetOc()
-				processContainerIpsPerNet(&cut.ContainerIdentifier, netKey, defaultIPAddress, netsUnderTest, nodeOc)
+				gomega.Expect(env.NodesUnderTest[pod.NodeName]).To(gomega.Not(gomega.BeNil()))
+				gomega.Expect(env.NodesUnderTest[pod.NodeName].DebugContainer.GetOc()).To(gomega.Not(gomega.BeNil()))
+				nodeOc := env.NodesUnderTest[pod.NodeName].DebugContainer.GetOc()
+				processContainerIpsPerNet(&pod.ContainerIdentifier, netKey, defaultIPAddress, netsUnderTest, nodeOc)
 			}
 			badNets := runNetworkingTests(netsUnderTest, count)
 

--- a/test-network-function/platform/suite.go
+++ b/test-network-function/platform/suite.go
@@ -28,6 +28,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/test-network-function/test-network-function/pkg/config"
+	"github.com/test-network-function/test-network-function/pkg/config/configsections"
 	"github.com/test-network-function/test-network-function/pkg/tnf/testcases"
 
 	"github.com/test-network-function/test-network-function/test-network-function/common"
@@ -168,7 +169,7 @@ func testIsRedHatRelease(env *config.TestEnvironment) {
 }
 
 // testContainerIsRedHatRelease tests whether the container attached to oc is Red Hat based.
-func testContainerIsRedHatRelease(cut *config.Container) {
+func testContainerIsRedHatRelease(cut *configsections.Container) {
 	podName := cut.GetOc().GetPodName()
 	containerName := cut.GetOc().GetPodContainerName()
 	context := cut.GetOc()


### PR DESCRIPTION
Stores the context of one container in the pod object to get access to the networking namespace of the pod (since all container share the same net namespace). 
The networking tests are now ran per pod instead of per container