### PR TITLE
Diagnostic mode fix: close debug oc sessions before removing node lab…

### DIFF
--- a/test-network-function/common/suite.go
+++ b/test-network-function/common/suite.go
@@ -31,12 +31,7 @@ func RemoveLabelsFromAllNodes() {
 	}
 }
 
-var _ = ginkgo.BeforeSuite(func() {
-})
-
-var _ = ginkgo.AfterSuite(func() {
-	// clean up added label to nodes
-	log.Info("Clean up added labels to nodes")
+func RemoveDebugPods() {
 	env = configpkg.GetTestEnvironment()
 	env.LoadAndRefresh()
 	for name, node := range env.NodesUnderTest {
@@ -46,4 +41,13 @@ var _ = ginkgo.AfterSuite(func() {
 		node.DebugContainer.CloseOc()
 		autodiscover.DeleteDebugLabel(name)
 	}
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	// clean up added label to nodes
+	log.Info("Clean up added labels to nodes")
+	RemoveDebugPods()
 })

--- a/test-network-function/diagnostic/diagnostic.go
+++ b/test-network-function/diagnostic/diagnostic.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// defaultTimeoutSeconds contains the default timeout in seconds.
-	defaultTimeoutSeconds = 120
+	defaultTimeoutSeconds = 20
 )
 
 var (

--- a/test-network-function/suite_test.go
+++ b/test-network-function/suite_test.go
@@ -160,7 +160,7 @@ func TestTest(t *testing.T) {
 	if diagnosticMode {
 		log.Warn("No test suites selected to run. Diagnostic mode enabled.")
 		// In diagnostic mode, we need to remove labels explicitly before exiting tnf.
-		defer common.RemoveLabelsFromAllNodes()
+		defer common.RemoveDebugPods()
 	}
 
 	// Make sure cluster nodes don't have the debug pod label from previous runs,


### PR DESCRIPTION
…els.

This commit tries to fix the crash that happens when running the
container in diagnostic mode: race condition when the program finishes,
as the oc debug session were not closed before the labels are being
removed from the nodes.