### PR TITLE
Bump install-tools ginkgo to 2.1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ update-deps:
 
 # Install build tools and other required software.
 install-tools:
-	go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.1
+	go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.2
 	go install github.com/onsi/gomega
 	go install github.com/golang/mock/mockgen@v1.6.0
 


### PR DESCRIPTION
#631 doesn't cover this change.