### PR TITLE
lifecycle: specify error when logging

### DIFF
--- a/test-network-function/lifecycle/suite.go
+++ b/test-network-function/lifecycle/suite.go
@@ -698,8 +698,8 @@ func drainNode(node string, context *interactive.Context) {
 		log.Fatalf("Failed to drain node %s, err: %v", node, err)
 	}
 
-	if result == tnf.ERROR {
-		log.Fatalf("Failed to drain node %s. The tester returned tnf.ERROR", node)
+	if result != tnf.SUCCESS {
+		log.Fatalf("Failed to drain node %s. The tester returned %d", node, result)
 	}
 }
 

--- a/test-network-function/lifecycle/suite.go
+++ b/test-network-function/lifecycle/suite.go
@@ -694,8 +694,12 @@ func drainNode(node string, context *interactive.Context) {
 	test, err := tnf.NewTest(context.GetExpecter(), tester, []reel.Handler{tester}, context.GetErrorChannel())
 	gomega.Expect(err).To(gomega.BeNil())
 	result, err := test.Run()
-	if err != nil || result == tnf.ERROR {
-		log.Fatalf("Test skipped because of draining node failure - platform issue")
+	if err != nil {
+		log.Fatalf("Test skipped because of draining node failure - platform issue, err: %v", err)
+	}
+
+	if result == tnf.ERROR {
+		log.Fatalf("Test skipped because of draining node failure - NewTest returned tnf.ERROR")
 	}
 }
 

--- a/test-network-function/lifecycle/suite.go
+++ b/test-network-function/lifecycle/suite.go
@@ -695,11 +695,11 @@ func drainNode(node string, context *interactive.Context) {
 	gomega.Expect(err).To(gomega.BeNil())
 	result, err := test.Run()
 	if err != nil {
-		log.Fatalf("Test skipped because of draining node failure - platform issue, err: %v", err)
+		log.Fatalf("Failed to drain node %s, err: %v", node, err)
 	}
 
 	if result == tnf.ERROR {
-		log.Fatalf("Test skipped because of draining node failure - NewTest returned tnf.ERROR")
+		log.Fatalf("Failed to drain node %s. The tester returned tnf.ERROR", node)
 	}
 }
 


### PR DESCRIPTION
Split combined error log to show the reason.