### PR TITLE
lifecycle's terminationGracePeriod TC removed.

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -221,18 +221,6 @@ Description|http://test-network-function.com/testcases/lifecycle/pod-scheduling 
 Result Type|informative
 Suggested Remediation|In most cases, Pod's should not specify their host Nodes through nodeSelector or nodeAffinity.  However, there are cases in which CNFs require specialized hardware specific to a particular class of Node.  As such, this test is purely informative, and will not prevent a CNF from being certified. However, one should have an appropriate justification as to why nodeSelector and/or nodeAffinity is utilized by a CNF.
 Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
-#### pod-termination-grace-period
-
-Property|Description
----|---
-Test Case Name|pod-termination-grace-period
-Test Case Label|lifecycle-pod-termination-grace-period
-Unique ID|http://test-network-function.com/testcases/lifecycle/pod-termination-grace-period
-Version|v1.0.0
-Description|http://test-network-function.com/testcases/lifecycle/pod-termination-grace-period tests whether the terminationGracePeriod is CNF-specific, or if the default (30s) is utilized.  This test is informative, and will not affect CNF Certification.  In many cases, the default terminationGracePeriod is perfectly acceptable for a CNF.
-Result Type|informative
-Suggested Remediation|Choose a terminationGracePeriod that is appropriate for your given CNF.  If the default (30s) is appropriate, then feel free to ignore this informative message.  This test is meant to raise awareness around how Pods are terminated, and to suggest that a CNF is configured based on its requirements.  In addition to a terminationGracePeriod, consider utilizing a termination hook in the case that your application requires special shutdown instructions.
-Best Practice Reference|[CNF Best Practice V1.2](https://connect.redhat.com/sites/default/files/2021-03/Cloud%20Native%20Network%20Function%20Requirements.pdf) Section 6.2
 #### readiness
 
 Property|Description

--- a/test-network-function/identifiers/identifiers.go
+++ b/test-network-function/identifiers/identifiers.go
@@ -101,11 +101,6 @@ var (
 		Url:     formTestURL(common.AccessControlTestKey, "namespace"),
 		Version: versionOne,
 	}
-	// TestNonDefaultGracePeriodIdentifier tests best grace period practices.
-	TestNonDefaultGracePeriodIdentifier = claim.Identifier{
-		Url:     formTestURL(common.LifecycleTestKey, "pod-termination-grace-period"),
-		Version: versionOne,
-	}
 	// TestNonTaintedNodeKernelsIdentifier is the identifier for the test checking tainted nodes.
 	TestNonTaintedNodeKernelsIdentifier = claim.Identifier{
 		Url:     formTestURL(common.PlatformAlterationTestKey, "tainted-node-kernel"),
@@ -400,20 +395,6 @@ the namespaces should not start with "default, openshift-, istio- or aspenmesh-"
 the following conditions: (1) It was declared in the yaml config file under the targetNameSpaces
 tag. (2) It doesn't have any of the following prefixes: default, openshift-, istio- and aspenmesh-`),
 		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2, 16.3.8 & 16.3.9",
-	},
-
-	TestNonDefaultGracePeriodIdentifier: {
-		Identifier: TestNonDefaultGracePeriodIdentifier,
-		Type:       informativeResult,
-		Remediation: `Choose a terminationGracePeriod that is appropriate for your given CNF.  If the default (30s) is appropriate, then feel
-free to ignore this informative message.  This test is meant to raise awareness around how Pods are terminated, and to
-suggest that a CNF is configured based on its requirements.  In addition to a terminationGracePeriod, consider utilizing
-a termination hook in the case that your application requires special shutdown instructions.`,
-		Description: formDescription(TestNonDefaultGracePeriodIdentifier,
-			`tests whether the terminationGracePeriod is CNF-specific, or if the default (30s) is utilized.  This test is
-informative, and will not affect CNF Certification.  In many cases, the default terminationGracePeriod is perfectly
-acceptable for a CNF.`),
-		BestPracticeReference: bestPracticeDocV1dot2URL + " Section 6.2",
 	},
 
 	TestNonTaintedNodeKernelsIdentifier: {

--- a/test-network-function/lifecycle/suite.go
+++ b/test-network-function/lifecycle/suite.go
@@ -17,7 +17,6 @@
 package lifecycle
 
 import (
-	"encoding/json"
 	"fmt"
 	"path"
 	"strings"
@@ -44,12 +43,11 @@ import (
 )
 
 const (
-	defaultTerminationGracePeriod = 30
-	baseNodeDrainTimeout          = 5 * time.Minute
-	maxNodeDrainTimeout           = 30 * time.Minute
-	scalingTimeout                = 1 * time.Minute
-	scalingPollingPeriod          = 1 * time.Second
-	postNodeDrainRecoveryTimeOut  = 2 * time.Minute
+	baseNodeDrainTimeout         = 5 * time.Minute
+	maxNodeDrainTimeout          = 30 * time.Minute
+	scalingTimeout               = 1 * time.Minute
+	scalingPollingPeriod         = 1 * time.Second
+	postNodeDrainRecoveryTimeOut = 2 * time.Minute
 )
 
 var (
@@ -126,8 +124,6 @@ var _ = ginkgo.Describe(common.LifecycleTestKey, func() {
 		testImagePolicy(env)
 
 		testNodeSelector(env)
-
-		testGracePeriod(env)
 
 		testShutdown(env)
 
@@ -328,124 +324,6 @@ func testNodeSelector(env *config.TestEnvironment) {
 		if n := len(badPods); n > 0 {
 			log.Debugf("Pods with nodeSelector/nodeAffinity: %+v", badPods)
 			ginkgo.Fail(fmt.Sprintf("%d pods found with nodeSelector/nodeAffinity rules", n))
-		}
-	})
-}
-
-func testTerminationGracePeriodOnPodSet(podsetsUnderTests []configsections.PodSet, context *interactive.Context) []configsections.PodSet {
-	const ocCommandTemplate = "oc get %s %s -n %s -o jsonpath={.metadata.annotations\\.\"kubectl\\.kubernetes\\.io/last-applied-configuration\"}"
-
-	type lastAppliedConfigType struct {
-		Spec struct {
-			Template struct {
-				Spec struct {
-					TerminationGracePeriodSeconds int
-				}
-			}
-		}
-	}
-
-	badPodsets := []configsections.PodSet{}
-	for _, podset := range podsetsUnderTests {
-		ocCommand := fmt.Sprintf(ocCommandTemplate, podset.Type, podset.Name, podset.Namespace)
-		lastAppliedConfigString, err := utils.ExecuteCommand(ocCommand, common.DefaultTimeout, context)
-		if err != nil {
-			ginkgo.Fail(fmt.Sprintf("%s %s (ns %s): failed to get last-applied-configuration field", podset.Type, podset.Name, podset.Namespace))
-		}
-		lastAppliedConfig := lastAppliedConfigType{}
-
-		// Use -1 as default value, in case the param was not set.
-		lastAppliedConfig.Spec.Template.Spec.TerminationGracePeriodSeconds = -1
-
-		err = json.Unmarshal([]byte(lastAppliedConfigString), &lastAppliedConfig)
-		if err != nil {
-			ginkgo.Fail(fmt.Sprintf("%s %s (ns %s): failed to unmarshall last-applied-configuration string (%s)", podset.Type, podset.Name, podset.Namespace, lastAppliedConfigString))
-		}
-
-		if lastAppliedConfig.Spec.Template.Spec.TerminationGracePeriodSeconds == -1 {
-			tnf.ClaimFilePrintf("%s %s (ns %s) template's spec does not have a terminationGracePeriodSeconds value set. Default value (%d) will be used.",
-				podset.Type, podset.Name, podset.Namespace, defaultTerminationGracePeriod)
-			badPodsets = append(badPodsets, podset)
-		} else {
-			log.Infof("%s %s (ns %s) last-applied-configuration's terminationGracePeriodSeconds: %d", podset.Type, podset.Name, podset.Namespace, lastAppliedConfig.Spec.Template.Spec.TerminationGracePeriodSeconds)
-		}
-	}
-
-	return badPodsets
-}
-
-func testTerminationGracePeriodOnPods(pods []*configsections.Pod, context *interactive.Context) []configsections.Pod {
-	const ocCommandTemplate = "oc get pod %s -n %s -o jsonpath={.metadata.annotations\\.\"kubectl\\.kubernetes\\.io/last-applied-configuration\"}"
-
-	type lastAppliedConfigType struct {
-		Spec struct {
-			TerminationGracePeriodSeconds int
-		}
-	}
-
-	badPods := []configsections.Pod{}
-	numUnmanagedPods := 0
-	for _, pod := range pods {
-		// We'll process only "unmanaged" pods (not belonging to any deployment/statefulset) here.
-		if pod.IsManaged {
-			continue
-		}
-
-		numUnmanagedPods++
-
-		ocCommand := fmt.Sprintf(ocCommandTemplate, pod.Name, pod.Namespace)
-		lastAppliedConfigString, err := utils.ExecuteCommand(ocCommand, common.DefaultTimeout, context)
-		if err != nil {
-			ginkgo.Fail(fmt.Sprintf("Pod %s (ns %s): failed to get last-applied-configuration field", pod.Name, pod.Namespace))
-		}
-		lastAppliedConfig := lastAppliedConfigType{}
-
-		// Use -1 as default value, in case the param was not set.
-		lastAppliedConfig.Spec.TerminationGracePeriodSeconds = -1
-
-		err = json.Unmarshal([]byte(lastAppliedConfigString), &lastAppliedConfig)
-		if err != nil {
-			ginkgo.Fail(fmt.Sprintf("Pod %s (ns %s): failed to unmarshall last-applied-configuration string (%s)", pod.Name, pod.Namespace, lastAppliedConfigString))
-		}
-
-		if lastAppliedConfig.Spec.TerminationGracePeriodSeconds == -1 {
-			tnf.ClaimFilePrintf("Pod %s (ns %s) spec does not have a terminationGracePeriodSeconds value set. Default value (%d) will be used.",
-				pod.Name, pod.Namespace, defaultTerminationGracePeriod)
-			badPods = append(badPods, *pod)
-		} else {
-			log.Infof("Pod %s (ns %s) last-applied-configuration's terminationGracePeriodSeconds: %d", pod.Name, pod.Namespace, lastAppliedConfig.Spec.TerminationGracePeriodSeconds)
-		}
-
-		log.Debugf("Number of unamanaged pods processed: %d", numUnmanagedPods)
-	}
-	return badPods
-}
-
-func testGracePeriod(env *config.TestEnvironment) {
-	testID := identifiers.XformToGinkgoItIdentifier(identifiers.TestNonDefaultGracePeriodIdentifier)
-	ginkgo.It(testID, ginkgo.Label(testID), func() {
-		ginkgo.By("Test terminationGracePeriod")
-		context := env.GetLocalShellContext()
-
-		badDeployments := testTerminationGracePeriodOnPodSet(env.DeploymentsUnderTest, context)
-		badStatefulsets := testTerminationGracePeriodOnPodSet(env.StateFulSetUnderTest, context)
-		badPods := testTerminationGracePeriodOnPods(env.PodsUnderTest, context)
-
-		numDeps := len(badDeployments)
-		if numDeps > 0 {
-			log.Debugf("Deployments found without terminationGracePeriodSeconds param set: %+v", badDeployments)
-		}
-		numSts := len(badStatefulsets)
-		if numSts > 0 {
-			log.Debugf("Statefulsets found without terminationGracePeriodSeconds param set: %+v", badStatefulsets)
-		}
-		numPods := len(badPods)
-		if numPods > 0 {
-			log.Debugf("Pods found without terminationGracePeriodSeconds param set: %+v", badPods)
-		}
-
-		if numDeps > 0 || numSts > 0 || numPods > 0 {
-			ginkgo.Fail(fmt.Sprintf("Found %d deployments, %d statefulsets and %d pods without terminationGracePeriodSeconds param set.", numDeps, numSts, numPods))
 		}
 	})
 }


### PR DESCRIPTION
Due to the issues on both the original and current implementation,
the terminationGracePeriod TC will be removed.

A new and improved version of this TC should be done in the new repo,
checking that after the configured (or defaulted) value, the pods were 
removed without any exit error code.