### PR TITLE
Bump GolangCI-lint to v1.44.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ COMMON_GO_ARGS=-race
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 GIT_RELEASE=$(shell git tag --points-at HEAD | head -n 1)
 GIT_PREVIOUS_RELEASE=$(shell git tag --no-contains HEAD --sort=v:refname | tail -n 1)
-GOLANGCI_VERSION=v1.44.0
+GOLANGCI_VERSION=v1.44.1
 
 # Run the unit tests and build all binaries
 build:

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ At a minimum, the following dependencies must be installed *prior* to running `m
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.17
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.44.0
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.44.1
 [jq](https://stedolan.github.io/jq/)|1.6
 [OpenShift Client](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/)|4.7
 


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.44.1

No code changes found/needed.