### PR TITLE
Backport for skip Multus label support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ For Network Interfaces:
 * If the above is not present, the k8s.v1.cni.cncf.io/networks-status annotation is checked and the "interface" from the first entry found with "default"=true is used. This annotation is automatically managed in OpenShift but may not be present in K8s.
 
 The label test-network-function.com/skip_connectivity_tests excludes pods from connectivity tests. The label value is not important, only its presence.
+The label test-network-function.com/skip_multus_connectivity_tests excludes pods from Multus connectivity tests only. The label value is not important, only its presence. Note: if both labels are present the test-network-function.com/skip_connectivity_tests takes precedence.
 
 #### operators
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,7 +115,10 @@ type TestEnvironment struct {
 	// ContainersToExcludeFromConnectivityTests is a set used for storing the containers that should be excluded from
 	// connectivity testing.
 	ContainersToExcludeFromConnectivityTests map[configsections.ContainerIdentifier]interface{}
-	Config                                   configsections.TestConfiguration
+	// ContainersToExcludeFromMultusConnectivityTests is a set used for storing the containers that should be excluded from
+	// Multus connectivity testing.
+	ContainersToExcludeFromMultusConnectivityTests map[configsections.ContainerIdentifier]interface{}
+	Config                                         configsections.TestConfiguration
 	// loaded tracks if the config has been loaded to prevent it being reloaded.
 	loaded bool
 	// set when an intrusive test has done something that would cause Pod/Container to be recreated
@@ -231,11 +234,14 @@ func (env *TestEnvironment) doAutodiscover() {
 	}
 
 	env.ContainersToExcludeFromConnectivityTests = make(map[configsections.ContainerIdentifier]interface{})
+	env.ContainersToExcludeFromMultusConnectivityTests = make(map[configsections.ContainerIdentifier]interface{})
 
 	for _, cid := range env.Config.ExcludeContainersFromConnectivityTests {
 		env.ContainersToExcludeFromConnectivityTests[cid] = ""
 	}
-
+	for _, cid := range env.Config.ExcludeContainersFromMultusConnectivityTests {
+		env.ContainersToExcludeFromMultusConnectivityTests[cid] = ""
+	}
 	env.ContainersUnderTest = env.createContainerMapWithOcSession(env.Config.ContainerList)
 	env.PodsUnderTest = env.Config.PodsUnderTest
 
@@ -246,6 +252,7 @@ func (env *TestEnvironment) doAutodiscover() {
 	env.recordPodsDefaultIP(env.PodsUnderTest)
 	for _, cid := range env.Config.Partner.ContainersDebugList {
 		env.ContainersToExcludeFromConnectivityTests[cid.ContainerIdentifier] = ""
+		env.ContainersToExcludeFromMultusConnectivityTests[cid.ContainerIdentifier] = ""
 	}
 	env.DeploymentsUnderTest = env.Config.DeploymentsUnderTest
 	env.StateFulSetUnderTest = env.Config.StateFulSetUnderTest
@@ -344,6 +351,7 @@ func (env *TestEnvironment) discoverNodes() {
 	autodiscover.FindDebugPods(&env.Config.Partner)
 	for _, debugPod := range env.Config.Partner.ContainersDebugList {
 		env.ContainersToExcludeFromConnectivityTests[debugPod.ContainerIdentifier] = ""
+		env.ContainersToExcludeFromMultusConnectivityTests[debugPod.ContainerIdentifier] = ""
 	}
 	env.DebugContainers = env.createContainerMapWithOcSession(env.Config.Partner.ContainersDebugList)
 

--- a/pkg/config/configsections/common.go
+++ b/pkg/config/configsections/common.go
@@ -94,7 +94,9 @@ type TestTarget struct {
 	// ContainerConfigList is the list of containers that needs to be tested.
 	ContainerList []Container `yaml:"containersUnderTest" json:"containersUnderTest"`
 	// ExcludeContainersFromConnectivityTests excludes specific containers from network connectivity tests.  This is particularly useful for containers that don't have ping available.
-	ExcludeContainersFromConnectivityTests []ContainerIdentifier `yaml:"excludeContainersFromConnectivityTests" json:"excludeContainersFromConnectivityTests"`
+	ExcludeContainersFromConnectivityTests []ContainerIdentifier `yaml:"ExcludeContainersFromConnectivityTests" json:"ExcludeContainersFromConnectivityTests"`
+	// ExcludeContainersFromMultusConnectivityTests excludes specific containers from network connectivity tests.  This is particularly useful for containers that don't have ping available.
+	ExcludeContainersFromMultusConnectivityTests []ContainerIdentifier `yaml:"excludeContainersFromMultusConnectivityTests" json:"excludeContainersFromMultusConnectivityTests"`
 	// Operator is the list of operator objects that needs to be tested.
 	Operators []Operator `yaml:"operators,omitempty"  json:"operators,omitempty"`
 	//

--- a/test-network-function/networking/suite.go
+++ b/test-network-function/networking/suite.go
@@ -263,7 +263,8 @@ func testMultusNetworkConnectivity(env *config.TestEnvironment, count int) {
 				if _, ok := env.ContainersToExcludeFromConnectivityTests[aContainerInPod.ContainerIdentifier]; ok {
 					tnf.ClaimFilePrintf("Skipping pod %s because it is excluded from all connectivity tests", pod.Name)
 					continue
-				} else if _, ok := env.ContainersToExcludeFromMultusConnectivityTests[aContainerInPod.ContainerIdentifier]; ok {
+				} 
+				if _, ok := env.ContainersToExcludeFromMultusConnectivityTests[aContainerInPod.ContainerIdentifier]; ok {
 					tnf.ClaimFilePrintf("Skipping pod %s because it is excluded from multus connectivity tests only", pod.Name)
 					continue
 				}

--- a/test-network-function/networking/suite.go
+++ b/test-network-function/networking/suite.go
@@ -263,7 +263,7 @@ func testMultusNetworkConnectivity(env *config.TestEnvironment, count int) {
 				if _, ok := env.ContainersToExcludeFromConnectivityTests[aContainerInPod.ContainerIdentifier]; ok {
 					tnf.ClaimFilePrintf("Skipping pod %s because it is excluded from all connectivity tests", pod.Name)
 					continue
-				} 
+				}
 				if _, ok := env.ContainersToExcludeFromMultusConnectivityTests[aContainerInPod.ContainerIdentifier]; ok {
 					tnf.ClaimFilePrintf("Skipping pod %s because it is excluded from multus connectivity tests only", pod.Name)
 					continue

--- a/test-network-function/networking/suite.go
+++ b/test-network-function/networking/suite.go
@@ -232,7 +232,7 @@ func testDefaultNetworkConnectivity(env *config.TestEnvironment, count int) {
 				// The first container is used to get the network namespace
 				aContainerInPod := pod.ContainerList[0]
 				if _, ok := env.ContainersToExcludeFromConnectivityTests[aContainerInPod.ContainerIdentifier]; ok {
-					tnf.ClaimFilePrintf("Skipping pod %s because it is excluded from connectivity tests (default interface)", pod.Name)
+					tnf.ClaimFilePrintf("Skipping pod %s because it is excluded from all connectivity tests", pod.Name)
 					continue
 				}
 				netKey := "default" //nolint:goconst // only used once
@@ -261,7 +261,10 @@ func testMultusNetworkConnectivity(env *config.TestEnvironment, count int) {
 				// The first container is used to get the network namespace
 				aContainerInPod := pod.ContainerList[0]
 				if _, ok := env.ContainersToExcludeFromConnectivityTests[aContainerInPod.ContainerIdentifier]; ok {
-					tnf.ClaimFilePrintf("Skipping pod %s because it is excluded from connectivity tests (multus interface)", pod.Name)
+					tnf.ClaimFilePrintf("Skipping pod %s because it is excluded from all connectivity tests", pod.Name)
+					continue
+				} else if _, ok := env.ContainersToExcludeFromMultusConnectivityTests[aContainerInPod.ContainerIdentifier]; ok {
+					tnf.ClaimFilePrintf("Skipping pod %s because it is excluded from multus connectivity tests only", pod.Name)
 					continue
 				}
 				for netKey, multusIPAddress := range pod.MultusIPAddressesPerNet {


### PR DESCRIPTION
Backport of the new label to skip Multus test (https://github.com/test-network-function/test-network-function/pull/605) on current main (instead of furture IPv6 update)