### PR TITLE
Tentative Fix for diagnostics suite failure when running from container

### DIFF
--- a/test-network-function/diagnostic/diagnostic.go
+++ b/test-network-function/diagnostic/diagnostic.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// defaultTimeoutSeconds contains the default timeout in seconds.
-	defaultTimeoutSeconds = 20
+	defaultTimeoutSeconds = 120
 )
 
 var (


### PR DESCRIPTION
The latest commit cannot pass diagnostics test when run from a container. The issue seems to be due to the diagnostic tests taking more time than allowed by the diagnostics test timeout (20s). When the command getting the info from the nodes does not return in time, the nodes are unlabeled triggering the killing of debug pods and (sometimes) printing of a fatal error (137).
I was able to reproduce the issue locally on my laptop, reduding the timeout to 1s makes it reproducible all the time. Most of the time there is a fatal error 137 or shorter logs and a pipe broken error. The modified timeout seems to fix the issue (120s)