### PR TITLE
ModuleInTree function modified to use /sys/module/<mod>/taint

### DIFF
--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -118,29 +118,23 @@ func TestModuleInTree(t *testing.T) {
 		isInTree   bool
 	}{
 		{
-			fakeOutput: `filename:
-			alias:
-			version:
-			license:
-			srcversion:
-			depends:
-			retpoline:
-			intree:
-			name:
-			vermagic:`,
-			isInTree: true,
+			fakeOutput: "",
+			isInTree:   true,
 		},
 		{
-			fakeOutput: `filename:
-			alias:
-			version:
-			license:
-			srcversion:
-			depends:
-			retpoline:
-			name:
-			vermagic:`,
-			isInTree: false,
+			// "K": kernel has been live patched
+			fakeOutput: "K",
+			isInTree:   true,
+		},
+		{
+			// "O": externally-built (“out-of-tree”) module was loaded
+			// "E": unsigned module was loaded
+			fakeOutput: "OE",
+			isInTree:   false,
+		},
+		{
+			fakeOutput: "O",
+			isInTree:   false,
 		},
 	}
 

--- a/test-network-function/platform/suite.go
+++ b/test-network-function/platform/suite.go
@@ -395,6 +395,7 @@ func testTainted(env *config.TestEnvironment) {
 			if !node.HasDebugPod() {
 				continue
 			}
+			ginkgo.By(fmt.Sprintf("Checking kernel taints of node %s", node.Name))
 			log.Debug("Node has a debug pod")
 			context := node.DebugContainer.GetOc()
 			tester := nodetainted.NewNodeTainted(common.DefaultTimeout)
@@ -434,8 +435,8 @@ func testTainted(env *config.TestEnvironment) {
 					// If the module info does not contain this string, the module is "tainted".
 					taintedModules := getOutOfTreeModules(modules, node.Name, context)
 					log.Debug("Collected all of the tainted modules: ", taintedModules)
-					tnf.ClaimFilePrintf("Kernel Modules loaded that cause taints: ", taintedModules)
-					tnf.ClaimFilePrintf("Modules allowed via configuration: ", env.Config.AcceptedKernelTaints)
+					tnf.ClaimFilePrintf("Kernel Modules loaded that cause taints: %v", taintedModules)
+					tnf.ClaimFilePrintf("Modules allowed via configuration: %v", env.Config.AcceptedKernelTaints)
 
 					// Looks through the accepted taints listed in the tnf-config file.
 					// If all of the tainted modules show up in the configuration file, don't fail the test.


### PR DESCRIPTION
The use of modinfo won't work in cases where modules have been loaded
from inside pods (like in SRO), since those pods have a different
filesystem namespace for /lib/modules.

The ModuleInTree function has been updated to parse the content of the
file /sys/module/<module>/taint, which returns a string with a letter
per taint. The taint <-> letter correspondence list can be found here:
- https://github.com/torvalds/linux/blob/master/kernel/panic.c#L369
- https://www.kernel.org/doc/html/latest/admin-guide/tainted-kernels.html

Some log traces improved.