### PR TITLE
Include logic to retrieve indexImage and bundleImage for CSV

### DIFF
--- a/pkg/config/autodiscover/autodiscover_targets.go
+++ b/pkg/config/autodiscover/autodiscover_targets.go
@@ -17,6 +17,7 @@
 package autodiscover
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -238,6 +239,7 @@ func buildOperatorFromCSVResource(csv *CSVResource, istest bool) (op configsecti
 		op.SubscriptionName = subscriptionName[0]
 	}
 	if !istest {
+		op.BundleImage, op.IndexImage = setBundleAndIndexImage(op.Name, op.Namespace)
 		op.Packag, op.Org, op.Version = csv.PackOrgVersion(op.Name)
 	}
 
@@ -258,6 +260,31 @@ func getConfiguredOperatorTests() []string {
 	}
 	log.WithField("opTests", opTests).Infof("got all tests from %s.", testcases.ConfiguredTestFile)
 	return opTests
+}
+
+// setBundleAndIndexImage provides the bundle image and index image for a given CSV.
+// These variables are saved in the `configsections.Operator` in order to be used by DCI,
+// which obtains them from the claim.json and provides them to preflight suite.
+func setBundleAndIndexImage(csvName string, csvNamespace string) (string, string) {
+	// First step is to extract the installplan related to the csv
+	installPlanCmd := fmt.Sprintf("oc get installplan -n %s | grep %q | awk '{ print $1 }'", csvNamespace, csvName)
+	installPlan := execCommandOutput(installPlanCmd)
+
+	// Then, retrieve the bundle image using the installplan
+	bundleImageCmd := fmt.Sprintf("oc get installplan -n %s %s -o json | jq .status.bundleLookups[].path", csvNamespace, installPlan)
+	bundleImage := execCommandOutput(bundleImageCmd)
+
+	// To retrieve the index image, we firstly need the catalogsource and the namespace in which it is deployed
+	catalogSourceNameCmd := fmt.Sprintf("oc get installplan -n %s %s -o json | jq .status.bundleLookups[].catalogSourceRef.name", csvNamespace, installPlan)
+	catalogSourceNamespaceCmd := fmt.Sprintf("oc get installplan -n %s %s -o json | jq .status.bundleLookups[].catalogSourceRef.namespace", csvNamespace, installPlan)
+	catalogSourceName := execCommandOutput(catalogSourceNameCmd)
+	catalogSourceNamespace := execCommandOutput(catalogSourceNamespaceCmd)
+
+	// Then, we can retrieve the index image
+	indexImageCmd := fmt.Sprintf("oc get catalogsource -n %s %s -o json | jq .spec.image", catalogSourceNamespace, catalogSourceName)
+	indexImage := execCommandOutput(indexImageCmd)
+
+	return bundleImage, indexImage
 }
 
 // getClusterCrdNames returns a list of crd names found in the cluster.

--- a/pkg/config/configsections/common.go
+++ b/pkg/config/configsections/common.go
@@ -39,6 +39,12 @@ type Operator struct {
 	// Subscription name is required field, Name of used subscription.
 	SubscriptionName string `yaml:"subscriptionName" json:"subscriptionName"`
 
+	// BundleImage is the URL referencing the bundle image
+	BundleImage string `yaml:"bundleImage" json:"bundleImage"`
+
+	// IndexImage is the URL referencing the index image
+	IndexImage string `yaml:"indexImage" json:"indexImage"`
+
 	Packag string `yaml:"packag" json:"packag"`
 
 	Org string `yaml:"Org" json:"Org"`


### PR DESCRIPTION
This change is required for DCI in order to:

- Define indexImage and bundleImage in the Operator type
- Include the logic needed to retrieve these values and save them in the new variables created
- Provide these variables in the claim.json

With this, we can run CNF Cert Suite on DCI and, based on the claim.json file, we can retrieve all the data from the operators tested to feed preflight test suite.