### PR TITLE
Bug fix: kernel tainted test did not fail on other types of failures

### DIFF
--- a/test-network-function/platform/suite.go
+++ b/test-network-function/platform/suite.go
@@ -441,6 +441,8 @@ func testTainted(env *config.TestEnvironment) {
 					// Looks through the accepted taints listed in the tnf-config file.
 					// If all of the tainted modules show up in the configuration file, don't fail the test.
 					nodeTaintsAccepted = taintsAccepted(env.Config.AcceptedKernelTaints, taintedModules)
+				} else if len(individualTaints) > 0 {
+					nodeTaintsAccepted = false // taint was caused by something other than `module was loaded`
 				}
 
 				message = fmt.Sprintf("Decoded tainted kernel causes (code=%d) for node %s : %s\n", taintedBitmap, node.Name, taintMsg)


### PR DESCRIPTION
As I was [writing unit tests](https://github.com/test-network-function/cnf-certification-test/pull/63) for the "new" repo, I came across this bug where we would only flag the node as failed if it failed because of a `module was loaded` reason.  

