### PR TITLE
Add case for docker-pullable

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -161,20 +161,13 @@ func NewGenericTesterAndValidate(templateFile, schemaPath string, values map[str
 	return tester, handlers
 }
 
-// RunCommandInContainerNameSpace run a host command in a running container with the nsenter command.
-// takes the container nodeName, node Oc and container UID
-// returns the raw output of the command
-func RunCommandInContainerNameSpace(nodeName string, nodeOc *interactive.Oc, containerID, command string, timeout time.Duration, runtime string) string {
-	containrPID := GetContainerPID(nodeName, nodeOc, containerID, runtime)
-	nodeCommand := "nsenter -t " + containrPID + " -n " + command
-	return RunCommandInNode(nodeName, nodeOc, nodeCommand, timeout)
-}
-
 // GetContainerPID gets the container PID from a kubernetes node, Oc and container PID
 func GetContainerPID(nodeName string, nodeOc *interactive.Oc, containerID, runtime string) string {
 	command := ""
 	switch runtime {
 	case "docker": //nolint:goconst // used only once
+		command = "chroot /host docker inspect -f '{{.State.Pid}}' " + containerID + " 2>/dev/null"
+	case "docker-pullable": //nolint:goconst // used only once
 		command = "chroot /host docker inspect -f '{{.State.Pid}}' " + containerID + " 2>/dev/null"
 	case "cri-o": //nolint:goconst // used only once
 		command = "chroot /host crictl inspect --output go-template --template '{{.info.pid}}' " + containerID + " 2>/dev/null"


### PR DESCRIPTION
A couple of changes:
- RunCommandInContainerNameSpace was unused.  Removed.
- `docker-pullable` was part of the imageID in my latest version of minikube.  See:

```
"imageID": "docker-pullable://quay.io/testnetworkfunction/debug-partner@sha256:8a9b6370854f37acb25f22177ba4185b04a41100fb482b863817c9642c8dc474",
```