### PR TITLE
Ensure catalog suites are always ordered

### DIFF
--- a/cmd/tnf/generate/catalog/catalog.go
+++ b/cmd/tnf/generate/catalog/catalog.go
@@ -201,6 +201,9 @@ func outputTestCases() {
 	// we need the list of suite's names
 	suites := getSuitesFromIdentifiers(keys)
 
+	// Sort the list of suite names
+	sort.Strings(suites)
+
 	// Iterating the map by test and suite names
 	for _, suite := range suites {
 		fmt.Fprintf(os.Stdout, "\n### %s\n\n", suite)


### PR DESCRIPTION
Previously, we were not ensuring an order when getting the list of
suites in outputTestCases(). This caused issues, because the CATALOG.md
file could be changed by any PR, breaking order.

Fixes #583