### PR TITLE
Fix missed version changes

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -141,7 +141,7 @@ jobs:
         run: go install github.com/golang/mock/mockgen@v1.6.0 && make mocks
 
       - name: Install ginkgo
-        run: go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.3
 
       - name: Execute `make build`
         run: make build

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ ENV TEMP_DIR=/tmp
 
 # Install dependencies
 RUN yum install -y gcc git jq make wget
-RUN wget https://get.helm.sh/helm-v3.8.1-linux-amd64.tar.gz && \
-    tar -xvf helm-v3.8.1-linux-amd64.tar.gz && \
+RUN wget https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz && \
+    tar -xvf helm-v3.8.2-linux-amd64.tar.gz && \
     cp linux-amd64/helm /usr/bin/helm
 # Install Go binary
 ENV GO_DL_URL="https://golang.org/dl"

--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,8 @@ install-tools:
 	go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.3
 	go install github.com/onsi/gomega
 	go install github.com/golang/mock/mockgen@v1.6.0
-	wget https://get.helm.sh/helm-v3.8.1-linux-amd64.tar.gz && \
-    tar -xvf helm-v3.8.1-linux-amd64.tar.gz && \
+	wget https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz && \
+    tar -xvf helm-v3.8.2-linux-amd64.tar.gz && \
     cp linux-amd64/helm /usr/local/bin/helm
 	
 # Install golangci-lint	


### PR DESCRIPTION
- Bumping installed Helm version to match the new repo's [changes](https://github.com/test-network-function/cnf-certification-test/pull/127).
- Found in the new repo that the version of ginkgo is [not correct](https://github.com/test-network-function/cnf-certification-test/pull/130).  Fixing that here too.