### PR TITLE
Update Go to 1.17.6

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.17.6
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.17.6
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.17.6
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.17.6
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN yum install -y gcc git jq make wget
 
 # Install Go binary
 ENV GO_DL_URL="https://golang.org/dl"
-ENV GO_BIN_TAR="go1.17.5.linux-amd64.tar.gz"
+ENV GO_BIN_TAR="go1.17.6.linux-amd64.tar.gz"
 ENV GO_BIN_URL_x86_64=${GO_DL_URL}/${GO_BIN_TAR}
 ENV GOPATH="/root/go"
 RUN if [[ "$(uname -m)" -eq "x86_64" ]] ; then \


### PR DESCRIPTION
Go 1.17.6 is now available.

https://twitter.com/golang/status/1479199301352013829

From their release page:
```
go1.17.6 (released 2022-01-06) includes fixes to the compiler, linker, runtime, and the crypto/x509, net/http, and reflect packages. See the Go 1.17.6 milestone on our issue tracker for details.
```