### PR TITLE
Update multus networking TC id

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -9,174 +9,6 @@ So, a Test Case could be composed by one or many Test Case Building Blocks.
 
 Test Cases are the specifications used to perform a meaningful test.  Test cases may run once, or several times against several targets.  CNF Certification includes a number of normative and informative tests to ensure CNFs follow best practices.  Here is the list of available 
 
-### networking
-
-#### icmpv4-connectivity
-
-Property|Description
----|---
-Test Case Name|icmpv4-connectivity
-Test Case Label|networking-icmpv4-connectivity
-Unique ID|http://test-network-function.com/testcases/networking/icmpv4-connectivity
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/networking/icmpv4-connectivity checks that each CNF Container is able to communicate via ICMPv4 on the Default OpenShift network.  This test case requires the Deployment of the debug daemonset.
-Result Type|normative
-Suggested Remediation|Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases, CNFs may require routing table changes in order to communicate over the Default network. To exclude a particular container from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
-#### icmpv4-connectivity-multus
-
-Property|Description
----|---
-Test Case Name|icmpv4-connectivity-multus
-Test Case Label|networking-icmpv4-connectivity-multus
-Unique ID|http://test-network-function.com/testcases/networking/icmpv4-connectivity-multus
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/networking/icmpv4-connectivity-multus checks that each CNF Container is able to communicate via ICMPv4 on the Multus network(s).  This test case requires the Deployment of the debug daemonset.
-Result Type|normative
-Suggested Remediation|Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases, CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular container from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
-#### service-type
-
-Property|Description
----|---
-Test Case Name|service-type
-Test Case Label|networking-service-type
-Unique ID|http://test-network-function.com/testcases/networking/service-type
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/networking/service-type tests that each CNF Service does not utilize NodePort(s).
-Result Type|normative
-Suggested Remediation|Ensure Services are not configured to use NodePort(s).
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.3.1
-
-### observability
-
-#### container-logging
-
-Property|Description
----|---
-Test Case Name|container-logging
-Test Case Label|observability-container-logging
-Unique ID|http://test-network-function.com/testcases/observability/container-logging
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/observability/container-logging check that all containers under test use standard input output and standard error when logging
-Result Type|informative
-Suggested Remediation|make sure containers are not redirecting stdout/stderr
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 11.1
-#### crd-status
-
-Property|Description
----|---
-Test Case Name|crd-status
-Test Case Label|observability-crd-status
-Unique ID|http://test-network-function.com/testcases/observability/crd-status
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/observability/crd-status checks that all CRDs have a status subresource specification.
-Result Type|informative
-Suggested Remediation|make sure that all the CRDs have a meaningful status specification.
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
-
-### operator
-
-#### install-source
-
-Property|Description
----|---
-Test Case Name|install-source
-Test Case Label|operator-install-source
-Unique ID|http://test-network-function.com/testcases/operator/install-source
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/operator/install-source tests whether a CNF Operator is installed via OLM.
-Result Type|normative
-Suggested Remediation|Ensure that your Operator is installed via OLM.
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2.12 and Section 6.3.3
-#### install-status
-
-Property|Description
----|---
-Test Case Name|install-status
-Test Case Label|operator-install-status
-Unique ID|http://test-network-function.com/testcases/operator/install-status
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/operator/install-status Ensures that CNF Operators abide by best practices.  The following is tested: 1. The Operator CSV reports "Installed" status. 2. The operator is not installed with privileged rights. Test passes if clusterPermissions is not present in the CSV manifest or is present  with no resourceNames under its rules.
-Result Type|normative
-Suggested Remediation|Ensure that your Operator abides by the Operator Best Practices mentioned in the description.
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2.12 and Section 6.3.3
-
-### platform-alteration
-
-#### base-image
-
-Property|Description
----|---
-Test Case Name|base-image
-Test Case Label|platform-alteration-base-image
-Unique ID|http://test-network-function.com/testcases/platform-alteration/base-image
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/platform-alteration/base-image ensures that the Container Base Image is not altered post-startup.  This test is a heuristic, and ensures that there are no changes to the following directories: 1) /var/lib/rpm 2) /var/lib/dpkg 3) /bin 4) /sbin 5) /lib 6) /lib64 7) /usr/bin 8) /usr/sbin 9) /usr/lib 10) /usr/lib64
-Result Type|normative
-Suggested Remediation|Ensure that Container applications do not modify the Container Base Image.  In particular, ensure that the following directories are not modified: 1) /var/lib/rpm 2) /var/lib/dpkg 3) /bin 4) /sbin 5) /lib 6) /lib64 7) /usr/bin 8) /usr/sbin 9) /usr/lib 10) /usr/lib64 Ensure that all required binaries are built directly into the container image, and are not installed post startup.
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2.2
-#### boot-params
-
-Property|Description
----|---
-Test Case Name|boot-params
-Test Case Label|platform-alteration-boot-params
-Unique ID|http://test-network-function.com/testcases/platform-alteration/boot-params
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/platform-alteration/boot-params tests that boot parameters are set through the MachineConfigOperator, and not set manually on the Node.
-Result Type|normative
-Suggested Remediation|Ensure that boot parameters are set directly through the MachineConfigOperator, or indirectly through the PerformanceAddonOperator.  Boot parameters should not be changed directly through the Node, as OpenShift should manage the changes for you.
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2.13 and 6.2.14
-#### hugepages-config
-
-Property|Description
----|---
-Test Case Name|hugepages-config
-Test Case Label|platform-alteration-hugepages-config
-Unique ID|http://test-network-function.com/testcases/platform-alteration/hugepages-config
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/platform-alteration/hugepages-config checks to see that HugePage settings have been configured through MachineConfig, and not manually on the underlying Node.  This test case applies only to Nodes that are configured with the "worker" MachineConfigSet.  First, the "worker" MachineConfig is polled, and the Hugepage settings are extracted.  Next, the underlying Nodes are polled for configured HugePages through inspection of /proc/meminfo.  The results are compared, and the test passes only if they are the same.
-Result Type|normative
-Suggested Remediation|HugePage settings should be configured either directly through the MachineConfigOperator or indirectly using the PerformanceAddonOperator.  This ensures that OpenShift is aware of the special MachineConfig requirements, and can provision your CNF on a Node that is part of the corresponding MachineConfigSet.  Avoid making changes directly to an underlying Node, and let OpenShift handle the heavy lifting of configuring advanced settings.
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
-#### isredhat-release
-
-Property|Description
----|---
-Test Case Name|isredhat-release
-Test Case Label|platform-alteration-isredhat-release
-Unique ID|http://test-network-function.com/testcases/platform-alteration/isredhat-release
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/platform-alteration/isredhat-release verifies if the container base image is redhat.
-Result Type|normative
-Suggested Remediation|build a new docker image that's based on UBI (redhat universal base image).
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
-#### sysctl-config
-
-Property|Description
----|---
-Test Case Name|sysctl-config
-Test Case Label|platform-alteration-sysctl-config
-Unique ID|http://test-network-function.com/testcases/platform-alteration/sysctl-config
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/platform-alteration/sysctl-config tests that no one has changed the node's sysctl configs after the node 			was created, the tests works by checking if the sysctl configs are consistent with the 			MachineConfig CR which defines how the node should be configured
-Result Type|normative
-Suggested Remediation|You should recreate the node or change the sysctls, recreating is recommended because there might be other unknown changes
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
-#### tainted-node-kernel
-
-Property|Description
----|---
-Test Case Name|tainted-node-kernel
-Test Case Label|platform-alteration-tainted-node-kernel
-Unique ID|http://test-network-function.com/testcases/platform-alteration/tainted-node-kernel
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/platform-alteration/tainted-node-kernel ensures that the Node(s) hosting CNFs do not utilize tainted kernels. This test case is especially important to support Highly Available CNFs, since when a CNF is re-instantiated on a backup Node, that Node's kernel may not have the same hacks.'
-Result Type|normative
-Suggested Remediation|Test failure indicates that the underlying Node's' kernel is tainted.  Ensure that you have not altered underlying Node(s) kernels in order to run the CNF.
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2.14
-
 ### access-control
 
 #### cluster-role-bindings
@@ -452,6 +284,174 @@ Description|http://test-network-function.com/testcases/lifecycle/statefulset-sca
 Result Type|normative
 Suggested Remediation|Make sure CNF statefulsets/replica sets can scale in/out successfully.
 Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
+
+### networking
+
+#### icmpv4-connectivity
+
+Property|Description
+---|---
+Test Case Name|icmpv4-connectivity
+Test Case Label|networking-icmpv4-connectivity
+Unique ID|http://test-network-function.com/testcases/networking/icmpv4-connectivity
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/icmpv4-connectivity checks that each CNF Container is able to communicate via ICMPv4 on the Default OpenShift network.  This test case requires the Deployment of the debug daemonset.
+Result Type|normative
+Suggested Remediation|Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases, CNFs may require routing table changes in order to communicate over the Default network. To exclude a particular pod from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
+#### icmpv4-connectivity-multus
+
+Property|Description
+---|---
+Test Case Name|icmpv4-connectivity-multus
+Test Case Label|networking-icmpv4-connectivity-multus
+Unique ID|http://test-network-function.com/testcases/networking/icmpv4-connectivity-multus
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/icmpv4-connectivity-multus checks that each CNF Container is able to communicate via ICMPv4 on the Multus network(s).  This test case requires the Deployment of the debug daemonset.
+Result Type|normative
+Suggested Remediation|Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases, CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular pod from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
+#### service-type
+
+Property|Description
+---|---
+Test Case Name|service-type
+Test Case Label|networking-service-type
+Unique ID|http://test-network-function.com/testcases/networking/service-type
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/service-type tests that each CNF Service does not utilize NodePort(s).
+Result Type|normative
+Suggested Remediation|Ensure Services are not configured to use NodePort(s).
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.3.1
+
+### observability
+
+#### container-logging
+
+Property|Description
+---|---
+Test Case Name|container-logging
+Test Case Label|observability-container-logging
+Unique ID|http://test-network-function.com/testcases/observability/container-logging
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/observability/container-logging check that all containers under test use standard input output and standard error when logging
+Result Type|informative
+Suggested Remediation|make sure containers are not redirecting stdout/stderr
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 11.1
+#### crd-status
+
+Property|Description
+---|---
+Test Case Name|crd-status
+Test Case Label|observability-crd-status
+Unique ID|http://test-network-function.com/testcases/observability/crd-status
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/observability/crd-status checks that all CRDs have a status subresource specification.
+Result Type|informative
+Suggested Remediation|make sure that all the CRDs have a meaningful status specification.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
+
+### operator
+
+#### install-source
+
+Property|Description
+---|---
+Test Case Name|install-source
+Test Case Label|operator-install-source
+Unique ID|http://test-network-function.com/testcases/operator/install-source
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/operator/install-source tests whether a CNF Operator is installed via OLM.
+Result Type|normative
+Suggested Remediation|Ensure that your Operator is installed via OLM.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2.12 and Section 6.3.3
+#### install-status
+
+Property|Description
+---|---
+Test Case Name|install-status
+Test Case Label|operator-install-status
+Unique ID|http://test-network-function.com/testcases/operator/install-status
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/operator/install-status Ensures that CNF Operators abide by best practices.  The following is tested: 1. The Operator CSV reports "Installed" status. 2. The operator is not installed with privileged rights. Test passes if clusterPermissions is not present in the CSV manifest or is present  with no resourceNames under its rules.
+Result Type|normative
+Suggested Remediation|Ensure that your Operator abides by the Operator Best Practices mentioned in the description.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2.12 and Section 6.3.3
+
+### platform-alteration
+
+#### base-image
+
+Property|Description
+---|---
+Test Case Name|base-image
+Test Case Label|platform-alteration-base-image
+Unique ID|http://test-network-function.com/testcases/platform-alteration/base-image
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/platform-alteration/base-image ensures that the Container Base Image is not altered post-startup.  This test is a heuristic, and ensures that there are no changes to the following directories: 1) /var/lib/rpm 2) /var/lib/dpkg 3) /bin 4) /sbin 5) /lib 6) /lib64 7) /usr/bin 8) /usr/sbin 9) /usr/lib 10) /usr/lib64
+Result Type|normative
+Suggested Remediation|Ensure that Container applications do not modify the Container Base Image.  In particular, ensure that the following directories are not modified: 1) /var/lib/rpm 2) /var/lib/dpkg 3) /bin 4) /sbin 5) /lib 6) /lib64 7) /usr/bin 8) /usr/sbin 9) /usr/lib 10) /usr/lib64 Ensure that all required binaries are built directly into the container image, and are not installed post startup.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2.2
+#### boot-params
+
+Property|Description
+---|---
+Test Case Name|boot-params
+Test Case Label|platform-alteration-boot-params
+Unique ID|http://test-network-function.com/testcases/platform-alteration/boot-params
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/platform-alteration/boot-params tests that boot parameters are set through the MachineConfigOperator, and not set manually on the Node.
+Result Type|normative
+Suggested Remediation|Ensure that boot parameters are set directly through the MachineConfigOperator, or indirectly through the PerformanceAddonOperator.  Boot parameters should not be changed directly through the Node, as OpenShift should manage the changes for you.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2.13 and 6.2.14
+#### hugepages-config
+
+Property|Description
+---|---
+Test Case Name|hugepages-config
+Test Case Label|platform-alteration-hugepages-config
+Unique ID|http://test-network-function.com/testcases/platform-alteration/hugepages-config
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/platform-alteration/hugepages-config checks to see that HugePage settings have been configured through MachineConfig, and not manually on the underlying Node.  This test case applies only to Nodes that are configured with the "worker" MachineConfigSet.  First, the "worker" MachineConfig is polled, and the Hugepage settings are extracted.  Next, the underlying Nodes are polled for configured HugePages through inspection of /proc/meminfo.  The results are compared, and the test passes only if they are the same.
+Result Type|normative
+Suggested Remediation|HugePage settings should be configured either directly through the MachineConfigOperator or indirectly using the PerformanceAddonOperator.  This ensures that OpenShift is aware of the special MachineConfig requirements, and can provision your CNF on a Node that is part of the corresponding MachineConfigSet.  Avoid making changes directly to an underlying Node, and let OpenShift handle the heavy lifting of configuring advanced settings.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
+#### isredhat-release
+
+Property|Description
+---|---
+Test Case Name|isredhat-release
+Test Case Label|platform-alteration-isredhat-release
+Unique ID|http://test-network-function.com/testcases/platform-alteration/isredhat-release
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/platform-alteration/isredhat-release verifies if the container base image is redhat.
+Result Type|normative
+Suggested Remediation|build a new docker image that's based on UBI (redhat universal base image).
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
+#### sysctl-config
+
+Property|Description
+---|---
+Test Case Name|sysctl-config
+Test Case Label|platform-alteration-sysctl-config
+Unique ID|http://test-network-function.com/testcases/platform-alteration/sysctl-config
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/platform-alteration/sysctl-config tests that no one has changed the node's sysctl configs after the node 			was created, the tests works by checking if the sysctl configs are consistent with the 			MachineConfig CR which defines how the node should be configured
+Result Type|normative
+Suggested Remediation|You should recreate the node or change the sysctls, recreating is recommended because there might be other unknown changes
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
+#### tainted-node-kernel
+
+Property|Description
+---|---
+Test Case Name|tainted-node-kernel
+Test Case Label|platform-alteration-tainted-node-kernel
+Unique ID|http://test-network-function.com/testcases/platform-alteration/tainted-node-kernel
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/platform-alteration/tainted-node-kernel ensures that the Node(s) hosting CNFs do not utilize tainted kernels. This test case is especially important to support Highly Available CNFs, since when a CNF is re-instantiated on a backup Node, that Node's kernel may not have the same hacks.'
+Result Type|normative
+Suggested Remediation|Test failure indicates that the underlying Node's' kernel is tainted.  Ensure that you have not altered underlying Node(s) kernels in order to run the CNF.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2.14
 
 ## Test Case Building Blocks Catalog
 

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -426,7 +426,19 @@ Unique ID|http://test-network-function.com/testcases/networking/icmpv4-connectiv
 Version|v1.0.0
 Description|http://test-network-function.com/testcases/networking/icmpv4-connectivity checks that each CNF Container is able to communicate via ICMPv4 on the Default OpenShift network.  This test case requires the Deployment of the debug daemonset. 
 Result Type|normative
-Suggested Remediation|Ensure that the CNF is able to communicate via the Default OpenShift network.  In some rare cases, CNFs may require routing table changes in order to communicate over the Default network.  In other cases, if the Container base image does not provide the "ip" or "ping" binaries, this test may not be applicable.  For instructions on how to exclude a particular container from ICMPv4 connectivity tests, consult: [README.md](https://github.com/test-network-function/test-network-function#issue-161-some-containers-under-test-do-not-contain-ping-or-ip-binary-utilities).
+Suggested Remediation|Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases, CNFs may require routing table changes in order to communicate over the Default network. For instructions on how to exclude a particular container from ICMPv4 connectivity tests, consult: [README.md](https://github.com/test-network-function/test-network-function#issue-161-some-containers-under-test-do-not-contain-ping-or-ip-binary-utilities).
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
+#### icmpv4-connectivity-multus
+
+Property|Description
+---|---
+Test Case Name|icmpv4-connectivity-multus
+Test Case Label|networking-icmpv4-connectivity-multus
+Unique ID|http://test-network-function.com/testcases/networking/icmpv4-connectivity-multus
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/icmpv4-connectivity-multus checks that each CNF Container is able to communicate via ICMPv4 on the Multus network(s).  This test case requires the Deployment of the debug daemonset.
+Result Type|normative
+Suggested Remediation|Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases, CNFs may require routing table changes in order to communicate over the Multus network(s). For instructions on how to exclude a particular container from ICMPv4 connectivity tests, consult: [README.md](https://github.com/test-network-function/test-network-function#issue-161-some-containers-under-test-do-not-contain-ping-or-ip-binary-utilities).
 Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
 #### service-type
 

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -9,6 +9,45 @@ So, a Test Case could be composed by one or many Test Case Building Blocks.
 
 Test Cases are the specifications used to perform a meaningful test.  Test cases may run once, or several times against several targets.  CNF Certification includes a number of normative and informative tests to ensure CNFs follow best practices.  Here is the list of available 
 
+### networking
+
+#### icmpv4-connectivity
+
+Property|Description
+---|---
+Test Case Name|icmpv4-connectivity
+Test Case Label|networking-icmpv4-connectivity
+Unique ID|http://test-network-function.com/testcases/networking/icmpv4-connectivity
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/icmpv4-connectivity checks that each CNF Container is able to communicate via ICMPv4 on the Default OpenShift network.  This test case requires the Deployment of the debug daemonset.
+Result Type|normative
+Suggested Remediation|Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases, CNFs may require routing table changes in order to communicate over the Default network. To exclude a particular container from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
+#### icmpv4-connectivity-multus
+
+Property|Description
+---|---
+Test Case Name|icmpv4-connectivity-multus
+Test Case Label|networking-icmpv4-connectivity-multus
+Unique ID|http://test-network-function.com/testcases/networking/icmpv4-connectivity-multus
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/icmpv4-connectivity-multus checks that each CNF Container is able to communicate via ICMPv4 on the Multus network(s).  This test case requires the Deployment of the debug daemonset.
+Result Type|normative
+Suggested Remediation|Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases, CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular container from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
+#### service-type
+
+Property|Description
+---|---
+Test Case Name|service-type
+Test Case Label|networking-service-type
+Unique ID|http://test-network-function.com/testcases/networking/service-type
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/service-type tests that each CNF Service does not utilize NodePort(s).
+Result Type|normative
+Suggested Remediation|Ensure Services are not configured to use NodePort(s).
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.3.1
+
 ### observability
 
 #### container-logging
@@ -413,45 +452,6 @@ Description|http://test-network-function.com/testcases/lifecycle/statefulset-sca
 Result Type|normative
 Suggested Remediation|Make sure CNF statefulsets/replica sets can scale in/out successfully.
 Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
-
-### networking
-
-#### icmpv4-connectivity
-
-Property|Description
----|---
-Test Case Name|icmpv4-connectivity
-Test Case Label|networking-icmpv4-connectivity
-Unique ID|http://test-network-function.com/testcases/networking/icmpv4-connectivity
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/networking/icmpv4-connectivity checks that each CNF Container is able to communicate via ICMPv4 on the Default OpenShift network.  This test case requires the Deployment of the debug daemonset. 
-Result Type|normative
-Suggested Remediation|Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases, CNFs may require routing table changes in order to communicate over the Default network. For instructions on how to exclude a particular container from ICMPv4 connectivity tests, consult: [README.md](https://github.com/test-network-function/test-network-function#issue-161-some-containers-under-test-do-not-contain-ping-or-ip-binary-utilities).
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
-#### icmpv4-connectivity-multus
-
-Property|Description
----|---
-Test Case Name|icmpv4-connectivity-multus
-Test Case Label|networking-icmpv4-connectivity-multus
-Unique ID|http://test-network-function.com/testcases/networking/icmpv4-connectivity-multus
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/networking/icmpv4-connectivity-multus checks that each CNF Container is able to communicate via ICMPv4 on the Multus network(s).  This test case requires the Deployment of the debug daemonset.
-Result Type|normative
-Suggested Remediation|Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases, CNFs may require routing table changes in order to communicate over the Multus network(s). For instructions on how to exclude a particular container from ICMPv4 connectivity tests, consult: [README.md](https://github.com/test-network-function/test-network-function#issue-161-some-containers-under-test-do-not-contain-ping-or-ip-binary-utilities).
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
-#### service-type
-
-Property|Description
----|---
-Test Case Name|service-type
-Test Case Label|networking-service-type
-Unique ID|http://test-network-function.com/testcases/networking/service-type
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/networking/service-type tests that each CNF Service does not utilize NodePort(s).
-Result Type|normative
-Suggested Remediation|Ensure Services are not configured to use NodePort(s).
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.3.1
 
 ## Test Case Building Blocks Catalog
 

--- a/test-network-function/identifiers/identifiers.go
+++ b/test-network-function/identifiers/identifiers.go
@@ -97,8 +97,8 @@ var (
 		Url:     formTestURL(common.NetworkingTestKey, "icmpv4-connectivity"),
 		Version: versionOne,
 	}
-	// TestICMPv4ConnectivityIdentifierMultus tests icmpv4 connectivity on multus networks.
-	TestICMPv4ConnectivityIdentifierMultus = claim.Identifier{
+	// TestICMPv4ConnectivityMultusIdentifier tests icmpv4 connectivity on multus networks.
+	TestICMPv4ConnectivityMultusIdentifier = claim.Identifier{
 		Url:     formTestURL(common.NetworkingTestKey, "icmpv4-connectivity-multus"),
 		Version: versionOne,
 	}
@@ -354,13 +354,13 @@ test case requires the Deployment of the debug daemonset.`),
 		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2",
 	},
 
-	TestICMPv4ConnectivityIdentifierMultus: {
-		Identifier: TestICMPv4ConnectivityIdentifierMultus,
+	TestICMPv4ConnectivityMultusIdentifier: {
+		Identifier: TestICMPv4ConnectivityMultusIdentifier,
 		Type:       normativeResult,
 		Remediation: `Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases,
 CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular pod
 from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.`,
-		Description: formDescription(TestICMPv4ConnectivityIdentifierMultus,
+		Description: formDescription(TestICMPv4ConnectivityMultusIdentifier,
 			`checks that each CNF Container is able to communicate via ICMPv4 on the Multus network(s).  This
 test case requires the Deployment of the debug daemonset.`),
 		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2",

--- a/test-network-function/identifiers/identifiers.go
+++ b/test-network-function/identifiers/identifiers.go
@@ -97,6 +97,11 @@ var (
 		Url:     formTestURL(common.NetworkingTestKey, "icmpv4-connectivity"),
 		Version: versionOne,
 	}
+	// TestICMPv4ConnectivityIdentifierMultus tests icmpv4 connectivity on multus networks.
+	TestICMPv4ConnectivityIdentifierMultus = claim.Identifier{
+		Url:     formTestURL(common.NetworkingTestKey, "icmpv4-connectivity-multus"),
+		Version: versionOne,
+	}
 	// TestNamespaceBestPracticesIdentifier ensures the namespace has followed best namespace practices.
 	TestNamespaceBestPracticesIdentifier = claim.Identifier{
 		Url:     formTestURL(common.AccessControlTestKey, "namespace"),
@@ -340,15 +345,27 @@ they are the same.`),
 	TestICMPv4ConnectivityIdentifier: {
 		Identifier: TestICMPv4ConnectivityIdentifier,
 		Type:       normativeResult,
-		Remediation: `Ensure that the CNF is able to communicate via the Default OpenShift network.  In some rare cases,
-CNFs may require routing table changes in order to communicate over the Default network.  In other cases, if the
-Container base image does not provide the "ip" or "ping" binaries, this test may not be applicable.  For instructions on
+		Remediation: `Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases,
+CNFs may require routing table changes in order to communicate over the Default network. For instructions on
 how to exclude a particular container from ICMPv4 connectivity tests, consult:
 [README.md](https://github.com/test-network-function/test-network-function#issue-161-some-containers-under-test-do-not-contain-ping-or-ip-binary-utilities).`,
 		Description: formDescription(TestICMPv4ConnectivityIdentifier,
 			`checks that each CNF Container is able to communicate via ICMPv4 on the Default OpenShift network.  This
 test case requires the Deployment of the debug daemonset.
 `),
+		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2",
+	},
+
+	TestICMPv4ConnectivityIdentifierMultus: {
+		Identifier: TestICMPv4ConnectivityIdentifierMultus,
+		Type:       normativeResult,
+		Remediation: `Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases,
+CNFs may require routing table changes in order to communicate over the Multus network(s). For instructions on
+how to exclude a particular container from ICMPv4 connectivity tests, consult:
+[README.md](https://github.com/test-network-function/test-network-function#issue-161-some-containers-under-test-do-not-contain-ping-or-ip-binary-utilities).`,
+		Description: formDescription(TestICMPv4ConnectivityIdentifierMultus,
+			`checks that each CNF Container is able to communicate via ICMPv4 on the Multus network(s).  This
+test case requires the Deployment of the debug daemonset.`),
 		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2",
 	},
 

--- a/test-network-function/identifiers/identifiers.go
+++ b/test-network-function/identifiers/identifiers.go
@@ -346,13 +346,11 @@ they are the same.`),
 		Identifier: TestICMPv4ConnectivityIdentifier,
 		Type:       normativeResult,
 		Remediation: `Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases,
-CNFs may require routing table changes in order to communicate over the Default network. For instructions on
-how to exclude a particular container from ICMPv4 connectivity tests, consult:
-[README.md](https://github.com/test-network-function/test-network-function#issue-161-some-containers-under-test-do-not-contain-ping-or-ip-binary-utilities).`,
+CNFs may require routing table changes in order to communicate over the Default network. To exclude a particular container
+from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.`,
 		Description: formDescription(TestICMPv4ConnectivityIdentifier,
 			`checks that each CNF Container is able to communicate via ICMPv4 on the Default OpenShift network.  This
-test case requires the Deployment of the debug daemonset.
-`),
+test case requires the Deployment of the debug daemonset.`),
 		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2",
 	},
 
@@ -360,9 +358,8 @@ test case requires the Deployment of the debug daemonset.
 		Identifier: TestICMPv4ConnectivityIdentifierMultus,
 		Type:       normativeResult,
 		Remediation: `Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases,
-CNFs may require routing table changes in order to communicate over the Multus network(s). For instructions on
-how to exclude a particular container from ICMPv4 connectivity tests, consult:
-[README.md](https://github.com/test-network-function/test-network-function#issue-161-some-containers-under-test-do-not-contain-ping-or-ip-binary-utilities).`,
+CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular container
+from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.`,
 		Description: formDescription(TestICMPv4ConnectivityIdentifierMultus,
 			`checks that each CNF Container is able to communicate via ICMPv4 on the Multus network(s).  This
 test case requires the Deployment of the debug daemonset.`),

--- a/test-network-function/identifiers/identifiers.go
+++ b/test-network-function/identifiers/identifiers.go
@@ -346,7 +346,7 @@ they are the same.`),
 		Identifier: TestICMPv4ConnectivityIdentifier,
 		Type:       normativeResult,
 		Remediation: `Ensure that the CNF is able to communicate via the Default OpenShift network. In some rare cases,
-CNFs may require routing table changes in order to communicate over the Default network. To exclude a particular container
+CNFs may require routing table changes in order to communicate over the Default network. To exclude a particular pod
 from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.`,
 		Description: formDescription(TestICMPv4ConnectivityIdentifier,
 			`checks that each CNF Container is able to communicate via ICMPv4 on the Default OpenShift network.  This
@@ -358,7 +358,7 @@ test case requires the Deployment of the debug daemonset.`),
 		Identifier: TestICMPv4ConnectivityIdentifierMultus,
 		Type:       normativeResult,
 		Remediation: `Ensure that the CNF is able to communicate via the Multus network(s). In some rare cases,
-CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular container
+CNFs may require routing table changes in order to communicate over the Multus network(s). To exclude a particular pod
 from ICMPv4 connectivity tests, add the test-network-function.com/skip_connectivity_tests label to it. The label value is not important, only its presence.`,
 		Description: formDescription(TestICMPv4ConnectivityIdentifierMultus,
 			`checks that each CNF Container is able to communicate via ICMPv4 on the Multus network(s).  This

--- a/test-network-function/networking/suite.go
+++ b/test-network-function/networking/suite.go
@@ -230,7 +230,7 @@ func testDefaultNetworkConnectivity(env *config.TestEnvironment, count int) {
 }
 func testMultusNetworkConnectivity(env *config.TestEnvironment, count int) {
 	ginkgo.When("Testing Multus network connectivity", func() {
-		testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv4ConnectivityIdentifierMultus)
+		testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv4ConnectivityMultusIdentifier)
 		ginkgo.It(testID, ginkgo.Label(testID), func() {
 			netsUnderTest := make(map[string]netTestContext)
 			for _, pod := range env.PodsUnderTest {

--- a/test-network-function/networking/suite.go
+++ b/test-network-function/networking/suite.go
@@ -230,7 +230,7 @@ func testDefaultNetworkConnectivity(env *config.TestEnvironment, count int) {
 }
 func testMultusNetworkConnectivity(env *config.TestEnvironment, count int) {
 	ginkgo.When("Testing Multus network connectivity", func() {
-		testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv4ConnectivityIdentifier)
+		testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestICMPv4ConnectivityIdentifierMultus)
 		ginkgo.It(testID, ginkgo.Label(testID), func() {
 			netsUnderTest := make(map[string]netTestContext)
 			for _, pod := range env.PodsUnderTest {


### PR DESCRIPTION
Previously, the networking ICMPv4 connectivity tests for the default and
Multus networks shared the same id. This commit splits that, so each
test case has a single id.

Fixes #576