### PR TITLE
Create new test ID for networking's testListenAndDeclared TC

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -284,6 +284,18 @@ Description|http://test-network-function.com/testcases/networking/service-type t
 Result Type|normative
 Suggested Remediation|Ensure Services are not configured to use NodePort(s).
 Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.3.1
+#### undeclared-container-ports-usage
+
+Property|Description
+---|---
+Test Case Name|undeclared-container-ports-usage
+Test Case Label|networking-undeclared-container-ports-usage
+Unique ID|http://test-network-function.com/testcases/networking/undeclared-container-ports-usage
+Version|v1.0.0
+Description|http://test-network-function.com/testcases/networking/undeclared-container-ports-usage check that containers don't listen on ports that weren't declared in their specification
+Result Type|normative
+Suggested Remediation|ensure the CNF apps don't listen on undeclared containers' ports
+Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 16.3.1.1
 
 ### observability
 

--- a/test-network-function/identifiers/identifiers.go
+++ b/test-network-function/identifiers/identifiers.go
@@ -224,6 +224,10 @@ var (
 		Url:     formTestURL(common.PlatformAlterationTestKey, "isredhat-release"),
 		Version: versionOne,
 	}
+	TestUndeclaredContainerPortsUsage = claim.Identifier{
+		Url:     formTestURL(common.NetworkingTestKey, "undeclared-container-ports-usage"),
+		Version: versionOne,
+	}
 )
 
 func formDescription(identifier claim.Identifier, description string) string {
@@ -650,5 +654,13 @@ the changes for you.`,
 			`check that all pods under test have automountServiceAccountToken set to false`),
 		Remediation:           `check that pod has automountServiceAccountToken set to false or pod is attached to service account which has automountServiceAccountToken set to false`,
 		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 13.7",
+	},
+	TestUndeclaredContainerPortsUsage: {
+		Identifier: TestUndeclaredContainerPortsUsage,
+		Type:       normativeResult,
+		Description: formDescription(TestUndeclaredContainerPortsUsage,
+			`check that containers don't listen on ports that weren't declared in their specification`),
+		Remediation:           `ensure the CNF apps don't listen on undeclared containers' ports`,
+		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 16.3.1.1",
 	},
 }

--- a/test-network-function/networking/suite.go
+++ b/test-network-function/networking/suite.go
@@ -468,8 +468,8 @@ func testListenAndDeclared(env *config.TestEnvironment) {
 	undeclaredPorts := make(map[key]string)
 	var skippedPods []configsections.Pod
 	var failedPods []configsections.Pod
-	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestServicesDoNotUseNodeportsIdentifier)
-	ginkgo.It(testID, func() {
+	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestUndeclaredContainerPortsUsage)
+	ginkgo.It(testID, ginkgo.Label(testID), func() {
 	OUTER:
 		for _, podUnderTest := range env.PodsUnderTest {
 			for i := 0; i < podUnderTest.ContainerCount; i++ {


### PR DESCRIPTION
It was mistakenly using the nodePort check's one.