### PR TITLE
Re-enable the unused linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,6 +88,7 @@ linters:
     - typecheck
     - unconvert
     - unparam
+    - unused
     - varcheck
     - whitespace
   # don't enable:
@@ -104,7 +105,6 @@ linters:
   # - scopelint
   # - structcheck
   # - testpackage
-  # - unused
   # - wsl
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/pkg/tnf/handlers/base/redhat/version.go
+++ b/pkg/tnf/handlers/base/redhat/version.go
@@ -47,8 +47,6 @@ type Release struct {
 	timeout time.Duration
 	// args stores the command and arguments.
 	args []string
-	// release contains the contents of /etc/redhat-release if it exists, or "NOT Red Hat Based" if it does not exist.
-	release string
 	// isRedHatBased contains whether the container is based on Red Hat technologies.
 	isRedHatBased bool
 }


### PR DESCRIPTION
`release` was not used and subsequently removed.