### PR TITLE
Add allow-list for tainted modules

### DIFF
--- a/pkg/config/configsections/certified_request_test.go
+++ b/pkg/config/configsections/certified_request_test.go
@@ -56,6 +56,10 @@ var (
 		Name:         "etcd",
 		Organization: "Core OS",
 	}
+
+	acceptedTaintsRequestInfo = AcceptedTaintsRequestInfo{
+		Module: "taint1",
+	}
 )
 
 var (
@@ -120,6 +124,9 @@ func buildRequestConfig() *TestConfiguration {
 		jenkinsOperatorRequestInfo,
 		etcdOperatorRequestInfo,
 	}
+	conf.AcceptedTaints = []AcceptedTaintsRequestInfo{
+		acceptedTaintsRequestInfo,
+	}
 	return conf
 }
 
@@ -132,6 +139,7 @@ func RequestTest(t *testing.T, marshalFun marshalFunc, unmarshalFun unmarshalFun
 	assert.Equal(t, len(cfg.CertifiedOperatorInfo), 2)
 	assert.Equal(t, cfg.CertifiedOperatorInfo[0], jenkinsOperatorRequestInfo)
 	assert.Equal(t, cfg.CertifiedOperatorInfo[1], etcdOperatorRequestInfo)
+	assert.Equal(t, cfg.AcceptedTaints[0], acceptedTaintsRequestInfo)
 }
 
 func TestRequestInfos(t *testing.T) {

--- a/pkg/config/configsections/certified_request_test.go
+++ b/pkg/config/configsections/certified_request_test.go
@@ -57,7 +57,7 @@ var (
 		Organization: "Core OS",
 	}
 
-	acceptedKernelTaintsRequestInfo = AcceptedKernelTaintsRequestInfo{
+	acceptedKernelTaintsInfo = AcceptedKernelTaintsInfo{
 		Module: "taint1",
 	}
 )
@@ -124,8 +124,8 @@ func buildRequestConfig() *TestConfiguration {
 		jenkinsOperatorRequestInfo,
 		etcdOperatorRequestInfo,
 	}
-	conf.AcceptedKernelTaints = []AcceptedKernelTaintsRequestInfo{
-		acceptedKernelTaintsRequestInfo,
+	conf.AcceptedKernelTaints = []AcceptedKernelTaintsInfo{
+		acceptedKernelTaintsInfo,
 	}
 	return conf
 }
@@ -139,7 +139,7 @@ func RequestTest(t *testing.T, marshalFun marshalFunc, unmarshalFun unmarshalFun
 	assert.Equal(t, len(cfg.CertifiedOperatorInfo), 2)
 	assert.Equal(t, cfg.CertifiedOperatorInfo[0], jenkinsOperatorRequestInfo)
 	assert.Equal(t, cfg.CertifiedOperatorInfo[1], etcdOperatorRequestInfo)
-	assert.Equal(t, cfg.AcceptedKernelTaints[0], acceptedKernelTaintsRequestInfo)
+	assert.Equal(t, cfg.AcceptedKernelTaints[0], acceptedKernelTaintsInfo)
 }
 
 func TestRequestInfos(t *testing.T) {

--- a/pkg/config/configsections/certified_request_test.go
+++ b/pkg/config/configsections/certified_request_test.go
@@ -57,7 +57,7 @@ var (
 		Organization: "Core OS",
 	}
 
-	acceptedTaintsRequestInfo = AcceptedTaintsRequestInfo{
+	acceptedKernelTaintsRequestInfo = AcceptedKernelTaintsRequestInfo{
 		Module: "taint1",
 	}
 )
@@ -124,8 +124,8 @@ func buildRequestConfig() *TestConfiguration {
 		jenkinsOperatorRequestInfo,
 		etcdOperatorRequestInfo,
 	}
-	conf.AcceptedTaints = []AcceptedTaintsRequestInfo{
-		acceptedTaintsRequestInfo,
+	conf.AcceptedKernelTaints = []AcceptedKernelTaintsRequestInfo{
+		acceptedKernelTaintsRequestInfo,
 	}
 	return conf
 }
@@ -139,7 +139,7 @@ func RequestTest(t *testing.T, marshalFun marshalFunc, unmarshalFun unmarshalFun
 	assert.Equal(t, len(cfg.CertifiedOperatorInfo), 2)
 	assert.Equal(t, cfg.CertifiedOperatorInfo[0], jenkinsOperatorRequestInfo)
 	assert.Equal(t, cfg.CertifiedOperatorInfo[1], etcdOperatorRequestInfo)
-	assert.Equal(t, cfg.AcceptedTaints[0], acceptedTaintsRequestInfo)
+	assert.Equal(t, cfg.AcceptedKernelTaints[0], acceptedKernelTaintsRequestInfo)
 }
 
 func TestRequestInfos(t *testing.T) {

--- a/pkg/config/configsections/common.go
+++ b/pkg/config/configsections/common.go
@@ -64,6 +64,8 @@ type TestConfiguration struct {
 	CertifiedOperatorInfo []CertifiedOperatorRequestInfo `yaml:"certifiedoperatorinfo,omitempty" json:"certifiedoperatorinfo,omitempty"`
 	// CRDs section.
 	CrdFilters []CrdFilter `yaml:"targetCrdFilters" json:"targetCrdFilters"`
+	// AcceptedTaints
+	AcceptedTaints []AcceptedTaintsRequestInfo `yaml:"acceptedTaints,omitempty" json:"acceptedTaints,omitempty"`
 }
 
 // TestPartner contains the helper containers that can be used to facilitate tests

--- a/pkg/config/configsections/common.go
+++ b/pkg/config/configsections/common.go
@@ -65,7 +65,7 @@ type TestConfiguration struct {
 	// CRDs section.
 	CrdFilters []CrdFilter `yaml:"targetCrdFilters" json:"targetCrdFilters"`
 	// AcceptedKernelTaints
-	AcceptedKernelTaints []AcceptedKernelTaintsInfo `yaml:"AcceptedKernelTaints,omitempty" json:"AcceptedKernelTaints,omitempty"`
+	AcceptedKernelTaints []AcceptedKernelTaintsInfo `yaml:"acceptedKernelTaints,omitempty" json:"acceptedKernelTaints,omitempty"`
 }
 
 // TestPartner contains the helper containers that can be used to facilitate tests

--- a/pkg/config/configsections/common.go
+++ b/pkg/config/configsections/common.go
@@ -64,8 +64,8 @@ type TestConfiguration struct {
 	CertifiedOperatorInfo []CertifiedOperatorRequestInfo `yaml:"certifiedoperatorinfo,omitempty" json:"certifiedoperatorinfo,omitempty"`
 	// CRDs section.
 	CrdFilters []CrdFilter `yaml:"targetCrdFilters" json:"targetCrdFilters"`
-	// AcceptedTaints
-	AcceptedTaints []AcceptedTaintsRequestInfo `yaml:"acceptedTaints,omitempty" json:"acceptedTaints,omitempty"`
+	// AcceptedKernelTaints
+	AcceptedKernelTaints []AcceptedKernelTaintsRequestInfo `yaml:"AcceptedKernelTaints,omitempty" json:"AcceptedKernelTaints,omitempty"`
 }
 
 // TestPartner contains the helper containers that can be used to facilitate tests

--- a/pkg/config/configsections/common.go
+++ b/pkg/config/configsections/common.go
@@ -65,7 +65,7 @@ type TestConfiguration struct {
 	// CRDs section.
 	CrdFilters []CrdFilter `yaml:"targetCrdFilters" json:"targetCrdFilters"`
 	// AcceptedKernelTaints
-	AcceptedKernelTaints []AcceptedKernelTaintsRequestInfo `yaml:"AcceptedKernelTaints,omitempty" json:"AcceptedKernelTaints,omitempty"`
+	AcceptedKernelTaints []AcceptedKernelTaintsInfo `yaml:"AcceptedKernelTaints,omitempty" json:"AcceptedKernelTaints,omitempty"`
 }
 
 // TestPartner contains the helper containers that can be used to facilitate tests

--- a/pkg/config/configsections/request.go
+++ b/pkg/config/configsections/request.go
@@ -36,8 +36,8 @@ type CertifiedOperatorRequestInfo struct {
 	Organization string `yaml:"organization" json:"organization"`
 }
 
-// AcceptedKernelTaintsRequestInfo contains all certified operator request info
-type AcceptedKernelTaintsRequestInfo struct {
+// AcceptedKernelTaintsInfo contains all certified operator request info
+type AcceptedKernelTaintsInfo struct {
 
 	// Accepted modules that cause taints that we want to supply to the test suite
 	Module string `yaml:"module" json:"module"`

--- a/pkg/config/configsections/request.go
+++ b/pkg/config/configsections/request.go
@@ -36,8 +36,8 @@ type CertifiedOperatorRequestInfo struct {
 	Organization string `yaml:"organization" json:"organization"`
 }
 
-// AcceptedTaintsRequestInfo contains all certified operator request info
-type AcceptedTaintsRequestInfo struct {
+// AcceptedKernelTaintsRequestInfo contains all certified operator request info
+type AcceptedKernelTaintsRequestInfo struct {
 
 	// Accepted modules that cause taints that we want to supply to the test suite
 	Module string `yaml:"module" json:"module"`

--- a/pkg/config/configsections/request.go
+++ b/pkg/config/configsections/request.go
@@ -35,3 +35,10 @@ type CertifiedOperatorRequestInfo struct {
 	// Organization as understood by the operator publisher , e.g. `redhat-marketplace`
 	Organization string `yaml:"organization" json:"organization"`
 }
+
+// AcceptedTaintsRequestInfo contains all certified operator request info
+type AcceptedTaintsRequestInfo struct {
+
+	// Accepted modules that cause taints that we want to supply to the test suite
+	Module string `yaml:"module" json:"module"`
+}

--- a/pkg/config/testdata/tnf_test_config.yml
+++ b/pkg/config/testdata/tnf_test_config.yml
@@ -29,6 +29,9 @@ certifiedcontainerinfo:
 certifiedoperatorinfo:
   - name: etcd-operator
     organization: redhat-marketplace
+acceptedTaints:
+  - module: "taint1"
+  - module: "taint2"
 targetCrdFilters:
   - nameSuffix: "group1.test1.com"
   - nameSuffix: "test2.com"

--- a/pkg/config/testdata/tnf_test_config.yml
+++ b/pkg/config/testdata/tnf_test_config.yml
@@ -29,7 +29,7 @@ certifiedcontainerinfo:
 certifiedoperatorinfo:
   - name: etcd-operator
     organization: redhat-marketplace
-acceptedTaints:
+acceptedKernelTaints:
   - module: "taint1"
   - module: "taint2"
 targetCrdFilters:

--- a/pkg/tnf/handlers/nodetainted/nodetainted.go
+++ b/pkg/tnf/handlers/nodetainted/nodetainted.go
@@ -47,6 +47,16 @@ func NewNodeTainted(timeout time.Duration) *NodeTainted {
 	}
 }
 
+func NewLSMod(timeout time.Duration) *NodeTainted {
+	return &NodeTainted{
+		timeout: timeout,
+		result:  tnf.ERROR,
+		args: []string{
+			"lsmod",
+		},
+	}
+}
+
 // Args returns the command line args for the test.
 func (nt *NodeTainted) Args() []string {
 	return nt.args

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2022 Red Hat, Inc.
+// Copyright (C) 2020-2022 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -190,6 +190,7 @@ func GetModulesFromNode(nodeName string, nodeOc *interactive.Oc) []string {
 	//nolint:goconst // used only once
 	command := `chroot /host lsmod | awk '{ print $1 }' | grep -v Module`
 	output := RunCommandInNode(nodeName, nodeOc, command, timeoutPid)
+	output = strings.ReplaceAll(output, "\t", "")
 	return strings.Split(strings.ReplaceAll(output, "\r\n", "\n"), "\n")
 }
 
@@ -197,7 +198,6 @@ func ModuleInTree(nodeName, moduleName string, nodeOc *interactive.Oc) bool {
 	command := `chroot /host modinfo ` + moduleName + ` | awk '{ print $1 }'`
 	cmdOutput := RunCommandInNode(nodeName, nodeOc, command, timeoutPid)
 	outputSlice := strings.Split(strings.ReplaceAll(cmdOutput, "\r\n", "\n"), "\n")
-
 	// The output, if found, should look something like 'intree:   Y'.
 	// As long as we look for 'intree:' being contained in the string we should be good to go.
 	found := false
@@ -231,6 +231,5 @@ func StringInSlice(s []string, str string) bool {
 			return true
 		}
 	}
-
 	return false
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2022 Red Hat, Inc.
+// Copyright (C) 2020-2022 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,8 +20,10 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/test-network-function/test-network-function/pkg/tnf/interactive"
 )
 
 const (
@@ -110,32 +112,77 @@ func TestAddNsenterPrefix(t *testing.T) {
 	}
 }
 
-func TestStringInSlice(t *testing.T) {
+func TestModuleInTree(t *testing.T) {
 	testCases := []struct {
-		testString     string
-		testSlice      []string
-		expectedExists bool
+		fakeOutput string
+		isInTree   bool
 	}{
 		{
-			testString: "apples",
-			testSlice: []string{
-				"bananas",
-				"oranges",
-				"apples",
-			},
-			expectedExists: true,
+			fakeOutput: `filename:
+			alias:
+			version:
+			license:
+			srcversion:
+			depends:
+			retpoline:
+			intree:
+			name:
+			vermagic:`,
+			isInTree: true,
 		},
 		{
-			testString: "tacos",
-			testSlice: []string{
-				"burritos",
-				"enchiladas",
-			},
-			expectedExists: false,
+			fakeOutput: `filename:
+			alias:
+			version:
+			license:
+			srcversion:
+			depends:
+			retpoline:
+			name:
+			vermagic:`,
+			isInTree: false,
 		},
 	}
 
+	origFunc := RunCommandInNode
+	defer func() {
+		RunCommandInNode = origFunc
+	}()
 	for _, tc := range testCases {
-		assert.Equal(t, tc.expectedExists, StringInSlice(tc.testSlice, tc.testString))
+		RunCommandInNode = func(nodeName string, nodeOc *interactive.Oc, command string, timeout time.Duration) string {
+			return tc.fakeOutput
+		}
+		assert.Equal(t, tc.isInTree, ModuleInTree("testNode", "testModule", nil))
+	}
+}
+
+func TestGetModulesFromNode(t *testing.T) {
+	testCases := []struct {
+		fakeOutput     string
+		expectedOutput []string
+	}{
+		{
+			fakeOutput: `xt_nat
+			ip_vs_sh
+			vboxsf
+			vboxguest`,
+			expectedOutput: []string{
+				"xt_nat",
+				"ip_vs_sh",
+				"vboxsf",
+				"vboxguest",
+			},
+		},
+	}
+
+	origFunc := RunCommandInNode
+	defer func() {
+		RunCommandInNode = origFunc
+	}()
+	for _, tc := range testCases {
+		RunCommandInNode = func(nodeName string, nodeOc *interactive.Oc, command string, timeout time.Duration) string {
+			return strings.TrimSpace(tc.fakeOutput)
+		}
+		assert.Equal(t, tc.expectedOutput, GetModulesFromNode("testNode", nil))
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -109,3 +109,33 @@ func TestAddNsenterPrefix(t *testing.T) {
 		assert.Equal(t, tc.expectedString, AddNsenterPrefix(tc.containerID))
 	}
 }
+
+func TestStringInSlice(t *testing.T) {
+	testCases := []struct {
+		testString     string
+		testSlice      []string
+		expectedExists bool
+	}{
+		{
+			testString: "apples",
+			testSlice: []string{
+				"bananas",
+				"oranges",
+				"apples",
+			},
+			expectedExists: true,
+		},
+		{
+			testString: "tacos",
+			testSlice: []string{
+				"burritos",
+				"enchiladas",
+			},
+			expectedExists: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedExists, StringInSlice(tc.testSlice, tc.testString))
+	}
+}

--- a/test-network-function/platform/suite.go
+++ b/test-network-function/platform/suite.go
@@ -417,7 +417,7 @@ func testTainted(env *config.TestEnvironment) {
 
 					// We only will fail the tainted kernel check if the reason for the taint
 					// only pertains to `module was loaded`.
-					log.Debug("Checking for module was loaded taints")
+					log.Debug("Checking for 'module was loaded' taints")
 					moduleCheck := false
 					for _, it := range individualTaints {
 						if strings.Contains(it, `module was loaded`) {

--- a/test-network-function/platform/suite.go
+++ b/test-network-function/platform/suite.go
@@ -149,11 +149,11 @@ var _ = ginkgo.Describe(common.PlatformAlterationTestKey, func() {
 		// use this boolean to turn off tests that require OS packages
 		if !common.IsNonOcpCluster() {
 			testContainersFsDiff(env)
-			testTainted(env)
 			testHugepages(env)
 			testBootParams(env)
 			testSysctlConfigs(env)
 		}
+		testTainted(env) // minikube tainted kernels are allowed via config
 		testIsRedHatRelease(env)
 	}
 })

--- a/test-network-function/platform/suite.go
+++ b/test-network-function/platform/suite.go
@@ -435,6 +435,8 @@ func testTainted(env *config.TestEnvironment) {
 						// If the module info does not contain this string, the module is "tainted".
 						taintedModules := getTaintedModules(modules, node.Name, context)
 						log.Debug("Collected all of the tainted modules: ", taintedModules)
+						tnf.ClaimFilePrintf("Kernel Modules loaded that cause taints: ", taintedModules)
+						tnf.ClaimFilePrintf("Modules allowed via configuration: ", env.Config.AcceptedKernelTaints)
 
 						// Looks through the accepted taints listed in the tnf-config file.
 						// If all of the tainted modules show up in the configuration file, don't fail the test.

--- a/test-network-function/platform/suite.go
+++ b/test-network-function/platform/suite.go
@@ -369,18 +369,23 @@ func testSysctlConfigsHelper(podName, podNamespace string, context *interactive.
 	}
 }
 
-func printTainted(bitmap uint64) string {
+//nolint:gocritic
+func printTainted(bitmap uint64) (string, []string) {
 	values := getTaintedBitValues()
 	var out string
+	individualTaints := []string{}
 	for i := 0; i < 32; i++ {
 		bit := (bitmap >> i) & 1
 		if bit == 1 {
 			out += fmt.Sprintf("%s, ", values[i])
+			// Storing the individual taint messages for extra parsing.
+			individualTaints = append(individualTaints, values[i])
 		}
 	}
-	return out
+	return out, individualTaints
 }
 
+//nolint:funlen
 func testTainted(env *config.TestEnvironment) {
 	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestNonTaintedNodeKernelsIdentifier)
 	ginkgo.It(testID, ginkgo.Label(testID), func() {
@@ -392,11 +397,14 @@ func testTainted(env *config.TestEnvironment) {
 			if !node.HasDebugPod() {
 				continue
 			}
+			log.Debug("Node has a debug pod")
 			context := node.DebugContainer.GetOc()
 			tester := nodetainted.NewNodeTainted(common.DefaultTimeout)
 			test, err := tnf.NewTest(context.GetExpecter(), tester, []reel.Handler{tester}, context.GetErrorChannel())
 			gomega.Expect(err).To(gomega.BeNil())
+
 			var message string
+			nodeTaintsAccepted := true
 			test.RunWithCallbacks(func() {
 				message = fmt.Sprintf("Decoded tainted kernel causes (code=0) for node %s : None\n", node.Name)
 			}, func() {
@@ -405,9 +413,40 @@ func testTainted(env *config.TestEnvironment) {
 				if err != nil {
 					message = fmt.Sprintf("Could not decode tainted kernel causes (code=%d) for node %s\n", taintedBitmap, node.Name)
 				} else {
-					message = fmt.Sprintf("Decoded tainted kernel causes (code=%d) for node %s : %s\n", taintedBitmap, node.Name, printTainted(taintedBitmap))
+					taintMsg, individualTaints := printTainted(taintedBitmap)
+
+					// We only will fail the tainted kernel check if the reason for the taint
+					// only pertains to `module was loaded`.
+					log.Debug("Checking for module was loaded taints")
+					moduleCheck := false
+					for _, it := range individualTaints {
+						if strings.Contains(it, `module was loaded`) {
+							moduleCheck = true
+							break
+						}
+					}
+
+					if moduleCheck {
+						// Retrieve the modules from the node.
+						modules := utils.GetModulesFromNode(node.Name, context)
+						log.Debug("Got the modules from node")
+
+						// Loop through the modules looking for `InTree: Y`.
+						// If the module info does not contain this string, the module is "tainted".
+						taintedModules := getTaintedModules(modules, node.Name, context)
+						log.Debug("Collected all of the tainted modules: ", taintedModules)
+
+						// Looks through the accepted taints listed in the tnf-config file.
+						// If all of the tainted modules show up in the configuration file, don't fail the test.
+						nodeTaintsAccepted = taintsAccepted(env.Config.AcceptedTaints, taintedModules)
+					}
+
+					message = fmt.Sprintf("Decoded tainted kernel causes (code=%d) for node %s : %s\n", taintedBitmap, node.Name, taintMsg)
 				}
-				taintedNodes = append(taintedNodes, node.Name)
+				// Only add the tainted node to the slice if the taint is acceptable.
+				if !nodeTaintsAccepted {
+					taintedNodes = append(taintedNodes, node.Name)
+				}
 			}, func(e error) {
 				message = fmt.Sprintf("Failed to retrieve tainted kernel code for node %s\n", node.Name)
 				errNodes = append(errNodes, node.Name)
@@ -418,9 +457,42 @@ func testTainted(env *config.TestEnvironment) {
 				log.Errorf("Ginkgo writer could not write because: %s", err)
 			}
 		}
+
+		// We are expecting tainted nodes to be Nil, but only if:
+		// 1) The reason for the tainted node is contains(`module was loaded`)
+		// 2) The modules loaded are all whitelisted.
 		gomega.Expect(taintedNodes).To(gomega.BeNil())
 		gomega.Expect(errNodes).To(gomega.BeNil())
 	})
+}
+
+func taintsAccepted(confTaints []configsections.AcceptedTaintsRequestInfo, taintedModules []string) bool {
+	for _, taintedModule := range taintedModules {
+		found := false
+		log.Debug("Accepted Taints from Config: ", confTaints)
+		for _, confTaint := range confTaints {
+			log.Debug(fmt.Sprintf("Comparing confTaint: %s to taintedModule: %s", confTaint.Module, taintedModule))
+			if confTaint.Module == taintedModule {
+				found = true
+			}
+		}
+
+		if !found {
+			// Tainted modules were not found to be in the allow-list.
+			return false
+		}
+	}
+	return true
+}
+
+func getTaintedModules(modules []string, nodeName string, ctx *interactive.Oc) []string {
+	taintedModules := []string{}
+	for _, module := range modules {
+		if !utils.ModuleInTree(nodeName, module, ctx) {
+			taintedModules = append(taintedModules, module)
+		}
+	}
+	return taintedModules
 }
 
 func hugepageSizeToInt(s string) int {

--- a/test-network-function/platform/suite.go
+++ b/test-network-function/platform/suite.go
@@ -438,7 +438,7 @@ func testTainted(env *config.TestEnvironment) {
 
 						// Looks through the accepted taints listed in the tnf-config file.
 						// If all of the tainted modules show up in the configuration file, don't fail the test.
-						nodeTaintsAccepted = taintsAccepted(env.Config.AcceptedTaints, taintedModules)
+						nodeTaintsAccepted = taintsAccepted(env.Config.AcceptedKernelTaints, taintedModules)
 					}
 
 					message = fmt.Sprintf("Decoded tainted kernel causes (code=%d) for node %s : %s\n", taintedBitmap, node.Name, taintMsg)
@@ -466,7 +466,7 @@ func testTainted(env *config.TestEnvironment) {
 	})
 }
 
-func taintsAccepted(confTaints []configsections.AcceptedTaintsRequestInfo, taintedModules []string) bool {
+func taintsAccepted(confTaints []configsections.AcceptedKernelTaintsRequestInfo, taintedModules []string) bool {
 	for _, taintedModule := range taintedModules {
 		found := false
 		log.Debug("Accepted Taints from Config: ", confTaints)

--- a/test-network-function/platform/suite.go
+++ b/test-network-function/platform/suite.go
@@ -466,7 +466,7 @@ func testTainted(env *config.TestEnvironment) {
 	})
 }
 
-func taintsAccepted(confTaints []configsections.AcceptedKernelTaintsRequestInfo, taintedModules []string) bool {
+func taintsAccepted(confTaints []configsections.AcceptedKernelTaintsInfo, taintedModules []string) bool {
 	for _, taintedModule := range taintedModules {
 		found := false
 		log.Debug("Accepted Taints from Config: ", confTaints)

--- a/test-network-function/platform/suite_test.go
+++ b/test-network-function/platform/suite_test.go
@@ -56,7 +56,7 @@ var (
 	testKernelArgsHpDefSizePlusPairs3 = []string{"systemd.cpu_affinity=0,1,40,41,20,21,60,61", "default_hugepagesz=1G", "hugepagesz=1G", "hugepages=16", "hugepagesz=2M", "hugepages=256", "nmi_watchdog=0"}
 )
 
-func Test_decodeKernelTaints(t *testing.T) {
+func TestDecodeKernelTaints(t *testing.T) {
 	taint1, taint1Slice := decodeKernelTaints(2048)
 	assert.Equal(t, taint1, "workaround for bug in platform firmware applied, ")
 	assert.Len(t, taint1Slice, 1)
@@ -162,7 +162,6 @@ func Test_hugepagesFromKernelArgsFunc(t *testing.T) {
 	}
 }
 
-//nolint:funlen
 func TestGetOutOfTreeModules(t *testing.T) {
 	testCases := []struct {
 		modules                []string // Note: We are only using one item in this list for the test.
@@ -174,15 +173,7 @@ func TestGetOutOfTreeModules(t *testing.T) {
 				"test1",
 			},
 			modinfo: map[string]string{
-				"test1": `filename:
-				description:
-				author:
-				license:
-				depends:
-				retpoline:
-				intree:
-				name:
-				vermagic:`,
+				"test1": `Y`,
 			},
 			expectedTaintedModules: []string{}, // test1 is 'intree'
 		},
@@ -191,14 +182,7 @@ func TestGetOutOfTreeModules(t *testing.T) {
 				"test2",
 			},
 			modinfo: map[string]string{
-				"test2": `filename:
-				description:
-				author:
-				license:
-				depends:
-				retpoline:
-				name:
-				vermagic:`,
+				"test2": ``,
 			},
 			expectedTaintedModules: []string{"test2"}, // test2 is not 'intree'
 		},

--- a/test-network-function/platform/suite_test.go
+++ b/test-network-function/platform/suite_test.go
@@ -56,12 +56,12 @@ var (
 	testKernelArgsHpDefSizePlusPairs3 = []string{"systemd.cpu_affinity=0,1,40,41,20,21,60,61", "default_hugepagesz=1G", "hugepagesz=1G", "hugepages=16", "hugepagesz=2M", "hugepages=256", "nmi_watchdog=0"}
 )
 
-func Test_printTainted(t *testing.T) {
-	taint1, taint1Slice := printTainted(2048)
+func Test_decodeKernelTaints(t *testing.T) {
+	taint1, taint1Slice := decodeKernelTaints(2048)
 	assert.Equal(t, taint1, "workaround for bug in platform firmware applied, ")
 	assert.Len(t, taint1Slice, 1)
 
-	taint2, taint2Slice := printTainted(32769)
+	taint2, taint2Slice := decodeKernelTaints(32769)
 	assert.Equal(t, taint2, "proprietary module was loaded, kernel has been live patched, ")
 	assert.Len(t, taint2Slice, 2)
 }
@@ -163,7 +163,7 @@ func Test_hugepagesFromKernelArgsFunc(t *testing.T) {
 }
 
 //nolint:funlen
-func TestGetTaintedModules(t *testing.T) {
+func TestGetOutOfTreeModules(t *testing.T) {
 	testCases := []struct {
 		modules                []string // Note: We are only using one item in this list for the test.
 		modinfo                map[string]string
@@ -215,7 +215,7 @@ func TestGetTaintedModules(t *testing.T) {
 		utils.RunCommandInNode = func(nodeName string, nodeOc *interactive.Oc, command string, timeout time.Duration) string {
 			return tc.modinfo[tc.modules[0]]
 		}
-		assert.Equal(t, tc.expectedTaintedModules, getTaintedModules(tc.modules, "testnode", nil))
+		assert.Equal(t, tc.expectedTaintedModules, getOutOfTreeModules(tc.modules, "testnode", nil))
 	}
 }
 

--- a/test-network-function/platform/suite_test.go
+++ b/test-network-function/platform/suite_test.go
@@ -221,12 +221,12 @@ func TestGetTaintedModules(t *testing.T) {
 
 func TestTaintsAccepted(t *testing.T) {
 	testCases := []struct {
-		confTaints     []configsections.AcceptedKernelTaintsRequestInfo
+		confTaints     []configsections.AcceptedKernelTaintsInfo
 		taintedModules []string
 		expected       bool
 	}{
 		{
-			confTaints: []configsections.AcceptedKernelTaintsRequestInfo{
+			confTaints: []configsections.AcceptedKernelTaintsInfo{
 				{
 					Module: "taint1",
 				},
@@ -237,14 +237,14 @@ func TestTaintsAccepted(t *testing.T) {
 			expected: true,
 		},
 		{
-			confTaints: []configsections.AcceptedKernelTaintsRequestInfo{}, // no accepted modules
+			confTaints: []configsections.AcceptedKernelTaintsInfo{}, // no accepted modules
 			taintedModules: []string{
 				"taint1",
 			},
 			expected: false,
 		},
 		{ // We have no tainted modules, so the configuration does not matter.
-			confTaints: []configsections.AcceptedKernelTaintsRequestInfo{
+			confTaints: []configsections.AcceptedKernelTaintsInfo{
 				{
 					Module: "taint1",
 				},

--- a/test-network-function/platform/suite_test.go
+++ b/test-network-function/platform/suite_test.go
@@ -221,12 +221,12 @@ func TestGetTaintedModules(t *testing.T) {
 
 func TestTaintsAccepted(t *testing.T) {
 	testCases := []struct {
-		confTaints     []configsections.AcceptedTaintsRequestInfo
+		confTaints     []configsections.AcceptedKernelTaintsRequestInfo
 		taintedModules []string
 		expected       bool
 	}{
 		{
-			confTaints: []configsections.AcceptedTaintsRequestInfo{
+			confTaints: []configsections.AcceptedKernelTaintsRequestInfo{
 				{
 					Module: "taint1",
 				},
@@ -237,14 +237,14 @@ func TestTaintsAccepted(t *testing.T) {
 			expected: true,
 		},
 		{
-			confTaints: []configsections.AcceptedTaintsRequestInfo{}, // no accepted modules
+			confTaints: []configsections.AcceptedKernelTaintsRequestInfo{}, // no accepted modules
 			taintedModules: []string{
 				"taint1",
 			},
 			expected: false,
 		},
 		{ // We have no tainted modules, so the configuration does not matter.
-			confTaints: []configsections.AcceptedTaintsRequestInfo{
+			confTaints: []configsections.AcceptedKernelTaintsRequestInfo{
 				{
 					Module: "taint1",
 				},

--- a/test-network-function/tnf_config.yml
+++ b/test-network-function/tnf_config.yml
@@ -14,6 +14,6 @@ checkDiscoveredContainerCertificationStatus: false
 certifiedoperatorinfo:
   - name: etcd
     organization: community-operators # working example
-acceptedTaints:
+acceptedKernelTaints:
   - module: vboxsf
   - module: vboxguest

--- a/test-network-function/tnf_config.yml
+++ b/test-network-function/tnf_config.yml
@@ -14,3 +14,6 @@ checkDiscoveredContainerCertificationStatus: false
 certifiedoperatorinfo:
   - name: etcd
     organization: community-operators # working example
+acceptedTaints:
+  - module: vboxsf
+  - module: vboxguest


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/CNFCERT-204

If a node encounters a tainted kernel failure only pertaining to `module was loaded`-type errors, then the code will compare the list of loaded/out-of-tree modules to see if they are allowed via the configurable allow-list.

Set the allow list in the `tnf-config.yml` such as follows:
```
acceptedKernelTaints:
  - module: "taint1"
  - module: "taint2"
  ```

I added to the `test-network-function/tnf_config.yml` configuration file the following allowed tainted modules, vboxsf and vboxguest.  This will "allow" these two modules to taint the kernel and get away with it.  😉 

Marked this as WIP as I work out naming convention, possibly making up some more unit tests/breaking down the function into smaller chunks.